### PR TITLE
Add covering index in Flint Spark API

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -15,7 +15,7 @@ import org.opensearch.flint.core.metadata.FlintMetadata
 import org.opensearch.flint.spark.FlintSpark.RefreshMode.{FULL, INCREMENTAL, RefreshMode}
 import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex
-import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.COVERING_INDEX_TYPE
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.{parseFlintIndexName, COVERING_INDEX_TYPE}
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.SKIPPING_INDEX_TYPE
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.{SkippingKind, SkippingKindSerializer}
@@ -233,7 +233,7 @@ class FlintSpark(val spark: SparkSession) {
         new FlintSparkSkippingIndex(tableName, strategies)
       case COVERING_INDEX_TYPE =>
         new FlintSparkCoveringIndex(
-          indexName,
+          parseFlintIndexName(indexName, tableName),
           tableName,
           indexedColumns.arr.map { obj =>
             ((obj \ "columnName").extract[String], (obj \ "columnType").extract[String])

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -15,7 +15,7 @@ import org.opensearch.flint.core.metadata.FlintMetadata
 import org.opensearch.flint.spark.FlintSpark.RefreshMode.{FULL, INCREMENTAL, RefreshMode}
 import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex
-import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.{parseFlintIndexName, COVERING_INDEX_TYPE}
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.COVERING_INDEX_TYPE
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.SKIPPING_INDEX_TYPE
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.{SkippingKind, SkippingKindSerializer}
@@ -233,7 +233,7 @@ class FlintSpark(val spark: SparkSession) {
         new FlintSparkSkippingIndex(tableName, strategies)
       case COVERING_INDEX_TYPE =>
         new FlintSparkCoveringIndex(
-          parseFlintIndexName(indexName, tableName),
+          indexName,
           tableName,
           indexedColumns.arr.map { obj =>
             ((obj \ "columnName").extract[String], (obj \ "columnType").extract[String])

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -51,10 +51,13 @@ object FlintSparkIndex {
   val ID_COLUMN: String = "__id__"
 
   /**
-   * Common prefix of Flint index name.
+   * Common prefix of Flint index name which is "flint_database_table_"
    *
-   * @param tableName source table name
-   * @return Flint index name
+   * @param fullTableName
+   *   source full table name
+   * @return
+   *   Flint index name
    */
-  def flintIndexNamePrefix(tableName: String): String = s"flint_${tableName.replace(".", "_")}_"
+  def flintIndexNamePrefix(fullTableName: String): String =
+    s"flint_${fullTableName.replace(".", "_")}_"
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -49,4 +49,12 @@ object FlintSparkIndex {
    * ID column name.
    */
   val ID_COLUMN: String = "__id__"
+
+  /**
+   * Common prefix of Flint index name.
+   *
+   * @param tableName source table name
+   * @return Flint index name
+   */
+  def flintIndexNamePrefix(tableName: String): String = s"flint_${tableName.replace(".", "_")}_"
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
@@ -19,7 +19,7 @@ abstract class FlintSparkIndexBuilder(flint: FlintSpark) {
   protected var tableName: String = ""
 
   /** All columns of the given source table */
-  lazy val allColumns: Map[String, Column] = {
+  lazy protected val allColumns: Map[String, Column] = {
     require(tableName.nonEmpty, "Source table name is not provided")
 
     flint.spark.catalog

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.apache.spark.sql.catalog.Column
+
+abstract class FlintSparkIndexBuilder(flint: FlintSpark) {
+
+  protected var tableName: String = ""
+
+  lazy val allColumns: Map[String, Column] = {
+    require(tableName.nonEmpty, "Source table name is not provided")
+
+    flint.spark.catalog
+      .listColumns(tableName)
+      .collect()
+      .map(col => (col.name, col))
+      .toMap
+  }
+
+  def create(): Unit = flint.createIndex(buildIndex())
+
+  protected def buildIndex(): FlintSparkIndex
+
+  protected def findColumn(colName: String): Column =
+    allColumns.getOrElse(
+      colName,
+      throw new IllegalArgumentException(s"Column $colName does not exist"))
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
@@ -7,10 +7,18 @@ package org.opensearch.flint.spark
 
 import org.apache.spark.sql.catalog.Column
 
+/**
+ * Flint Spark index builder base class.
+ *
+ * @param flint
+ *   Flint Spark API entrypoint
+ */
 abstract class FlintSparkIndexBuilder(flint: FlintSpark) {
 
+  /** Source table name */
   protected var tableName: String = ""
 
+  /** All columns of the given source table */
   lazy val allColumns: Map[String, Column] = {
     require(tableName.nonEmpty, "Source table name is not provided")
 
@@ -21,8 +29,14 @@ abstract class FlintSparkIndexBuilder(flint: FlintSpark) {
       .toMap
   }
 
+  /**
+   * Create Flint index.
+   */
   def create(): Unit = flint.createIndex(buildIndex())
 
+  /**
+   * Build method for concrete builder class to implement
+   */
   protected def buildIndex(): FlintSparkIndex
 
   protected def findColumn(colName: String): Column =

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -54,8 +54,8 @@ class FlintSparkCoveringIndex(
   }
 
   override def build(df: DataFrame): DataFrame = {
-    // TODO: implement later
-    null
+    val colNames = indexedColumns.keys.toSeq
+    df.select(colNames.head, colNames.tail: _*)
   }
 
   private def getMetaInfo: String = {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.covering
+
+import org.opensearch.flint.core.metadata.FlintMetadata
+import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex, FlintSparkIndexBuilder}
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.COVERING_INDEX_TYPE
+
+import org.apache.spark.sql.DataFrame
+
+class FlintSparkCoveringIndex(
+    override val name: String,
+    val tableName: String,
+    val indexedColumns: Map[String, String])
+    extends FlintSparkIndex {
+
+  require(indexedColumns.nonEmpty, "indexed columns must not be empty")
+
+  override val kind: String = COVERING_INDEX_TYPE
+
+  override def metadata(): FlintMetadata = {
+    new FlintMetadata(s"""{
+        |   "_meta": {
+        |     "kind": "$kind",
+        |     "indexedColumns": $indexedColumns,
+        |     "source": "$tableName"
+        |   },
+        |   "properties": $getSchema
+        | }
+        |""".stripMargin)
+  }
+
+  override def build(df: DataFrame): DataFrame = {
+    null
+  }
+
+  private def getSchema: String = {
+    ""
+  }
+}
+
+object FlintSparkCoveringIndex {
+
+  /** Covering index type name */
+  val COVERING_INDEX_TYPE = "covering"
+
+  /** Builder class for covering index build */
+  class Builder(flint: FlintSpark) extends FlintSparkIndexBuilder(flint) {
+    private var indexName: String = ""
+    private var indexedColumns: Map[String, String] = Map()
+
+    /**
+     * Set covering index name.
+     *
+     * @param indexName
+     *   index name
+     * @return
+     *   index builder
+     */
+    def indexName(indexName: String): Builder = {
+      this.indexName = indexName
+      this
+    }
+
+    /**
+     * Configure which source table the index is based on.
+     *
+     * @param tableName
+     *   full table name
+     * @return
+     *   index builder
+     */
+    def onTable(tableName: String): Builder = {
+      this.tableName = tableName
+      this
+    }
+
+    /**
+     * Add indexed column name.
+     *
+     * @param colName
+     *   column name
+     * @return
+     *   index builder
+     */
+    def addIndexColumn(colName: String): Builder = {
+      indexedColumns += (colName -> findColumn(colName).dataType)
+      this
+    }
+
+    override protected def buildIndex(): FlintSparkIndex =
+      new FlintSparkCoveringIndex(indexName, tableName, indexedColumns)
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -59,8 +59,8 @@ class FlintSparkCoveringIndex(
   }
 
   private def getMetaInfo: String = {
-    val objects = indexedColumns.map { case (colName, colVal) =>
-      JObject("columnName" -> JString(colName), "columnType" -> JString(colVal))
+    val objects = indexedColumns.map { case (colName, colType) =>
+      JObject("columnName" -> JString(colName), "columnType" -> JString(colType))
     }.toList
     Serialization.write(JArray(objects))
   }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -11,6 +11,7 @@ import org.json4s.native.JsonMethods.{compact, parse, render}
 import org.json4s.native.Serialization
 import org.opensearch.flint.core.metadata.FlintMetadata
 import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex, FlintSparkIndexBuilder}
+import org.opensearch.flint.spark.FlintSparkIndex.flintIndexNamePrefix
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.{getFlintIndexName, COVERING_INDEX_TYPE}
 
 import org.apache.spark.sql.DataFrame
@@ -83,6 +84,9 @@ object FlintSparkCoveringIndex {
   /** Covering index type name */
   val COVERING_INDEX_TYPE = "covering"
 
+  /** Flint covering index name suffix */
+  val COVERING_INDEX_SUFFIX = "_index"
+
   /**
    * Get Flint index name which follows the convention: "flint_" prefix + source table name + +
    * given index name + "_index" suffix.
@@ -100,7 +104,7 @@ object FlintSparkCoveringIndex {
   def getFlintIndexName(indexName: String, tableName: String): String = {
     require(tableName.contains("."), "Full table name database.table is required")
 
-    s"flint_${tableName.replace(".", "_")}_${indexName}_index"
+    flintIndexNamePrefix(tableName) + indexName + COVERING_INDEX_SUFFIX
   }
 
   /**
@@ -115,8 +119,8 @@ object FlintSparkCoveringIndex {
    */
   def parseFlintIndexName(flintIndexName: String, tableName: String): String = {
     flintIndexName.substring(
-      s"flint_${tableName.replace(".", "_")}_".length,
-      flintIndexName.length - "_index".length)
+      flintIndexNamePrefix(tableName).length,
+      flintIndexName.length - COVERING_INDEX_SUFFIX.length)
   }
 
   /** Builder class for covering index build */

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -58,6 +58,7 @@ class FlintSparkCoveringIndex(
     df.select(colNames.head, colNames.tail: _*)
   }
 
+  // TODO: refactor all these once Flint metadata spec finalized
   private def getMetaInfo: String = {
     val objects = indexedColumns.map { case (colName, colType) =>
       JObject("columnName" -> JString(colName), "columnType" -> JString(colType))
@@ -93,7 +94,7 @@ object FlintSparkCoveringIndex {
      * @return
      *   index builder
      */
-    def indexName(indexName: String): Builder = {
+    def name(indexName: String): Builder = {
       this.indexName = indexName
       this
     }
@@ -119,7 +120,7 @@ object FlintSparkCoveringIndex {
      * @return
      *   index builder
      */
-    def addIndexColumn(colNames: String*): Builder = {
+    def addIndexColumns(colNames: String*): Builder = {
       colNames.foreach(colName => {
         indexedColumns += (colName -> findColumn(colName).dataType)
       })

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -46,7 +46,7 @@ class FlintSparkCoveringIndex(
   override def metadata(): FlintMetadata = {
     new FlintMetadata(s"""{
         |   "_meta": {
-        |     "name": "${name()}",
+        |     "name": "$indexName",
         |     "kind": "$kind",
         |     "indexedColumns": $getMetaInfo,
         |     "source": "$tableName"
@@ -105,22 +105,6 @@ object FlintSparkCoveringIndex {
     require(tableName.contains("."), "Full table name database.table is required")
 
     flintIndexNamePrefix(tableName) + indexName + COVERING_INDEX_SUFFIX
-  }
-
-  /**
-   * Parse original index name out of Flint index name.
-   *
-   * @param flintIndexName
-   *   Flint index name
-   * @param tableName
-   *   source table name
-   * @return
-   *   original index name specified by user
-   */
-  def parseFlintIndexName(flintIndexName: String, tableName: String): String = {
-    flintIndexName.substring(
-      flintIndexNamePrefix(tableName).length,
-      flintIndexName.length - COVERING_INDEX_SUFFIX.length)
   }
 
   /** Builder class for covering index build */

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -28,6 +28,8 @@ import org.apache.spark.sql.types.StructType
  *
  * @param tableName
  *   source table name
+ * @param indexedColumns
+ *   indexed column list
  */
 class FlintSparkSkippingIndex(
     tableName: String,
@@ -49,6 +51,7 @@ class FlintSparkSkippingIndex(
   override def metadata(): FlintMetadata = {
     new FlintMetadata(s"""{
         |   "_meta": {
+        |     "name": "${name()}",
         |     "kind": "$SKIPPING_INDEX_TYPE",
         |     "indexedColumns": $getMetaInfo,
         |     "source": "$tableName"

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -10,7 +10,7 @@ import org.json4s.native.JsonMethods._
 import org.json4s.native.Serialization
 import org.opensearch.flint.core.metadata.FlintMetadata
 import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex, FlintSparkIndexBuilder}
-import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
+import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, ID_COLUMN}
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.{getSkippingIndexName, FILE_PATH_COLUMN, SKIPPING_INDEX_TYPE}
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKindSerializer
 import org.opensearch.flint.spark.skipping.minmax.MinMaxSkippingStrategy
@@ -102,6 +102,9 @@ object FlintSparkSkippingIndex {
   /** File path column name */
   val FILE_PATH_COLUMN = "file_path"
 
+  /** Flint skipping index name suffix */
+  val SKIPPING_INDEX_SUFFIX = "skipping_index"
+
   /**
    * Get skipping index name which follows the convention: "flint_" prefix + source table name +
    * "_skipping_index" suffix.
@@ -117,7 +120,7 @@ object FlintSparkSkippingIndex {
   def getSkippingIndexName(tableName: String): String = {
     require(tableName.contains("."), "Full table name database.table is required")
 
-    s"flint_${tableName.replace(".", "_")}_skipping_index"
+    flintIndexNamePrefix(tableName) + SKIPPING_INDEX_SUFFIX
   }
 
   /** Builder class for skipping index build */

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -9,16 +9,19 @@ import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.json4s.native.Serialization
 import org.opensearch.flint.core.metadata.FlintMetadata
-import org.opensearch.flint.spark.FlintSparkIndex
+import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex, FlintSparkIndexBuilder}
 import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.{getSkippingIndexName, FILE_PATH_COLUMN, SKIPPING_INDEX_TYPE}
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKindSerializer
+import org.opensearch.flint.spark.skipping.minmax.MinMaxSkippingStrategy
+import org.opensearch.flint.spark.skipping.partition.PartitionSkippingStrategy
+import org.opensearch.flint.spark.skipping.valueset.ValueSetSkippingStrategy
 
 import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.catalyst.dsl.expressions.DslExpression
 import org.apache.spark.sql.flint.datatype.FlintDataType
 import org.apache.spark.sql.functions.{col, input_file_name, sha1}
-import org.apache.spark.sql.types.{DataType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.StructType
 
 /**
  * Flint skipping index in Spark.
@@ -112,5 +115,83 @@ object FlintSparkSkippingIndex {
     require(tableName.contains("."), "Full table name database.table is required")
 
     s"flint_${tableName.replace(".", "_")}_skipping_index"
+  }
+
+  /** Builder class for skipping index build */
+  class Builder(flint: FlintSpark) extends FlintSparkIndexBuilder(flint) {
+    private var indexedColumns: Seq[FlintSparkSkippingStrategy] = Seq()
+
+    /**
+     * Configure which source table the index is based on.
+     *
+     * @param tableName
+     *   full table name
+     * @return
+     *   index builder
+     */
+    def onTable(tableName: String): Builder = {
+      this.tableName = tableName
+      this
+    }
+
+    /**
+     * Add partition skipping indexed columns.
+     *
+     * @param colNames
+     *   indexed column names
+     * @return
+     *   index builder
+     */
+    def addPartitions(colNames: String*): Builder = {
+      require(tableName.nonEmpty, "table name cannot be empty")
+
+      colNames
+        .map(findColumn)
+        .map(col => PartitionSkippingStrategy(columnName = col.name, columnType = col.dataType))
+        .foreach(addIndexedColumn)
+      this
+    }
+
+    /**
+     * Add value set skipping indexed column.
+     *
+     * @param colName
+     *   indexed column name
+     * @return
+     *   index builder
+     */
+    def addValueSet(colName: String): Builder = {
+      require(tableName.nonEmpty, "table name cannot be empty")
+
+      val col = findColumn(colName)
+      addIndexedColumn(ValueSetSkippingStrategy(columnName = col.name, columnType = col.dataType))
+      this
+    }
+
+    /**
+     * Add min max skipping indexed column.
+     *
+     * @param colName
+     *   indexed column name
+     * @return
+     *   index builder
+     */
+    def addMinMax(colName: String): Builder = {
+      val col = findColumn(colName)
+      indexedColumns =
+        indexedColumns :+ MinMaxSkippingStrategy(columnName = col.name, columnType = col.dataType)
+      this
+    }
+
+    override def buildIndex(): FlintSparkIndex =
+      new FlintSparkSkippingIndex(tableName, indexedColumns)
+
+    private def addIndexedColumn(indexedCol: FlintSparkSkippingStrategy): Unit = {
+      require(
+        indexedColumns.forall(_.columnName != indexedCol.columnName),
+        s"${indexedCol.columnName} is already indexed")
+
+      indexedColumns = indexedColumns :+ indexedCol
+    }
   }
 }

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndexSuite.scala
@@ -5,7 +5,6 @@
 
 package org.opensearch.flint.spark.covering
 
-import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.parseFlintIndexName
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.FlintSuite
@@ -15,12 +14,6 @@ class FlintSparkCoveringIndexSuite extends FlintSuite {
   test("get covering index name") {
     val index = new FlintSparkCoveringIndex("ci", "default.test", Map("name" -> "string"))
     index.name() shouldBe "flint_default_test_ci_index"
-  }
-
-  test("parse covering index name") {
-    val flintIndexName = "flint_default_ci_test_name_and_age_index"
-    val indexName = parseFlintIndexName(flintIndexName, "default.ci_test")
-    indexName shouldBe "name_and_age"
   }
 
   test("should fail if get index name without full table name") {

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndexSuite.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.covering
+
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.parseFlintIndexName
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+import org.apache.spark.FlintSuite
+
+class FlintSparkCoveringIndexSuite extends FlintSuite {
+
+  test("get covering index name") {
+    val index = new FlintSparkCoveringIndex("ci", "default.test", Map("name" -> "string"))
+    index.name() shouldBe "flint_default_test_ci_index"
+  }
+
+  test("parse covering index name") {
+    val flintIndexName = "flint_default_ci_test_name_and_age_index"
+    val indexName = parseFlintIndexName(flintIndexName, "default.ci_test")
+    indexName shouldBe "name_and_age"
+  }
+
+  test("should fail if get index name without full table name") {
+    val index = new FlintSparkCoveringIndex("ci", "test", Map("name" -> "string"))
+    assertThrows[IllegalArgumentException] {
+      index.name()
+    }
+  }
+
+  test("should fail if no indexed column given") {
+    assertThrows[IllegalArgumentException] {
+      new FlintSparkCoveringIndex("ci", "default.test", Map.empty)
+    }
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndexSuite.scala
@@ -44,6 +44,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"
@@ -69,6 +70,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"
@@ -96,6 +98,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"
@@ -121,6 +124,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"
@@ -146,6 +150,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"
@@ -171,6 +176,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"
@@ -196,6 +202,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"
@@ -221,6 +228,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"
@@ -246,6 +254,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"
@@ -272,6 +281,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"
@@ -299,6 +309,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     index.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_test_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [{}],
          |     "source": "default.test"

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+class FlintSparkCoveringIndexITSuite extends FlintSparkIndexSuite {
+
+  /** Test table and index name */
+  private val testTable = "default.test"
+  private val testIndex = "test"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    sql(s"""
+           | CREATE TABLE $testTable
+           | (
+           |   name STRING,
+           |   age INT,
+           |   address STRING
+           | )
+           | USING CSV
+           | OPTIONS (
+           |  header 'false',
+           |  delimiter '\t'
+           | )
+           | PARTITIONED BY (
+           |    year INT,
+           |    month INT
+           | )
+           |""".stripMargin)
+
+    sql(s"""
+           | INSERT INTO $testTable
+           | PARTITION (year=2023, month=4)
+           | VALUES ('Hello', 30, 'Seattle')
+           | """.stripMargin)
+
+    sql(s"""
+           | INSERT INTO $testTable
+           | PARTITION (year=2023, month=5)
+           | VALUES ('World', 25, 'Portland')
+           | """.stripMargin)
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+
+    // Delete all test indices
+    flint.deleteIndex(testIndex)
+  }
+
+  test("create covering index with metadata successfully") {
+
+  }
+}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -34,9 +34,9 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
   test("create covering index with metadata successfully") {
     flint
       .coveringIndex()
-      .indexName(testIndex)
+      .name(testIndex)
       .onTable(testTable)
-      .addIndexColumn("name", "age")
+      .addIndexColumns("name", "age")
       .create()
 
     val index = flint.describeIndex(testIndex)
@@ -71,9 +71,9 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
   test("full refresh covering index successfully") {
     flint
       .coveringIndex()
-      .indexName(testIndex)
+      .name(testIndex)
       .onTable(testTable)
-      .addIndexColumn("name", "age")
+      .addIndexColumns("name", "age")
       .create()
 
     flint.refreshIndex(testIndex, FULL)
@@ -85,9 +85,9 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
   test("incremental refresh covering index successfully") {
     flint
       .coveringIndex()
-      .indexName(testIndex)
+      .name(testIndex)
       .onTable(testTable)
-      .addIndexColumn("name", "age")
+      .addIndexColumns("name", "age")
       .create()
 
     val jobId = flint.refreshIndex(testIndex, INCREMENTAL)

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -45,7 +45,7 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
     index shouldBe defined
     index.get.metadata().getContent should matchJson(s"""{
          |   "_meta": {
-         |     "name": "flint_default_ci_test_name_and_age_index",
+         |     "name": "name_and_age",
          |     "kind": "covering",
          |     "indexedColumns": [
          |     {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -21,35 +21,7 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    sql(s"""
-           | CREATE TABLE $testTable
-           | (
-           |   name STRING,
-           |   age INT,
-           |   address STRING
-           | )
-           | USING CSV
-           | OPTIONS (
-           |  header 'false',
-           |  delimiter '\t'
-           | )
-           | PARTITIONED BY (
-           |    year INT,
-           |    month INT
-           | )
-           |""".stripMargin)
-
-    sql(s"""
-           | INSERT INTO $testTable
-           | PARTITION (year=2023, month=4)
-           | VALUES ('Hello', 30, 'Seattle')
-           | """.stripMargin)
-
-    sql(s"""
-           | INSERT INTO $testTable
-           | PARTITION (year=2023, month=5)
-           | VALUES ('World', 25, 'Portland')
-           | """.stripMargin)
+    createPartitionedTable(testTable)
   }
 
   override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -101,4 +101,20 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
     val indexData = flint.queryIndex(testIndex)
     checkAnswer(indexData, Seq(Row("Hello", 30), Row("World", 25)))
   }
+
+  test("can have multiple covering indexes on a table") {
+    flint
+      .coveringIndex()
+      .name(testIndex)
+      .onTable(testTable)
+      .addIndexColumns("name", "age")
+      .create()
+
+    flint
+      .coveringIndex()
+      .name(testIndex + "_address")
+      .onTable(testTable)
+      .addIndexColumns("address")
+      .create()
+  }
 }

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSuite.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.opensearch.flint.OpenSearchSuite
+
+import org.apache.spark.FlintSuite
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.flint.config.FlintSparkConf.{HOST_ENDPOINT, HOST_PORT, REFRESH_POLICY}
+import org.apache.spark.sql.streaming.StreamTest
+
+trait FlintSparkIndexSuite
+    extends QueryTest
+    with FlintSuite
+    with OpenSearchSuite
+    with StreamTest {
+
+  /** Flint Spark high level API being tested */
+  lazy protected val flint: FlintSpark = {
+    setFlintSparkConf(HOST_ENDPOINT, openSearchHost)
+    setFlintSparkConf(HOST_PORT, openSearchPort)
+    setFlintSparkConf(REFRESH_POLICY, "true")
+    new FlintSpark(spark)
+  }
+}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -29,35 +29,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    sql(s"""
-        | CREATE TABLE $testTable
-        | (
-        |   name STRING,
-        |   age INT,
-        |   address STRING
-        | )
-        | USING CSV
-        | OPTIONS (
-        |  header 'false',
-        |  delimiter '\t'
-        | )
-        | PARTITIONED BY (
-        |    year INT,
-        |    month INT
-        | )
-        |""".stripMargin)
-
-    sql(s"""
-        | INSERT INTO $testTable
-        | PARTITION (year=2023, month=4)
-        | VALUES ('Hello', 30, 'Seattle')
-        | """.stripMargin)
-
-    sql(s"""
-        | INSERT INTO $testTable
-        | PARTITION (year=2023, month=5)
-        | VALUES ('World', 25, 'Portland')
-        | """.stripMargin)
+    createPartitionedTable(testTable)
   }
 
   override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -6,7 +6,6 @@
 package org.opensearch.flint.spark
 
 import com.stephenn.scalatest.jsonassert.JsonMatchers.matchJson
-import org.opensearch.flint.OpenSearchSuite
 import org.opensearch.flint.spark.FlintSpark.RefreshMode.{FULL, INCREMENTAL}
 import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingFileIndex
@@ -15,27 +14,13 @@ import org.scalatest.matchers.{Matcher, MatchResult}
 import org.scalatest.matchers.must.Matchers._
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
-import org.apache.spark.FlintSuite
-import org.apache.spark.sql.{Column, QueryTest, Row}
+import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.flint.config.FlintSparkConf._
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.streaming.StreamTest
 
-class FlintSparkSkippingIndexITSuite
-    extends QueryTest
-    with FlintSuite
-    with OpenSearchSuite
-    with StreamTest {
-
-  /** Flint Spark high level API being tested */
-  lazy val flint: FlintSpark = {
-    setFlintSparkConf(HOST_ENDPOINT, openSearchHost)
-    setFlintSparkConf(HOST_PORT, openSearchPort)
-    setFlintSparkConf(REFRESH_POLICY, "true")
-    new FlintSpark(spark)
-  }
+class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
 
   /** Test table and index name */
   private val testTable = "default.test"
@@ -96,6 +81,7 @@ class FlintSparkSkippingIndexITSuite
     index shouldBe defined
     index.get.metadata().getContent should matchJson(s"""{
         |   "_meta": {
+        |     "name": "flint_default_test_skipping_index",
         |     "kind": "skipping",
         |     "indexedColumns": [
         |     {
@@ -449,6 +435,7 @@ class FlintSparkSkippingIndexITSuite
     index.get.metadata().getContent should matchJson(
       s"""{
          |   "_meta": {
+         |     "name": "flint_default_data_type_table_skipping_index",
          |     "kind": "skipping",
          |     "indexedColumns": [
          |     {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -12,7 +12,10 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.flint.config.FlintSparkConf.{HOST_ENDPOINT, HOST_PORT, REFRESH_POLICY}
 import org.apache.spark.sql.streaming.StreamTest
 
-trait FlintSparkIndexSuite
+/**
+ * Flint Spark suite trait that initializes [[FlintSpark]] API instance.
+ */
+trait FlintSparkSuite
     extends QueryTest
     with FlintSuite
     with OpenSearchSuite

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -28,4 +28,39 @@ trait FlintSparkSuite
     setFlintSparkConf(REFRESH_POLICY, "true")
     new FlintSpark(spark)
   }
+
+  protected def createPartitionedTable(testTable: String): Unit = {
+    sql(
+      s"""
+         | CREATE TABLE $testTable
+         | (
+         |   name STRING,
+         |   age INT,
+         |   address STRING
+         | )
+         | USING CSV
+         | OPTIONS (
+         |  header 'false',
+         |  delimiter '\t'
+         | )
+         | PARTITIONED BY (
+         |    year INT,
+         |    month INT
+         | )
+         |""".stripMargin)
+
+    sql(
+      s"""
+         | INSERT INTO $testTable
+         | PARTITION (year=2023, month=4)
+         | VALUES ('Hello', 30, 'Seattle')
+         | """.stripMargin)
+
+    sql(
+      s"""
+         | INSERT INTO $testTable
+         | PARTITION (year=2023, month=5)
+         | VALUES ('World', 25, 'Portland')
+         | """.stripMargin)
+  }
 }


### PR DESCRIPTION
### Description

1. Add covering index implementation to `FlintSpark` API
2. Extract `FlintSparkIndexBuilder` and `FlintSparkSuite` with common code from skipping and covering index

#### TODO

1. Generate unique ID column for Flint sink Idempotency
2. Support filtering condition for partial indexing
3. Update user manual after SQL support ready
4. https://github.com/opensearch-project/opensearch-spark/issues/24

#### Example

Manual test example as below and will move to user manual doc once SQL support is ready:

```
$ spark-shell \
  --jars /xxx/flint-spark-integration-assembly-0.1.0-SNAPSHOT.jar \
  --conf spark.sql.extensions=org.opensearch.flint.spark.FlintSparkExtensions  \
  --conf spark.datasource.flint.host=xxx.us-east-1.es.amazonaws.com  \
  --conf spark.datasource.flint.port=-1  \
  --conf spark.datasource.flint.scheme=https \
  --conf spark.datasource.flint.auth=sigv4  \
  --conf spark.datasource.flint.region=us-east-1

import org.opensearch.flint.spark._
import org.opensearch.flint.spark.covering._
import org.opensearch.flint.spark.FlintSpark._

val flint = new FlintSpark(spark)
val flintIndexName = FlintSparkCoveringIndex.getFlintIndexName("orderkey", "stream.lineitem_tiny")

(flint.coveringIndex()
  .name("orderkey")
  .onTable("stream.lineitem_tiny")
  .addIndexColumns("l_orderkey", "l_quantity", "l_returnflag", "l_shipdate")
  .create())

flint.refreshIndex(flintIndexName, RefreshMode.INCREMENTAL)
```

OpenSearch index looks like below:

```
GET flint_stream_lineitem_tiny_orderkey_index/_mapping
{
  "flint_stream_lineitem_tiny_orderkey_index": {
    "mappings": {
      "_meta": {
        "name": "flint_stream_lineitem_tiny_orderkey_index",
        "source": "stream.lineitem_tiny",
        "kind": "covering",
        "indexedColumns": [
          {
            "columnType": "bigint",
            "columnName": "l_orderkey"
          },
          {
            "columnType": "float",
            "columnName": "l_quantity"
          },
          {
            "columnType": "string",
            "columnName": "l_returnflag"
          },
          {
            "columnType": "date",
            "columnName": "l_shipdate"
          }
        ]
      },
      "properties": {
        "l_orderkey": {
          "type": "long"
        },
        "l_quantity": {
          "type": "float"
        },
        "l_returnflag": {
          "type": "keyword"
        },
        "l_shipdate": {
          "type": "date",
          "format": "strict_date"
        }
      }
    }
  }
}

GET flint_stream_lineitem_tiny_orderkey_index/_search
{
     ......
    "hits": [
      {
        "_index": "flint_stream_lineitem_tiny_orderkey_index",
        "_id": "TfBEQ4oB9arJAA1F1Nkv",
        "_score": 1,
        "_source": {
          "l_orderkey": 27863683,
          "l_quantity": 22,
          "l_returnflag": "A",
          "l_shipdate": "1993-07-31"
        }
      },
      {
        "_index": "flint_stream_lineitem_tiny_orderkey_index",
        "_id": "TvBEQ4oB9arJAA1F1Nkv",
        "_score": 1,
        "_source": {
          "l_orderkey": 58918182,
          "l_quantity": 7,
          "l_returnflag": "R",
          "l_shipdate": "1993-07-31"
        }
      },
      ......
```

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/23

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
