### PR TITLE
Add create, drop and refresh covering index SQL support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,11 @@ A Flint index is ...
 
 ### Feature Highlights
 
-- Skipping Index
+- Skipping Index: accelerate data scan by maintaining compact aggregate data structure which includes
   - Partition: skip data scan by maintaining and filtering partitioned column value per file.
   - MinMax: skip data scan by maintaining lower and upper bound of the indexed column per file.
   - ValueSet: skip data scan by building a unique value set of the indexed column per file.
+- Covering Index: create index for selected columns within the source dataset to improve query performance
 
 Please see the following example in which Index Building Logic and Query Rewrite Logic column shows the basic idea behind each skipping index implementation.
 
@@ -117,7 +118,7 @@ High level API is dependent on query engine implementation. Please see Query Eng
 
 ### SQL
 
-DDL statement:
+#### Skipping Index
 
 ```sql
 CREATE SKIPPING INDEX
@@ -155,6 +156,38 @@ REFRESH SKIPPING INDEX ON alb_logs
 DESCRIBE SKIPPING INDEX ON alb_logs
 
 DROP SKIPPING INDEX ON alb_logs
+```
+
+#### Covering Index
+
+```sql
+CREATE INDEX name ON <object>
+( column [, ...] )
+WHERE <filter_predicate>
+WITH (auto_refresh = (true|false))
+
+REFRESH INDEX name ON <object>
+
+SHOW INDEX ON <object>
+
+DESCRIBE INDEX name ON <object>
+
+DROP INDEX name ON <object>
+```
+
+Example:
+
+```sql
+CREATE INDEX elb_and_requestUri
+ON alb_logs ( elb, requestUri )
+
+REFRESH INDEX elb_and_requestUri ON alb_logs
+
+SHOW INDEX ON alb_logs
+
+DESCRIBE INDEX elb_and_requestUri ON alb_logs
+
+DROP INDEX elb_and_requestUri ON alb_logs
 ```
 
 ## Index Store
@@ -264,6 +297,7 @@ Here is an example for Flint Spark integration:
 ```scala
 val flint = new FlintSpark(spark)
 
+// Skipping index
 flint.skippingIndex()
     .onTable("alb_logs")
     .filterBy("time > 2023-04-01 00:00:00")
@@ -273,6 +307,15 @@ flint.skippingIndex()
     .create()
 
 flint.refresh("flint_alb_logs_skipping_index", FULL)
+
+// Covering index
+flint.coveringIndex()
+    .name("elb_and_requestUri")
+    .onTable("alb_logs")
+    .addIndexColumns("elb", "requestUri")
+    .create()
+
+flint.refresh("flint_alb_logs_elb_and_requestUri_index")
 ```
 
 #### Skipping Index Provider SPI

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,7 +129,7 @@ WITH (auto_refresh = (true|false))
 
 REFRESH SKIPPING INDEX ON <object>
 
-DESCRIBE SKIPPING INDEX ON <object>
+[DESC|DESCRIBE] SKIPPING INDEX ON <object>
 
 DROP SKIPPING INDEX ON <object>
 
@@ -168,9 +168,9 @@ WITH (auto_refresh = (true|false))
 
 REFRESH INDEX name ON <object>
 
-SHOW INDEX ON <object>
+SHOW [INDEX|INDEXES] ON <object>
 
