### PR TITLE
Fix catalog-to-spark data type mapping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,7 @@ lazy val flintSparkIntegration = (project in file("flint-spark-integration"))
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest-flatspec" % "3.2.15" % "test",
       "org.scalatestplus" %% "mockito-4-6" % "3.2.15.0" % "test",
+      "com.stephenn" %% "scalatest-json-jsonassert" % "0.2.5" % "test",
       "com.github.sbt" % "junit-interface" % "0.13.3" % "test"),
     libraryDependencies ++= deps(sparkVersion),
     // ANTLR settings

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndexSuite.scala
@@ -5,6 +5,7 @@
 
 package org.opensearch.flint.spark.skipping
 
+import com.stephenn.scalatest.jsonassert.JsonMatchers.matchJson
 import org.mockito.Mockito.when
 import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.FILE_PATH_COLUMN
@@ -32,6 +33,293 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     val df = spark.createDataFrame(Seq(("hello", 20))).toDF("name", "age")
     val indexDf = index.build(df)
     indexDf.schema.fieldNames should contain only ("name", FILE_PATH_COLUMN, ID_COLUMN)
+  }
+
+  test("can build index for boolean column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(Map("boolean_col" -> "boolean"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("boolean_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "boolean_col": {
+         |       "type": "boolean"
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+  }
+
+  test("can build index for string column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(Map("string_col" -> "string"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("string_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "string_col": {
+         |       "type": "keyword"
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+  }
+
+  // TODO: test for osType "text"
+
+  test("can build index for long column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(Map("long_col" -> "bigint"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("long_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "long_col": {
+         |       "type": "long"
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+  }
+
+  test("can build index for int column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(Map("int_col" -> "int"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("int_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "int_col": {
+         |       "type": "integer"
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+  }
+
+  test("can build index for short column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(Map("short_col" -> "smallint"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("short_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "short_col": {
+         |       "type": "short"
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+  }
+
+  test("can build index for byte column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(Map("byte_col" -> "tinyint"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("byte_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "byte_col": {
+         |       "type": "byte"
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+  }
+
+  test("can build index for double column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(Map("double_col" -> "double"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("double_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "double_col": {
+         |       "type": "double"
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+  }
+
+  test("can build index for float column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(Map("float_col" -> "float"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("float_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "float_col": {
+         |       "type": "float"
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+  }
+
+  test("can build index for timestamp column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(Map("timestamp_col" -> "timestamp"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("timestamp_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "timestamp_col": {
+         |       "type": "date",
+         |       "format": "strict_date_optional_time_nanos"
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+  }
+
+  test("can build index for date column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(Map("date_col" -> "date"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("date_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "date_col": {
+         |       "type": "date",
+         |       "format": "strict_date"
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+  }
+
+  test("can build index for struct column") {
+    val indexCol = mock[FlintSparkSkippingStrategy]
+    when(indexCol.outputSchema()).thenReturn(
+      Map("struct_col" -> "struct<subfield1:string,subfield2:int>"))
+    when(indexCol.getAggregators).thenReturn(Seq(CollectSet(col("struct_col").expr)))
+
+    val index = new FlintSparkSkippingIndex("default.test", Seq(indexCol))
+    index.metadata().getContent should matchJson(
+      s"""{
+         |   "_meta": {
+         |     "kind": "skipping",
+         |     "indexedColumns": [{}],
+         |     "source": "default.test"
+         |   },
+         |   "properties": {
+         |     "struct_col": {
+         |       "properties": {
+         |         "subfield1": {
+         |           "type": "keyword"
+         |         },
+         |         "subfield2": {
+         |           "type": "integer"
+         |         }
+         |       }
+         |     },
+         |     "file_path": {
+         |       "type": "keyword"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
   }
 
   test("should fail if get index name without full table name") {


### PR DESCRIPTION
### Description
Fix data type mapping from catalog to spark. This is the first of a series of PRs to support more data types, such as varchar and decimal.

Notable differences in catalog types and Spark types:
|CatalogDataType|SparkDataType|
|-|-|
|bigint|long|
|int|integer|
|smallint|short|
|tinyint|byte|

Now these and struct type can be mapped correctly (as well as all other types)

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
