### PR TITLE
Add tumble windowing function

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkExtensions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkExtensions.scala
@@ -5,6 +5,7 @@
 
 package org.opensearch.flint.spark
 
+import org.opensearch.flint.spark.function.TumbleFunction
 import org.opensearch.flint.spark.sql.FlintSparkSqlParser
 
 import org.apache.spark.sql.SparkSessionExtensions
@@ -18,6 +19,9 @@ class FlintSparkExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectParser { (spark, parser) =>
       new FlintSparkSqlParser(parser)
     }
+
+    extensions.injectFunction(TumbleFunction.description)
+
     extensions.injectOptimizerRule { spark =>
       new FlintSparkOptimizer(spark)
     }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/function/TumbleFunction.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/function/TumbleFunction.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.function
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo}
+import org.apache.spark.sql.functions.window
+
+/**
+ * Tumble windowing function that groups row into fixed interval window without overlap.
+ */
+object TumbleFunction {
+
+  val identifier: FunctionIdentifier = FunctionIdentifier("tumble")
+
+  val exprInfo: ExpressionInfo = new ExpressionInfo(classOf[Column].getCanonicalName, "window")
+
+  val functionBuilder: Seq[Expression] => Expression =
+    (children: Seq[Expression]) => {
+      // Delegate actual implementation to window() function
+      val timeColumn = children.head
+      val windowDuration = children(1)
+      window(new Column(timeColumn), windowDuration.toString()).expr
+    }
+
+  /**
+   * Function description to register current function to Spark extension.
+   */
+  val description: (FunctionIdentifier, ExpressionInfo, FunctionBuilder) =
+    (identifier, exprInfo, functionBuilder)
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/function/TumbleFunction.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/function/TumbleFunction.scala
@@ -12,16 +12,27 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo}
 import org.apache.spark.sql.functions.window
 
 /**
- * Tumble windowing function that groups row into fixed interval window without overlap.
+ * Tumble windowing function that assigns row to fixed interval window without overlap.
  */
 object TumbleFunction {
 
+  /**
+   * Function name.
+   */
   val identifier: FunctionIdentifier = FunctionIdentifier("tumble")
 
+  /**
+   * Function output info.
+   */
   val exprInfo: ExpressionInfo = new ExpressionInfo(classOf[Column].getCanonicalName, "window")
 
+  /**
+   * Function implementation builder.
+   */
   val functionBuilder: Seq[Expression] => Expression =
     (children: Seq[Expression]) => {
+      require(children.size == 2, "column name and window expression are required")
+
       // Delegate actual implementation to window() function
       val timeColumn = children.head
       val windowDuration = children(1)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/function/TumbleFunction.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/function/TumbleFunction.scala
@@ -22,7 +22,7 @@ object TumbleFunction {
   val identifier: FunctionIdentifier = FunctionIdentifier("tumble")
 
   /**
-   * Function output info.
+   * Function signature: tumble function generates a new struct column after evaluation.
    */
   val exprInfo: ExpressionInfo = new ExpressionInfo(classOf[Column].getCanonicalName, "window")
 
@@ -33,7 +33,7 @@ object TumbleFunction {
     (children: Seq[Expression]) => {
       require(children.size == 2, "column name and window expression are required")
 
-      // Delegate actual implementation to window() function
+      // Delegate actual implementation to Spark existing window() function
       val timeColumn = children.head
       val windowDuration = children(1)
       window(new Column(timeColumn), windowDuration.toString()).expr

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/function/TumbleFunctionSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/function/TumbleFunctionSuite.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.function
+
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.FlintSuite
+
+class TumbleFunctionSuite extends FlintSuite with Matchers {
+
+  test("should require both column name and window expression as arguments") {
+    // TumbleFunction.functionBuilder(AttributeReference())
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/function/TumbleFunctionSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/function/TumbleFunctionSuite.scala
@@ -23,7 +23,7 @@ class TumbleFunctionSuite extends FlintSuite with Matchers {
     }
   }
 
-  test("should fail if only argument type is wrong") {
+  test("should fail if argument type is wrong") {
     assertThrows[AnalysisException] {
       TumbleFunction.functionBuilder(Seq(col("timestamp").expr, lit(10).expr))
     }

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/function/TumbleFunctionSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/function/TumbleFunctionSuite.scala
@@ -8,10 +8,24 @@ package org.opensearch.flint.spark.function
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.FlintSuite
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.functions.{col, lit}
 
 class TumbleFunctionSuite extends FlintSuite with Matchers {
 
-  test("should require both column name and window expression as arguments") {
-    // TumbleFunction.functionBuilder(AttributeReference())
+  test("should accept column name and window expression as arguments") {
+    TumbleFunction.functionBuilder(Seq(col("timestamp").expr, lit("10 minutes").expr))
+  }
+
+  test("should fail if only column name provided") {
+    assertThrows[IllegalArgumentException] {
+      TumbleFunction.functionBuilder(Seq(col("timestamp").expr))
+    }
+  }
+
+  test("should fail if only argument type is wrong") {
+    assertThrows[AnalysisException] {
+      TumbleFunction.functionBuilder(Seq(col("timestamp").expr, lit(10).expr))
+    }
   }
 }

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkWindowingFunctionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkWindowingFunctionITSuite.scala
@@ -11,7 +11,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.FlintSuite
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
+import org.apache.spark.sql.types.StructType
 
 class FlintSparkWindowingFunctionITSuite extends QueryTest with FlintSuite {
 
@@ -24,7 +24,7 @@ class FlintSparkWindowingFunctionITSuite extends QueryTest with FlintSuite {
           (3L, "2023-01-01 00:15:00")))
       .toDF("id", "timestamp")
 
-    val resultDF = inputDF.selectExpr("TUMBLE(timestamp, '10 minutes') AS window")
+    val resultDF = inputDF.selectExpr("TUMBLE(timestamp, '10 minutes')")
 
     resultDF.schema shouldBe StructType.fromDDL(
       "window struct<start:timestamp,end:timestamp> NOT NULL")

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkWindowingFunctionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkWindowingFunctionITSuite.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import java.sql.Timestamp
+
+import org.apache.spark.FlintSuite
+import org.apache.spark.sql.{QueryTest, Row}
+
+class FlintSparkWindowingFunctionITSuite extends QueryTest with FlintSuite {
+
+  test("tumble windowing function") {
+    val inputDF = spark
+      .createDataFrame(
+        Seq(
+          (1L, "2023-01-01 00:00:00"),
+          (2L, "2023-01-01 00:09:00"),
+          (3L, "2023-01-01 00:15:00")))
+      .toDF("id", "timestamp")
+
+    val resultDF = inputDF.selectExpr("TUMBLE(timestamp, '10 minutes') AS window")
+    val expectedData = Seq(
+      Row(Row(timestamp("2023-01-01 00:00:00"), timestamp("2023-01-01 00:10:00"))),
+      Row(Row(timestamp("2023-01-01 00:00:00"), timestamp("2023-01-01 00:10:00"))),
+      Row(Row(timestamp("2023-01-01 00:10:00"), timestamp("2023-01-01 00:20:00"))))
+
+    checkAnswer(resultDF, expectedData)
+  }
+
+  private def timestamp(ts: String): Timestamp = Timestamp.valueOf(ts)
+}


### PR DESCRIPTION
### Description

Add `TUMBLE` windowing function which is required by materialized view support.

The function generates a new column called `window`. It's a struct field consist of `start` and `end` field inside. The implementation is actually delegated to Spark existing `window()` function. Here is an example:

```
spark-sql>
... SELECT window, COUNT(*)
... FROM stream.lineitem_tiny
... GROUP BY TUMBLE(l_shipdate, '1 week')
... ORDER BY window.start
... LIMIT 10;

window	count(1)
{"start":1992-01-02 00:00:00,"end":1992-01-09 00:00:00}	1390
{"start":1992-06-04 00:00:00,"end":1992-06-11 00:00:00}	24980
{"start":1992-07-09 00:00:00,"end":1992-07-16 00:00:00}	24964
{"start":1992-07-16 00:00:00,"end":1992-07-23 00:00:00}	24957
{"start":1992-07-30 00:00:00,"end":1992-08-06 00:00:00}	25012
{"start":1992-08-06 00:00:00,"end":1992-08-13 00:00:00}	24929
{"start":1992-08-20 00:00:00,"end":1992-08-27 00:00:00}	24968
{"start":1992-09-03 00:00:00,"end":1992-09-10 00:00:00}	24972
{"start":1992-11-12 00:00:00,"end":1992-11-19 00:00:00}	24984
{"start":1993-01-07 00:00:00,"end":1993-01-14 00:00:00}	24753
Time taken: 5.095 seconds, Fetched 10 row(s)
```

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/25

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