-DESCRIBE INDEX name ON <object>
+[DESC|DESCRIBE] INDEX name ON <object>
 
 DROP INDEX name ON <object>
 ```

--- a/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4
+++ b/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4
@@ -46,12 +46,22 @@ dropSkippingIndexStatement
 
 coveringIndexStatement
     : createCoveringIndexStatement
+    | refreshCoveringIndexStatement
+    | dropCoveringIndexStatement
     ;
 
 createCoveringIndexStatement
     : CREATE INDEX indexName=identifier ON tableName=multipartIdentifier
         LEFT_PAREN indexColumns=multipartIdentifierPropertyList RIGHT_PAREN
         (WITH LEFT_PAREN propertyList RIGHT_PAREN)?
+    ;
+
+refreshCoveringIndexStatement
+    : REFRESH INDEX indexName=identifier ON tableName=multipartIdentifier
+    ;
+
+dropCoveringIndexStatement
+    : DROP INDEX indexName=identifier ON tableName=multipartIdentifier
     ;
 
 indexColTypeList

--- a/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4
+++ b/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4
@@ -16,6 +16,7 @@ singleStatement
 
 statement
     : skippingIndexStatement
+    | coveringIndexStatement
     ;
 
 skippingIndexStatement
@@ -41,6 +42,16 @@ describeSkippingIndexStatement
 
 dropSkippingIndexStatement
     : DROP SKIPPING INDEX ON tableName=multipartIdentifier
+    ;
+
+coveringIndexStatement
+    : createCoveringIndexStatement
+    ;
+
+createCoveringIndexStatement
+    : CREATE INDEX indexName=identifier ON tableName=multipartIdentifier
+        LEFT_PAREN indexColumns=multipartIdentifierPropertyList RIGHT_PAREN
+        (WITH LEFT_PAREN propertyList RIGHT_PAREN)?
     ;
 
 indexColTypeList

--- a/flint-spark-integration/src/main/antlr4/SparkSqlBase.g4
+++ b/flint-spark-integration/src/main/antlr4/SparkSqlBase.g4
@@ -85,6 +85,14 @@ grammar SparkSqlBase;
 }
 
 
+multipartIdentifierPropertyList
+    : multipartIdentifierProperty (COMMA multipartIdentifierProperty)*
+    ;
+
+multipartIdentifierProperty
+    : multipartIdentifier (options=propertyList)?
+    ;
+
 propertyList
     : property (COMMA property)*
     ;

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlAstBuilder.scala
@@ -5,14 +5,17 @@
 
 package org.opensearch.flint.spark.sql
 
-import org.opensearch.flint.spark.sql.skipping.FlintSparkSqlSkippingIndexAstBuilder
+import org.opensearch.flint.spark.sql.covering.FlintSparkCoveringIndexAstBuilder
+import org.opensearch.flint.spark.sql.skipping.FlintSparkSkippingIndexAstBuilder
 
 import org.apache.spark.sql.catalyst.plans.logical.Command
 
 /**
  * Flint Spark AST builder that builds Spark command for Flint index statement.
  */
-class FlintSparkSqlAstBuilder extends FlintSparkSqlSkippingIndexAstBuilder {
+class FlintSparkSqlAstBuilder
+    extends FlintSparkSkippingIndexAstBuilder
+    with FlintSparkCoveringIndexAstBuilder {
 
   override def aggregateResult(aggregate: Command, nextResult: Command): Command =
     if (nextResult != null) nextResult else aggregate

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlAstBuilder.scala
@@ -5,112 +5,14 @@
 
 package org.opensearch.flint.spark.sql
 
-import org.antlr.v4.runtime.tree.RuleNode
-import org.opensearch.flint.spark.FlintSpark
-import org.opensearch.flint.spark.FlintSpark.RefreshMode
-import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
-import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind
-import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{MIN_MAX, PARTITION, VALUE_SET}
-import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser._
+import org.opensearch.flint.spark.sql.skipping.FlintSparkSqlSkippingIndexAstBuilder
 
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.Command
-import org.apache.spark.sql.types.StringType
 
 /**
  * Flint Spark AST builder that builds Spark command for Flint index statement.
  */
-class FlintSparkSqlAstBuilder extends FlintSparkSqlExtensionsBaseVisitor[Command] {
-
-  override def visitCreateSkippingIndexStatement(
-      ctx: CreateSkippingIndexStatementContext): Command =
-    FlintSparkSqlCommand() { flint =>
-      // Create skipping index
-      val indexBuilder = flint
-        .skippingIndex()
-        .onTable(getFullTableName(flint, ctx.tableName))
-
-      ctx.indexColTypeList().indexColType().forEach { colTypeCtx =>
-        val colName = colTypeCtx.identifier().getText
-        val skipType = SkippingKind.withName(colTypeCtx.skipType.getText)
-        skipType match {
-          case PARTITION => indexBuilder.addPartitions(colName)
-          case VALUE_SET => indexBuilder.addValueSet(colName)
-          case MIN_MAX => indexBuilder.addMinMax(colName)
-        }
-      }
-      indexBuilder.create()
-
-      // Trigger auto refresh if enabled
-      if (isAutoRefreshEnabled(ctx.propertyList())) {
-        val indexName = getSkippingIndexName(flint, ctx.tableName)
-        flint.refreshIndex(indexName, RefreshMode.INCREMENTAL)
-      }
-      Seq.empty
-    }
-
-  override def visitRefreshSkippingIndexStatement(
-      ctx: RefreshSkippingIndexStatementContext): Command =
-    FlintSparkSqlCommand() { flint =>
-      val indexName = getSkippingIndexName(flint, ctx.tableName)
-      flint.refreshIndex(indexName, RefreshMode.FULL)
-      Seq.empty
-    }
-
-  override def visitDescribeSkippingIndexStatement(
-      ctx: DescribeSkippingIndexStatementContext): Command = {
-    val outputSchema = Seq(
-      AttributeReference("indexed_col_name", StringType, nullable = false)(),
-      AttributeReference("data_type", StringType, nullable = false)(),
-      AttributeReference("skip_type", StringType, nullable = false)())
-
-    FlintSparkSqlCommand(outputSchema) { flint =>
-      val indexName = getSkippingIndexName(flint, ctx.tableName)
-      flint
-        .describeIndex(indexName)
-        .map { case index: FlintSparkSkippingIndex =>
-          index.indexedColumns.map(strategy =>
-            Row(strategy.columnName, strategy.columnType, strategy.kind.toString))
-        }
-        .getOrElse(Seq.empty)
-    }
-  }
-
-  override def visitDropSkippingIndexStatement(ctx: DropSkippingIndexStatementContext): Command =
-    FlintSparkSqlCommand() { flint =>
-      val indexName = getSkippingIndexName(flint, ctx.tableName)
-      flint.deleteIndex(indexName)
-      Seq.empty
-    }
-
-  private def isAutoRefreshEnabled(ctx: PropertyListContext): Boolean = {
-    if (ctx == null) {
-      false
-    } else {
-      ctx
-        .property()
-        .forEach(p => {
-          if (p.key.getText == "auto_refresh") {
-            return p.value.getText.toBoolean
-          }
-        })
-      false
-    }
-  }
-
-  private def getSkippingIndexName(flint: FlintSpark, tableNameCtx: RuleNode): String =
-    FlintSparkSkippingIndex.getSkippingIndexName(getFullTableName(flint, tableNameCtx))
-
-  private def getFullTableName(flint: FlintSpark, tableNameCtx: RuleNode): String = {
-    val tableName = tableNameCtx.getText
-    if (tableName.contains(".")) {
-      tableName
-    } else {
-      val db = flint.spark.catalog.currentDatabase
-      s"$db.$tableName"
-    }
-  }
+class FlintSparkSqlAstBuilder extends FlintSparkSqlSkippingIndexAstBuilder {
 
   override def aggregateResult(aggregate: Command, nextResult: Command): Command =
     if (nextResult != null) nextResult else aggregate

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlAstBuilder.scala
@@ -14,7 +14,8 @@ import org.apache.spark.sql.catalyst.plans.logical.Command
  * Flint Spark AST builder that builds Spark command for Flint index statement.
  */
 class FlintSparkSqlAstBuilder
-    extends FlintSparkSkippingIndexAstBuilder
+    extends FlintSparkSqlExtensionsBaseVisitor[Command]
+    with FlintSparkSkippingIndexAstBuilder
     with FlintSparkCoveringIndexAstBuilder {
 
   override def aggregateResult(aggregate: Command, nextResult: Command): Command =

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlAstBuilder.scala
@@ -5,6 +5,9 @@
 
 package org.opensearch.flint.spark.sql
 
+import org.antlr.v4.runtime.tree.RuleNode
+import org.opensearch.flint.spark.FlintSpark
+import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser.PropertyListContext
 import org.opensearch.flint.spark.sql.covering.FlintSparkCoveringIndexAstBuilder
 import org.opensearch.flint.spark.sql.skipping.FlintSparkSkippingIndexAstBuilder
 
@@ -12,6 +15,7 @@ import org.apache.spark.sql.catalyst.plans.logical.Command
 
 /**
  * Flint Spark AST builder that builds Spark command for Flint index statement.
+ * This class mix-in all other AST builders and provides util methods.
  */
 class FlintSparkSqlAstBuilder
     extends FlintSparkSqlExtensionsBaseVisitor[Command]
@@ -20,4 +24,47 @@ class FlintSparkSqlAstBuilder
 
   override def aggregateResult(aggregate: Command, nextResult: Command): Command =
     if (nextResult != null) nextResult else aggregate
+}
+
+object FlintSparkSqlAstBuilder {
+
+  /**
+   * Check if auto_refresh is true in property list.
+   *
+   * @param ctx
+   *   property list
+   */
+  def isAutoRefreshEnabled(ctx: PropertyListContext): Boolean = {
+    if (ctx == null) {
+      false
+    } else {
+      ctx
+        .property()
+        .forEach(p => {
+          if (p.key.getText == "auto_refresh") {
+            return p.value.getText.toBoolean
+          }
+        })
+      false
+    }
+  }
+
+  /**
+   * Get full table name if database not specified.
+   *
+   * @param flint
+   *   Flint Spark which has access to Spark Catalog
+   * @param tableNameCtx
+   *   table name
+   * @return
+   */
+  def getFullTableName(flint: FlintSpark, tableNameCtx: RuleNode): String = {
+    val tableName = tableNameCtx.getText
+    if (tableName.contains(".")) {
+      tableName
+    } else {
+      val db = flint.spark.catalog.currentDatabase
+      s"$db.$tableName"
+    }
+  }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
@@ -5,12 +5,11 @@
 
 package org.opensearch.flint.spark.sql.covering
 
-import org.antlr.v4.runtime.tree.RuleNode
-import org.opensearch.flint.spark.FlintSpark
 import org.opensearch.flint.spark.FlintSpark.RefreshMode
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
 import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsVisitor}
-import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser.{CreateCoveringIndexStatementContext, PropertyListContext}
+import org.opensearch.flint.spark.sql.FlintSparkSqlAstBuilder.{getFullTableName, isAutoRefreshEnabled}
+import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser.CreateCoveringIndexStatementContext
 
 import org.apache.spark.sql.catalyst.plans.logical.Command
 
@@ -42,31 +41,6 @@ trait FlintSparkCoveringIndexAstBuilder extends FlintSparkSqlExtensionsVisitor[C
         flint.refreshIndex(flintIndexName, RefreshMode.INCREMENTAL)
       }
       Seq.empty
-    }
-  }
-
-  private def isAutoRefreshEnabled(ctx: PropertyListContext): Boolean = {
-    if (ctx == null) {
-      false
-    } else {
-      ctx
-        .property()
-        .forEach(p => {
-          if (p.key.getText == "auto_refresh") {
-            return p.value.getText.toBoolean
-          }
-        })
-      false
-    }
-  }
-
-  private def getFullTableName(flint: FlintSpark, tableNameCtx: RuleNode): String = {
-    val tableName = tableNameCtx.getText
-    if (tableName.contains(".")) {
-      tableName
-    } else {
-      val db = flint.spark.catalog.currentDatabase
-      s"$db.$tableName"
     }
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.sql.covering
+
+import org.antlr.v4.runtime.tree.RuleNode
+import org.opensearch.flint.spark.FlintSpark
+import org.opensearch.flint.spark.FlintSpark.RefreshMode
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
+import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsBaseVisitor}
+import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser.{CreateCoveringIndexStatementContext, PropertyListContext}
+
+import org.apache.spark.sql.catalyst.plans.logical.Command
+
+/**
+ * Flint Spark AST builder that builds Spark command for Flint covering index statement.
+ */
+trait FlintSparkCoveringIndexAstBuilder extends FlintSparkSqlExtensionsBaseVisitor[Command] {
+
+  override def visitCreateCoveringIndexStatement(
+      ctx: CreateCoveringIndexStatementContext): Command = {
+    FlintSparkSqlCommand() { flint =>
+      val indexName = ctx.indexName.getText
+      val tableName = ctx.tableName.getText
+      val indexBuilder =
+        flint
+          .coveringIndex()
+          .name(indexName)
+          .onTable(tableName)
+
+      ctx.indexColumns.multipartIdentifierProperty().forEach { indexColCtx =>
+        val colName = indexColCtx.multipartIdentifier().getText
+        indexBuilder.addIndexColumns(colName)
+      }
+      indexBuilder.create()
+
+      // Trigger auto refresh if enabled
+      if (isAutoRefreshEnabled(ctx.propertyList())) {
+        val flintIndexName = getFlintIndexName(indexName, getFullTableName(flint, ctx.tableName))
+        flint.refreshIndex(flintIndexName, RefreshMode.INCREMENTAL)
+      }
+      Seq.empty
+    }
+  }
+
+  private def isAutoRefreshEnabled(ctx: PropertyListContext): Boolean = {
+    if (ctx == null) {
+      false
+    } else {
+      ctx
+        .property()
+        .forEach(p => {
+          if (p.key.getText == "auto_refresh") {
+            return p.value.getText.toBoolean
+          }
+        })
+      false
+    }
+  }
+
+  private def getFullTableName(flint: FlintSpark, tableNameCtx: RuleNode): String = {
+    val tableName = tableNameCtx.getText
+    if (tableName.contains(".")) {
+      tableName
+    } else {
+      val db = flint.spark.catalog.currentDatabase
+      s"$db.$tableName"
+    }
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
@@ -9,7 +9,7 @@ import org.antlr.v4.runtime.tree.RuleNode
 import org.opensearch.flint.spark.FlintSpark
 import org.opensearch.flint.spark.FlintSpark.RefreshMode
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
-import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsBaseVisitor}
+import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsVisitor}
 import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser.{CreateCoveringIndexStatementContext, PropertyListContext}
 
 import org.apache.spark.sql.catalyst.plans.logical.Command
@@ -17,7 +17,7 @@ import org.apache.spark.sql.catalyst.plans.logical.Command
 /**
  * Flint Spark AST builder that builds Spark command for Flint covering index statement.
  */
-trait FlintSparkCoveringIndexAstBuilder extends FlintSparkSqlExtensionsBaseVisitor[Command] {
+trait FlintSparkCoveringIndexAstBuilder extends FlintSparkSqlExtensionsVisitor[Command] {
 
   override def visitCreateCoveringIndexStatement(
       ctx: CreateCoveringIndexStatementContext): Command = {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
@@ -9,7 +9,7 @@ import org.opensearch.flint.spark.FlintSpark.RefreshMode
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
 import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsVisitor}
 import org.opensearch.flint.spark.sql.FlintSparkSqlAstBuilder.{getFullTableName, isAutoRefreshEnabled}
-import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser.CreateCoveringIndexStatementContext
+import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser.{CreateCoveringIndexStatementContext, DropCoveringIndexStatementContext, RefreshCoveringIndexStatementContext}
 
 import org.apache.spark.sql.catalyst.plans.logical.Command
 
@@ -40,6 +40,30 @@ trait FlintSparkCoveringIndexAstBuilder extends FlintSparkSqlExtensionsVisitor[C
         val flintIndexName = getFlintIndexName(indexName, getFullTableName(flint, ctx.tableName))
         flint.refreshIndex(flintIndexName, RefreshMode.INCREMENTAL)
       }
+      Seq.empty
+    }
+  }
+
+  override def visitRefreshCoveringIndexStatement(
+      ctx: RefreshCoveringIndexStatementContext): Command = {
+    FlintSparkSqlCommand() { flint =>
+      val indexName = ctx.indexName.getText
+      val tableName = ctx.tableName.getText
+      val flintIndexName = getFlintIndexName(indexName, tableName)
+
+      flint.refreshIndex(flintIndexName, RefreshMode.FULL)
+      Seq.empty
+    }
+  }
+
+  override def visitDropCoveringIndexStatement(
+      ctx: DropCoveringIndexStatementContext): Command = {
+    FlintSparkSqlCommand() { flint =>
+      val indexName = ctx.indexName.getText
+      val tableName = getFullTableName(flint, ctx.tableName)
+      val flintIndexName = getFlintIndexName(indexName, tableName)
+
+      flint.deleteIndex(flintIndexName)
       Seq.empty
     }
   }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSkippingIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSkippingIndexAstBuilder.scala
@@ -11,7 +11,7 @@ import org.opensearch.flint.spark.FlintSpark.RefreshMode
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{MIN_MAX, PARTITION, VALUE_SET}
-import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsBaseVisitor}
+import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsVisitor}
 import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser._
 
 import org.apache.spark.sql.Row
@@ -22,7 +22,7 @@ import org.apache.spark.sql.types.StringType
 /**
  * Flint Spark AST builder that builds Spark command for Flint skipping index statement.
  */
-trait FlintSparkSkippingIndexAstBuilder extends FlintSparkSqlExtensionsBaseVisitor[Command] {
+trait FlintSparkSkippingIndexAstBuilder extends FlintSparkSqlExtensionsVisitor[Command] {
 
   override def visitCreateSkippingIndexStatement(
       ctx: CreateSkippingIndexStatementContext): Command =

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSkippingIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSkippingIndexAstBuilder.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.types.StringType
 /**
  * Flint Spark AST builder that builds Spark command for Flint skipping index statement.
  */
-class FlintSparkSqlSkippingIndexAstBuilder extends FlintSparkSqlExtensionsBaseVisitor[Command] {
+trait FlintSparkSkippingIndexAstBuilder extends FlintSparkSqlExtensionsBaseVisitor[Command] {
 
   override def visitCreateSkippingIndexStatement(
       ctx: CreateSkippingIndexStatementContext): Command =

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSkippingIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSkippingIndexAstBuilder.scala
@@ -12,6 +12,7 @@ import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{MIN_MAX, PARTITION, VALUE_SET}
 import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsVisitor}
+import org.opensearch.flint.spark.sql.FlintSparkSqlAstBuilder.{getFullTableName, isAutoRefreshEnabled}
 import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser._
 
 import org.apache.spark.sql.Row
@@ -85,31 +86,6 @@ trait FlintSparkSkippingIndexAstBuilder extends FlintSparkSqlExtensionsVisitor[C
       Seq.empty
     }
 
-  private def isAutoRefreshEnabled(ctx: PropertyListContext): Boolean = {
-    if (ctx == null) {
-      false
-    } else {
-      ctx
-        .property()
-        .forEach(p => {
-          if (p.key.getText == "auto_refresh") {
-            return p.value.getText.toBoolean
-          }
-        })
-      false
-    }
-  }
-
   private def getSkippingIndexName(flint: FlintSpark, tableNameCtx: RuleNode): String =
     FlintSparkSkippingIndex.getSkippingIndexName(getFullTableName(flint, tableNameCtx))
-
-  private def getFullTableName(flint: FlintSpark, tableNameCtx: RuleNode): String = {
-    val tableName = tableNameCtx.getText
-    if (tableName.contains(".")) {
-      tableName
-    } else {
-      val db = flint.spark.catalog.currentDatabase
-      s"$db.$tableName"
-    }
-  }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSqlSkippingIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSqlSkippingIndexAstBuilder.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.sql.skipping
+
+import org.antlr.v4.runtime.tree.RuleNode
+import org.opensearch.flint.spark.FlintSpark
+import org.opensearch.flint.spark.FlintSpark.RefreshMode
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{MIN_MAX, PARTITION, VALUE_SET}
+import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsBaseVisitor}
+import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser._
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.Command
+import org.apache.spark.sql.types.StringType
+
+/**
+ * Flint Spark AST builder that builds Spark command for Flint skipping index statement.
+ */
+class FlintSparkSqlSkippingIndexAstBuilder extends FlintSparkSqlExtensionsBaseVisitor[Command] {
+
+  override def visitCreateSkippingIndexStatement(
+      ctx: CreateSkippingIndexStatementContext): Command =
+    FlintSparkSqlCommand() { flint =>
+      // Create skipping index
+      val indexBuilder = flint
+        .skippingIndex()
+        .onTable(getFullTableName(flint, ctx.tableName))
+
+      ctx.indexColTypeList().indexColType().forEach { colTypeCtx =>
+        val colName = colTypeCtx.identifier().getText
+        val skipType = SkippingKind.withName(colTypeCtx.skipType.getText)
+        skipType match {
+          case PARTITION => indexBuilder.addPartitions(colName)
+          case VALUE_SET => indexBuilder.addValueSet(colName)
+          case MIN_MAX => indexBuilder.addMinMax(colName)
+        }
+      }
+      indexBuilder.create()
+
+      // Trigger auto refresh if enabled
+      if (isAutoRefreshEnabled(ctx.propertyList())) {
+        val indexName = getSkippingIndexName(flint, ctx.tableName)
+        flint.refreshIndex(indexName, RefreshMode.INCREMENTAL)
+      }
+      Seq.empty
+    }
+
+  override def visitRefreshSkippingIndexStatement(
+      ctx: RefreshSkippingIndexStatementContext): Command =
+    FlintSparkSqlCommand() { flint =>
+      val indexName = getSkippingIndexName(flint, ctx.tableName)
+      flint.refreshIndex(indexName, RefreshMode.FULL)
+      Seq.empty
+    }
+
+  override def visitDescribeSkippingIndexStatement(
+      ctx: DescribeSkippingIndexStatementContext): Command = {
+    val outputSchema = Seq(
+      AttributeReference("indexed_col_name", StringType, nullable = false)(),
+      AttributeReference("data_type", StringType, nullable = false)(),
+      AttributeReference("skip_type", StringType, nullable = false)())
+
+    FlintSparkSqlCommand(outputSchema) { flint =>
+      val indexName = getSkippingIndexName(flint, ctx.tableName)
+      flint
+        .describeIndex(indexName)
+        .map { case index: FlintSparkSkippingIndex =>
+          index.indexedColumns.map(strategy =>
+            Row(strategy.columnName, strategy.columnType, strategy.kind.toString))
+        }
+        .getOrElse(Seq.empty)
+    }
+  }
+
+  override def visitDropSkippingIndexStatement(ctx: DropSkippingIndexStatementContext): Command =
+    FlintSparkSqlCommand() { flint =>
+      val indexName = getSkippingIndexName(flint, ctx.tableName)
+      flint.deleteIndex(indexName)
+      Seq.empty
+    }
+
+  private def isAutoRefreshEnabled(ctx: PropertyListContext): Boolean = {
+    if (ctx == null) {
+      false
+    } else {
+      ctx
+        .property()
+        .forEach(p => {
+          if (p.key.getText == "auto_refresh") {
+            return p.value.getText.toBoolean
+          }
+        })
+      false
+    }
+  }
+
+  private def getSkippingIndexName(flint: FlintSpark, tableNameCtx: RuleNode): String =
+    FlintSparkSkippingIndex.getSkippingIndexName(getFullTableName(flint, tableNameCtx))
+
+  private def getFullTableName(flint: FlintSpark, tableNameCtx: RuleNode): String = {
+    val tableName = tableNameCtx.getText
+    if (tableName.contains(".")) {
+      tableName
+    } else {
+      val db = flint.spark.catalog.currentDatabase
+      s"$db.$tableName"
+    }
+  }
+}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
 
   /** Test table and index name */
-  private val testTable = "default.ci_sql_test"
+  private val testTable = "default.covering_sql_test"
   private val testIndex = "name_and_age"
   private val testFlintIndex = getFlintIndexName(testIndex, testTable)
 

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
+import org.scalatest.matchers.must.Matchers.defined
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
+
+  /** Test table and index name */
+  private val testTable = "default.ci_sql_test"
+  private val testIndex = "name_and_age"
+  private val testFlintIndex = getFlintIndexName(testIndex, testTable)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    createPartitionedTable(testTable)
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+
+    // Delete all test indices
+    flint.deleteIndex(testFlintIndex)
+  }
+
+  test("create covering index with auto refresh") {
+    sql(s"""
+         | CREATE INDEX $testIndex ON $testTable
+         | (name, age)
+         | WITH (auto_refresh = true)
+         |""".stripMargin)
+
+    // Wait for streaming job complete current micro batch
+    val job = spark.streams.active.find(_.name == testFlintIndex)
+    job shouldBe defined
+    failAfter(streamingTimeout) {
+      job.get.processAllAvailable()
+    }
+
+    val indexData = flint.queryIndex(testFlintIndex)
+    indexData.count() shouldBe 2
+  }
+}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -22,11 +22,14 @@ trait FlintSparkSuite
     with StreamTest {
 
   /** Flint Spark high level API being tested */
-  lazy protected val flint: FlintSpark = {
+  lazy protected val flint: FlintSpark = new FlintSpark(spark)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
     setFlintSparkConf(HOST_ENDPOINT, openSearchHost)
     setFlintSparkConf(HOST_PORT, openSearchPort)
     setFlintSparkConf(REFRESH_POLICY, "true")
-    new FlintSpark(spark)
   }
 
   protected def createPartitionedTable(testTable: String): Unit = {


### PR DESCRIPTION
### Description

1. Added SQL support for `CREATE/DROP/REFRESH` statement for covering index.
2. Updated user manual: https://github.com/dai-chen/opensearch-spark/blob/add-covering-index-sql-support/docs/index.md#covering-index
3. Refactor Flint SQL AST builder to separate and mix-in AST builder for different derived dataset

#### TODO

Will publish PR for `SHOW/DESC` statement separately for review convenience.

#### Example

Create covering index with auto refresh enabled and drop it when not needed:

```
spark-sql> CREATE INDEX orderkey_and_quantity 
... ON stream.lineitem_tiny (l_orderkey, l_quantity)
... WITH (auto_refresh = true);

