### PR TITLE
Add index settings option in create statement

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -197,6 +197,7 @@ User can provide the following options in `WITH` clause of create statement:
 + `auto_refresh`: triggers Incremental Refresh immediately after index create complete if true. Otherwise, user has to trigger Full Refresh by `REFRESH` statement manually.
 + `refresh_interval`: a string as the time interval for incremental refresh, e.g. 1 minute, 10 seconds. This is only applicable when auto refresh enabled. Please check `org.apache.spark.unsafe.types.CalendarInterval` for valid duration identifiers. By default, next micro batch will be generated as soon as the previous one complete processing.
 + `checkpoint_location`: a string as the location path for incremental refresh job checkpoint. The location has to be a path in an HDFS compatible file system and only applicable when auto refresh enabled. If unspecified, temporary checkpoint directory will be used and may result in checkpoint data lost upon restart.
++ `index_settings`: a JSON string as index settings for OpenSearch index that will be created. Please follow the format in OpenSearch documentation. If unspecified, default OpenSearch index settings will be applied.
 
 ```sql
 WITH (

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/FlintMetadata.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/FlintMetadata.java
@@ -14,11 +14,27 @@ public class FlintMetadata {
   // TODO: define metadata format and create strong-typed class
   private final String content;
 
+  // TODO: piggyback optional index settings and will refactor as above
+  private String indexSettings;
+
   public FlintMetadata(String content) {
     this.content = content;
   }
 
+  public FlintMetadata(String content, String indexSettings) {
+    this.content = content;
+    this.indexSettings = indexSettings;
+  }
+
   public String getContent() {
     return content;
+  }
+
+  public String getIndexSettings() {
+    return indexSettings;
+  }
+
+  public void setIndexSettings(String indexSettings) {
+    this.indexSettings = indexSettings;
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -86,12 +86,10 @@ class FlintSpark(val spark: SparkSession) {
         throw new IllegalStateException(s"Flint index $indexName already exists")
       }
     } else {
-      flintClient.createIndex(indexName, index.metadata())
+      val metadata = index.metadata()
+      index.options.indexSettings().foreach(metadata.setIndexSettings)
+      flintClient.createIndex(indexName, metadata)
     }
-
-    val metadata = index.metadata()
-    index.options.indexSettings().foreach(metadata.setIndexSettings)
-    flintClient.createIndex(indexName, metadata)
   }
 
   /**

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -88,6 +88,10 @@ class FlintSpark(val spark: SparkSession) {
     } else {
       flintClient.createIndex(indexName, index.metadata())
     }
+
+    val metadata = index.metadata()
+    index.options.indexSettings().foreach(metadata.setIndexSettings)
+    flintClient.createIndex(indexName, metadata)
   }
 
   /**

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
@@ -36,6 +36,14 @@ case class FlintSparkIndexOptions(options: Map[String, String]) {
    *   checkpoint location path
    */
   def checkpointLocation(): Option[String] = options.get("checkpoint_location")
+
+  /**
+   * The index settings for OpenSearch index created.
+   *
+   * @return
+   *   index setting JSON
+   */
+  def indexSettings(): Option[String] = options.get("index_settings")
 }
 
 object FlintSparkIndexOptions {

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
@@ -8,6 +8,9 @@ package org.opensearch.flint.core
 import scala.collection.JavaConverters._
 
 import com.stephenn.scalatest.jsonassert.JsonMatchers.matchJson
+import org.json4s.{Formats, NoTypeHints}
+import org.json4s.native.JsonMethods.parse
+import org.json4s.native.Serialization
 import org.opensearch.client.json.jackson.JacksonJsonpMapper
 import org.opensearch.client.opensearch.OpenSearchClient
 import org.opensearch.client.transport.rest_client.RestClientTransport
@@ -44,6 +47,20 @@ class FlintOpenSearchClientSuite extends AnyFlatSpec with OpenSearchSuite with M
 
     flintClient.exists(indexName) shouldBe true
     flintClient.getIndexMetadata(indexName).getContent should matchJson(content)
+  }
+
+  it should "create index with settings" in {
+    val indexName = "flint_test_with_settings"
+    val indexSettings = "{\"number_of_shards\": 3,\"number_of_replicas\": 2}"
+    flintClient.createIndex(indexName, new FlintMetadata("{}", indexSettings))
+
+    flintClient.exists(indexName) shouldBe true
+
+    // OS uses full setting name ("index" prefix) and store as string
+    implicit val formats: Formats = Serialization.formats(NoTypeHints)
+    val settings = parse(flintClient.getIndexMetadata(indexName).getIndexSettings)
+    (settings \ "index.number_of_shards").extract[String] shouldBe "3"
+    (settings \ "index.number_of_replicas").extract[String] shouldBe "2"
   }
 
   it should "get all index metadata with the given index name pattern" in {

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
@@ -67,7 +67,10 @@ class FlintOpenSearchClientSuite extends AnyFlatSpec with OpenSearchSuite with M
     flintClient.createIndex("flint_test_1_index", new FlintMetadata("{}"))
     flintClient.createIndex("flint_test_2_index", new FlintMetadata("{}"))
 
-    flintClient.getAllIndexMetadata("flint_*_index") should have size 2
+    val allMetadata = flintClient.getAllIndexMetadata("flint_*_index")
+    allMetadata should have size 2
+    allMetadata.forEach(metadata => metadata.getContent shouldBe "{}")
+    allMetadata.forEach(metadata => metadata.getIndexSettings should not be empty)
   }
 
   it should "return false if index not exist" in {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -6,7 +6,13 @@
 package org.opensearch.flint.spark
 
 import scala.Option.empty
+import scala.collection.JavaConverters.mapAsJavaMapConverter
 
+import org.json4s.{Formats, NoTypeHints}
+import org.json4s.native.JsonMethods.parse
+import org.json4s.native.Serialization
+import org.opensearch.flint.core.FlintOptions
+import org.opensearch.flint.core.storage.FlintOpenSearchClient
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
 import org.scalatest.matchers.must.Matchers.defined
@@ -50,6 +56,42 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
 
     val indexData = flint.queryIndex(testFlintIndex)
     indexData.count() shouldBe 2
+  }
+
+  test("create skipping index with streaming job options") {
+    withTempDir { checkpointDir =>
+      sql(s"""
+             | CREATE INDEX $testIndex ON $testTable ( name )
+             | WITH (
+             |   auto_refresh = true,
+             |   refresh_interval = '5 Seconds',
+             |   checkpoint_location = '${checkpointDir.getAbsolutePath}'
+             | )
+             | """.stripMargin)
+
+      val index = flint.describeIndex(testFlintIndex)
+      index shouldBe defined
+      index.get.options.autoRefresh() shouldBe true
+      index.get.options.refreshInterval() shouldBe Some("5 Seconds")
+      index.get.options.checkpointLocation() shouldBe Some(checkpointDir.getAbsolutePath)
+    }
+  }
+
+  test("create skipping index with index settings") {
+    sql(s"""
+           | CREATE INDEX $testIndex ON $testTable ( name )
+           | WITH (
+           |   index_settings = '{"number_of_shards": 2, "number_of_replicas": 3}'
+           | )
+           |""".stripMargin)
+
+    // Check if the index setting option is set to OS index setting
+    val flintClient = new FlintOpenSearchClient(new FlintOptions(openSearchOptions.asJava))
+
+    implicit val formats: Formats = Serialization.formats(NoTypeHints)
+    val settings = parse(flintClient.getIndexMetadata(testFlintIndex).getIndexSettings)
+    (settings \ "index.number_of_shards").extract[String] shouldBe "2"
+    (settings \ "index.number_of_replicas").extract[String] shouldBe "3"
   }
 
   test("create covering index with manual refresh") {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -133,11 +133,12 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
         | }
         |""".stripMargin)
 
+    // Load index options from index mapping (verify OS index setting in SQL IT)
     index.get.options.autoRefresh() shouldBe true
     index.get.options.refreshInterval() shouldBe Some("1 Minute")
     index.get.options.checkpointLocation() shouldBe Some("s3a://test/")
     index.get.options.indexSettings() shouldBe
-      "{\"number_of_shards\": 3,\"number_of_replicas\": 2}"
+      Some("{\"number_of_shards\": 3,\"number_of_replicas\": 2}")
   }
 
   test("should not have ID column in index data") {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -6,6 +6,7 @@
 package org.opensearch.flint.spark
 
 import com.stephenn.scalatest.jsonassert.JsonMatchers.matchJson
+import org.json4s.native.JsonMethods._
 import org.opensearch.flint.core.FlintVersion.current
 import org.opensearch.flint.spark.FlintSpark.RefreshMode.{FULL, INCREMENTAL}
 import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
@@ -116,12 +117,22 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
         "auto_refresh" -> "true",
         "refresh_interval" -> "1 Minute",
         "checkpoint_location" -> "s3a://test/",
-        "index_settings" -> "{\"number_of_shards\": 3,\"number_of_replicas\": 2}"
-      )))
+        "index_settings" -> "{\"number_of_shards\": 3,\"number_of_replicas\": 2}")))
       .create()
 
     val index = flint.describeIndex(testIndex)
     index shouldBe defined
+    val optionJson = compact(render(
+      parse(index.get.metadata().getContent) \ "_meta" \ "options"))
+    optionJson should matchJson("""
+        | {
+        |   "auto_refresh": "true",
+        |   "refresh_interval": "1 Minute",
+        |   "checkpoint_location": "s3a://test/",
+        |   "index_settings": "{\"number_of_shards\": 3,\"number_of_replicas\": 2}"
+        | }
+        |""".stripMargin)
+
     index.get.options.autoRefresh() shouldBe true
     index.get.options.refreshInterval() shouldBe Some("1 Minute")
     index.get.options.checkpointLocation() shouldBe Some("s3a://test/")

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -115,7 +115,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
       .options(FlintSparkIndexOptions(Map(
         "auto_refresh" -> "true",
         "refresh_interval" -> "1 Minute",
-        "checkpoint_location" -> "s3a://test/"
+        "checkpoint_location" -> "s3a://test/",
+        "index_settings" -> "{\"number_of_shards\": 3,\"number_of_replicas\": 2}"
       )))
       .create()
 
@@ -124,6 +125,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
     index.get.options.autoRefresh() shouldBe true
     index.get.options.refreshInterval() shouldBe Some("1 Minute")
     index.get.options.checkpointLocation() shouldBe Some("s3a://test/")
+    index.get.options.indexSettings() shouldBe
+      "{\"number_of_shards\": 3,\"number_of_replicas\": 2}"
   }
 
   test("should not have ID column in index data") {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
@@ -6,7 +6,13 @@
 package org.opensearch.flint.spark
 
 import scala.Option.empty
+import scala.collection.JavaConverters.mapAsJavaMapConverter
 
+import org.json4s.{Formats, NoTypeHints}
+import org.json4s.native.JsonMethods.parse
+import org.json4s.native.Serialization
+import org.opensearch.flint.core.FlintOptions
+import org.opensearch.flint.core.storage.FlintOpenSearchClient
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
 import org.scalatest.matchers.must.Matchers.defined
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
@@ -73,6 +79,24 @@ class FlintSparkSkippingIndexSqlITSuite extends FlintSparkSuite {
       index.get.options.refreshInterval() shouldBe Some("5 Seconds")
       index.get.options.checkpointLocation() shouldBe Some(checkpointDir.getAbsolutePath)
     }
+  }
+
+  test("create skipping index with index settings") {
+    sql(s"""
+           | CREATE SKIPPING INDEX ON $testTable
+           | ( year PARTITION )
+           | WITH (
+           |   index_settings = '{"number_of_shards": 3, "number_of_replicas": 2}'
+           | )
+           |""".stripMargin)
+
+    // Check if the index settings is set to OS index
+    val flintClient = new FlintOpenSearchClient(new FlintOptions(openSearchOptions.asJava))
+
+    implicit val formats: Formats = Serialization.formats(NoTypeHints)
+    val settings = parse(flintClient.getIndexMetadata(testIndex).getIndexSettings)
+    (settings \ "index.number_of_shards").extract[String] shouldBe "3"
+    (settings \ "index.number_of_replicas").extract[String] shouldBe "2"
   }
 
   test("create skipping index with manual refresh") {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
@@ -90,7 +90,7 @@ class FlintSparkSkippingIndexSqlITSuite extends FlintSparkSuite {
            | )
            |""".stripMargin)
 
-    // Check if the index settings is set to OS index
+    // Check if the index setting option is set to OS index setting
     val flintClient = new FlintOpenSearchClient(new FlintOptions(openSearchOptions.asJava))
 
     implicit val formats: Formats = Serialization.formats(NoTypeHints)


### PR DESCRIPTION
### Description

1. Add new `index_settings` option. Please see doc: https://github.com/dai-chen/opensearch-spark/blob/add-index-settings-option/docs/index.md#create-index-options
2. Use a new `FlintMetadata.indexSettings` field to pass it to Flint client. Will refactor the Flint metadata and finalize spec in https://github.com/opensearch-project/opensearch-spark/issues/24

#### Example

```
spark-sql> CREATE INDEX orderkey_and_quantity
         > ON stream.lineitem_tiny (l_orderkey, l_quantity)
         > WITH (
         >   index_settings = '{"number_of_shards":9,"number_of_replicas":2}'
         > );

GET flint_stream_lineitem_tiny_orderkey_and_quantity_index/_settings
{
  "flint_stream_lineitem_tiny_orderkey_and_quantity_index": {
    "settings": {
      "index": {
        "creation_date": "1695680614547",
        "number_of_shards": "9",
        "number_of_replicas": "2",
        "uuid": "M-HlOt8yT1i7hKEm_GJmOw",
        "version": {
          "created": "136267827"
        },
        "provided_name": "flint_stream_lineitem_tiny_orderkey_and_quantity_index"
      }
    }
  }
}
```

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/26

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
