### PR TITLE
Update version and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ bin/spark-shell --packages "org.opensearch:opensearch-spark_2.12:0.1.0-SNAPSHOT"
 
 ## Code of Conduct
 
-This project has adopted an [Open Source Code of Conduct](../CODE_OF_CONDUCT.md).
+This project has adopted an [Open Source Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Security
 
@@ -47,8 +47,8 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## License
 
-See the [LICENSE](../LICENSE.txt) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](./LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 ## Copyright
 
-Copyright OpenSearch Contributors. See [NOTICE](../NOTICE) for details.
+Copyright OpenSearch Contributors. See [NOTICE](./NOTICE) for details.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Please refer to the [Flint Index Reference Manual](./docs/index.md) for more inf
 
 ## Prerequisites
 
-+ Spark 3.3.1
-+ Scala 2.12.14
+Version compatibility:
+
+| Flint version | JDK version | Spark version | Scala version | OpenSearch |
+|---------------|-------------|---------------|---------------|------------|
+| 0.1.0         | 11+         | 3.3.1         | 2.12.14       | 2.6+       |
 
 ## Usage
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintVersion.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintVersion.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+/**
+ * Flint version.
+ */
+case class FlintVersion(version: String) {
+
+  override def toString: String = version
+}
+
+object FlintVersion {
+  val V_0_1_0: FlintVersion = FlintVersion("0.1.0")
+
+  def current(): FlintVersion = V_0_1_0
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -45,6 +45,7 @@ class FlintSparkSkippingIndex(
 
   override def metadata(): FlintMetadata = {
     new FlintMetadata(s"""{
+        |   "version": 1.0,
         |   "_meta": {
         |     "kind": "$SKIPPING_INDEX_TYPE",
         |     "indexedColumns": $getMetaInfo,

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -9,7 +9,7 @@ import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.json4s.native.Serialization
 import org.opensearch.flint.core.metadata.FlintMetadata
-import org.opensearch.flint.spark.FlintSparkIndex
+import org.opensearch.flint.spark.{FlintSparkIndex, FlintVersion}
 import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.{getSkippingIndexName, FILE_PATH_COLUMN, SKIPPING_INDEX_TYPE}
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKindSerializer
@@ -45,8 +45,8 @@ class FlintSparkSkippingIndex(
 
   override def metadata(): FlintMetadata = {
     new FlintMetadata(s"""{
-        |   "version": "1.0.0",
         |   "_meta": {
+        |     "version": "${FlintVersion.current()}",
         |     "kind": "$SKIPPING_INDEX_TYPE",
         |     "indexedColumns": $getMetaInfo,
         |     "source": "$tableName"

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -45,7 +45,7 @@ class FlintSparkSkippingIndex(
 
   override def metadata(): FlintMetadata = {
     new FlintMetadata(s"""{
-        |   "version": 1.0,
+        |   "version": "1.0.0",
         |   "_meta": {
         |     "kind": "$SKIPPING_INDEX_TYPE",
         |     "indexedColumns": $getMetaInfo,

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -95,8 +95,8 @@ class FlintSparkSkippingIndexITSuite
     val index = flint.describeIndex(indexName)
     index shouldBe defined
     index.get.metadata().getContent should matchJson(s"""{
-        |   "version": "1.0.0",
         |   "_meta": {
+        |     "version": "0.1.0",
         |     "kind": "skipping",
         |     "indexedColumns": [
         |     {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -104,6 +104,7 @@ class FlintSparkSkippingIndexITSuite
     val index = flint.describeIndex(indexName)
     index shouldBe defined
     index.get.metadata().getContent should matchJson(s"""{
+        |   "version": 1.0,
         |   "_meta": {
         |     "kind": "skipping",
         |     "indexedColumns": [

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -104,7 +104,7 @@ class FlintSparkSkippingIndexITSuite
     val index = flint.describeIndex(indexName)
     index shouldBe defined
     index.get.metadata().getContent should matchJson(s"""{
-        |   "version": 1.0,
+        |   "version": "1.0.0",
         |   "_meta": {
         |     "kind": "skipping",
         |     "indexedColumns": [


### PR DESCRIPTION
### Description

Previously the Flint version info is hardcoding. Added a new class to manage the version and use it across the codebase. Updated README with version and compatibility matrix accordingly: https://github.com/dai-chen/opensearch-spark/blob/update-doc-and-version/README.md#prerequisites

### Issues Resolved

#2 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