spark-sql> DROP INDEX orderkey_and_quantity ON stream.lineitem_tiny;
```

OpenSearch index looks like:

```
GET flint_stream_lineitem_tiny_orderkey_and_quantity_index/_mapping
{
  "flint_stream_lineitem_tiny_orderkey_and_quantity_index": {
    "mappings": {
      "_meta": {
        "name": "orderkey_and_quantity",
        "source": "stream.lineitem_tiny",
        "kind": "covering",
        "indexedColumns": [
          {
            "columnType": "bigint",
            "columnName": "l_orderkey"
          },
          {
            "columnType": "float",
            "columnName": "l_quantity"
          }
        ]
      },
      "properties": {
        "l_orderkey": {
          "type": "long"
        },
        "l_quantity": {
          "type": "float"
        }
      }
    }
  }
}

GET flint_stream_lineitem_tiny_orderkey_and_quantity_index/_search
{
     ...
    "max_score": 1,
    "hits": [
      {
        "_index": "flint_stream_lineitem_tiny_orderkey_and_quantity_index",
        "_id": "a_hXqooBWdGHpYUCwr6x",
        "_score": 1,
        "_source": {
          "l_orderkey": 22828645,
          "l_quantity": 26
        }
      },
      {
        "_index": "flint_stream_lineitem_tiny_orderkey_and_quantity_index",
        "_id": "bPhXqooBWdGHpYUCwr6x",
        "_score": 1,
        "_source": {
          "l_orderkey": 59498081,
          "l_quantity": 16
        }
      },
      ...
```

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/23

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
