### PR TITLE
Persisting runtime env info into Flint metadata

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -66,10 +66,6 @@ object FlintSparkIndex {
   def flintIndexNamePrefix(fullTableName: String): String =
     s"flint_${fullTableName.replace(".", "_")}_"
 
-  // TODO: avoid hardcoding env name below by providing another config
-  private val EMR_S_APP_ID_KEY = "SERVERLESS_EMR_VIRTUAL_CLUSTER_ID"
-  private val EMR_S_JOB_ID_KEY = "SERVERLESS_EMR_JOB_ID"
-
   /**
    * Populate environment variables to persist in Flint metadata.
    *
@@ -77,12 +73,12 @@ object FlintSparkIndex {
    *   env key value mapping to populate
    */
   def populateEnvToMetadata: Map[String, String] = {
-    val appId = System.getenv(EMR_S_APP_ID_KEY)
-    if (appId == null) {
-      Map.empty
-    } else {
-      val jobId = System.getenv(EMR_S_JOB_ID_KEY)
-      Map(EMR_S_APP_ID_KEY -> appId, EMR_S_JOB_ID_KEY -> jobId)
-    }
+    // TODO: avoid hardcoding env name below by providing another config
+    val envNames = Seq("SERVERLESS_EMR_VIRTUAL_CLUSTER_ID", "SERVERLESS_EMR_JOB_ID")
+    envNames
+      .flatMap(key =>
+        Option(System.getenv(key))
+          .map(value => key -> value))
+      .toMap
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -65,4 +65,24 @@ object FlintSparkIndex {
    */
   def flintIndexNamePrefix(fullTableName: String): String =
     s"flint_${fullTableName.replace(".", "_")}_"
+
+  // TODO: avoid hardcoding env name below by providing another config
+  private val EMR_S_APP_ID_KEY = "SERVERLESS_EMR_VIRTUAL_CLUSTER_ID"
+  private val EMR_S_JOB_ID_KEY = "SERVERLESS_EMR_JOB_ID"
+
+  /**
+   * Populate environment variables to persist in Flint metadata.
+   *
+   * @return
+   *   env key value mapping to populate
+   */
+  def populateEnvToMetadata: Map[String, String] = {
+    val appId = System.getenv(EMR_S_APP_ID_KEY)
+    if (appId == null) {
+      Map.empty
+    } else {
+      val jobId = System.getenv(EMR_S_JOB_ID_KEY)
+      Map(EMR_S_APP_ID_KEY -> appId, EMR_S_JOB_ID_KEY -> jobId)
+    }
+  }
 }

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -57,7 +57,8 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
          |        "columnType": "int"
          |     }],
          |     "source": "spark_catalog.default.ci_test",
-         |     "options": {}
+         |     "options": {},
+         |     "properties": {}
          |   },
          |   "properties": {
          |     "name": {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -78,7 +78,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
         |        "columnType": "int"
         |     }],
         |     "source": "spark_catalog.default.test",
-        |     "options": {}
+        |     "options": {},
+        |     "properties": {}
         |   },
         |   "properties": {
         |     "year": {
@@ -506,7 +507,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
          |        "columnType": "struct<subfield1:string,subfield2:int>"
          |     }],
          |     "source": "$testTable",
-         |     "options": {}
+         |     "options": {},
+         |     "properties": {}
          |   },
          |   "properties": {
          |     "boolean_col": {


### PR DESCRIPTION
### Description

Persist env info in Flint metadata, such as EMR-S job info. We persist them for CREATE statement regardless of index options, such as `auto_refresh`.

#### TODO

1. Refactor Flint metadata to de-dup serialization code in https://github.com/opensearch-project/opensearch-spark/issues/24
2. Remove hardcoding env name in https://github.com/opensearch-project/opensearch-spark/issues/59

#### Example

For EMR-S Spark:

```
# Skipping index test
CREATE SKIPPING INDEX ON myglue.default.http_logs (clientip VALUE_SET);

GET flint_myglue_default_http_logs_skipping_index/_mapping
{
    "mappings": {
      "_meta": {
        "kind": "skipping",
        "indexedColumns": 
        ...
        "source": "myglue.default.http_logs",
        "version": "0.1.0",
        "properties": {
          "env": {
            "SERVERLESS_EMR_VIRTUAL_CLUSTER_ID": "XXXXXX",
            "SERVERLESS_EMR_JOB_ID": "YYYYYY"
          }
        }
      },
      ...

# Covering index test
CREATE INDEX clientip_and_request ON default.http_logs_streaming (clientip, request);

GET flint_myglue_default_http_logs_streaming_clientip_and_request_index/_mapping
{
    "mappings": {
      "_meta": {
        "kind": "covering",
        "indexedColumns":
        ...
        "name": "clientip_and_request",
        "options": {},
        "source": "myglue.default.http_logs_streaming",
        "properties": {
          "env": {
            "SERVERLESS_EMR_VIRTUAL_CLUSTER_ID": "XXXXXX",
            "SERVERLESS_EMR_JOB_ID": "YYYYYY"
          }
        }
      },
      ...
```

For Non-EMR-S Spark, the `properties` should be empty without any env info:

```
spark-sql> CREATE SKIPPING INDEX ON myglue.stream.lineitem_tiny (l_shipdate VALUE_SET);

GET flint_myglue_stream_lineitem_tiny_skipping_index/_mapping
{
    "mappings": {
      "_meta": {
        "kind": "skipping",
        "indexedColumns":
        ...
        "source": "myglue.stream.lineitem_tiny",
        "version": "0.1.0",
        "properties": {}
      },
      ...
```

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/57

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
