### PR TITLE
Add validation for index options

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -199,6 +199,8 @@ User can provide the following options in `WITH` clause of create statement:
 + `checkpoint_location`: a string as the location path for incremental refresh job checkpoint. The location has to be a path in an HDFS compatible file system and only applicable when auto refresh enabled. If unspecified, temporary checkpoint directory will be used and may result in checkpoint data lost upon restart.
 + `index_settings`: a JSON string as index settings for OpenSearch index that will be created. Please follow the format in OpenSearch documentation. If unspecified, default OpenSearch index settings will be applied.
 
+Note that the index option name is case-sensitive.
+
 ```sql
 WITH (
   auto_refresh = [true|false],

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
@@ -5,9 +5,7 @@
 
 package org.opensearch.flint.spark
 
-import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.{
-  AUTO_REFRESH, CHECKPOINT_LOCATION, INDEX_SETTINGS, OptionName, REFRESH_INTERVAL
-}
+import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.{AUTO_REFRESH, CHECKPOINT_LOCATION, INDEX_SETTINGS, OptionName, REFRESH_INTERVAL}
 import org.opensearch.flint.spark.FlintSparkIndexOptions.validateOptionNames
 
 /**
@@ -89,12 +87,16 @@ object FlintSparkIndexOptions {
     val INDEX_SETTINGS: OptionName.Value = Value("index_settings")
   }
 
-  // This method has to be here otherwise Scala compilation failure
+  /**
+   * Validate option names and throw exception if any unknown found.
+   *
+   * @param options
+   *   options given
+   */
   def validateOptionNames(options: Map[String, String]): Unit = {
-    val allowedNames = OptionName.values.map(_.toString)
-    val unknownNames = options.keys.filterNot(allowedNames.contains)
+    val allOptions = OptionName.values.map(_.toString)
+    val invalidOptions = options.keys.filterNot(allOptions.contains)
 
-    require(unknownNames.isEmpty,
-      s"option name ${unknownNames.mkString(",")} is invalid")
+    require(invalidOptions.isEmpty, s"option name ${invalidOptions.mkString(",")} is invalid")
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
@@ -5,8 +5,6 @@
 
 package org.opensearch.flint.spark
 
-import java.util.Locale
-
 import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.{
   AUTO_REFRESH, CHECKPOINT_LOCATION, INDEX_SETTINGS, OptionName, REFRESH_INTERVAL
 }
@@ -89,14 +87,6 @@ object FlintSparkIndexOptions {
     val REFRESH_INTERVAL: OptionName.Value = Value("refresh_interval")
     val CHECKPOINT_LOCATION: OptionName.Value = Value("checkpoint_location")
     val INDEX_SETTINGS: OptionName.Value = Value("index_settings")
-
-    /**
-     * @return
-     *   convert enum name to lowercase as public option name
-     */
-    override def toString(): String = {
-      super.toString().toLowerCase(Locale.ROOT)
-    }
   }
 
   // This method has to be here otherwise Scala compilation failure

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
@@ -54,6 +54,20 @@ case class FlintSparkIndexOptions(options: Map[String, String]) {
    */
   def indexSettings(): Option[String] = getOptionValue(INDEX_SETTINGS)
 
+  /**
+   * @return
+   *   all option values and fill default value if unspecified
+   */
+  def optionsWithDefault: Map[String, String] = {
+    val map = Map.newBuilder[String, String]
+    map ++= options
+
+    if (!options.contains(AUTO_REFRESH.toString)) {
+      map += (AUTO_REFRESH.toString -> autoRefresh().toString)
+    }
+    map.result()
+  }
+
   private def getOptionValue(name: OptionName): Option[String] = {
     options.get(name.toString)
   }
@@ -76,6 +90,10 @@ object FlintSparkIndexOptions {
     val CHECKPOINT_LOCATION: OptionName.Value = Value("checkpoint_location")
     val INDEX_SETTINGS: OptionName.Value = Value("index_settings")
 
+    /**
+     * @return
+     *   convert enum name to lowercase as public option name
+     */
     override def toString(): String = {
       super.toString().toLowerCase(Locale.ROOT)
     }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -74,7 +74,7 @@ case class FlintSparkCoveringIndex(
   }
 
   private def getIndexOptions: String = {
-    Serialization.write(options.options)
+    Serialization.write(options.optionsWithDefault)
   }
 
   private def getIndexProperties: String = {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -87,7 +87,7 @@ class FlintSparkSkippingIndex(
   }
 
   private def getIndexOptions: String = {
-    Serialization.write(options.options)
+    Serialization.write(options.optionsWithDefault)
   }
 
   private def getIndexProperties: String = {

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexOptionsSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexOptionsSuite.scala
@@ -32,17 +32,23 @@ class FlintSparkIndexOptionsSuite extends FlintSuite with Matchers {
     options.refreshInterval() shouldBe empty
     options.checkpointLocation() shouldBe empty
     options.indexSettings() shouldBe empty
+    options.optionsWithDefault should contain("auto_refresh" -> "false")
+  }
+
+  test("should return default option value if unspecified with specified value") {
+    val options = FlintSparkIndexOptions(Map("refresh_interval" -> "1 Minute"))
+
+    options.optionsWithDefault shouldBe Map(
+      "auto_refresh" -> "false",
+      "refresh_interval" -> "1 Minute")
   }
 
   test("should report error if any unknown option name") {
-    the [IllegalArgumentException] thrownBy
+    the[IllegalArgumentException] thrownBy
       FlintSparkIndexOptions(Map("autoRefresh" -> "true"))
 
-    the [IllegalArgumentException] thrownBy {
-      FlintSparkIndexOptions(Map(
-        "auto_refresh" -> "true",
-        "indexSetting" -> "test"
-      ))
+    the[IllegalArgumentException] thrownBy {
+      FlintSparkIndexOptions(Map("auto_refresh" -> "true", "indexSetting" -> "test"))
     } should have message "requirement failed: option name indexSetting is invalid"
   }
 }

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexOptionsSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexOptionsSuite.scala
@@ -5,11 +5,19 @@
 
 package org.opensearch.flint.spark
 
+import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.{AUTO_REFRESH, CHECKPOINT_LOCATION, INDEX_SETTINGS, REFRESH_INTERVAL}
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.FlintSuite
 
 class FlintSparkIndexOptionsSuite extends FlintSuite with Matchers {
+
+  test("should return lowercase name as option name") {
+    AUTO_REFRESH.toString shouldBe "auto_refresh"
+    REFRESH_INTERVAL.toString shouldBe "refresh_interval"
+    CHECKPOINT_LOCATION.toString shouldBe "checkpoint_location"
+    INDEX_SETTINGS.toString shouldBe "index_settings"
+  }
 
   test("should return specified option value") {
     val options = FlintSparkIndexOptions(
@@ -46,6 +54,9 @@ class FlintSparkIndexOptionsSuite extends FlintSuite with Matchers {
   test("should report error if any unknown option name") {
     the[IllegalArgumentException] thrownBy
       FlintSparkIndexOptions(Map("autoRefresh" -> "true"))
+
+    the[IllegalArgumentException] thrownBy
+      FlintSparkIndexOptions(Map("AUTO_REFRESH" -> "true"))
 
     the[IllegalArgumentException] thrownBy {
       FlintSparkIndexOptions(Map("auto_refresh" -> "true", "indexSetting" -> "test"))

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexOptionsSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexOptionsSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.FlintSuite
+
+class FlintSparkIndexOptionsSuite extends FlintSuite with Matchers {
+
+  test("should return specified option value") {
+    val options = FlintSparkIndexOptions(
+      Map(
+        "auto_refresh" -> "true",
+        "refresh_interval" -> "1 Minute",
+        "checkpoint_location" -> "s3://test/",
+        "index_settings" -> """{"number_of_shards": 3}"""))
+
+    options.autoRefresh() shouldBe true
+    options.refreshInterval() shouldBe Some("1 Minute")
+    options.checkpointLocation() shouldBe Some("s3://test/")
+    options.indexSettings() shouldBe Some("""{"number_of_shards": 3}""")
+  }
+
+  test("should return default option value if unspecified") {
+    val options = FlintSparkIndexOptions(Map.empty)
+
+    options.autoRefresh() shouldBe false
+    options.refreshInterval() shouldBe empty
+    options.checkpointLocation() shouldBe empty
+    options.indexSettings() shouldBe empty
+  }
+
+  test("should report error if any unknown option name") {
+    the [IllegalArgumentException] thrownBy
+      FlintSparkIndexOptions(Map("autoRefresh" -> "true"))
+
+    the [IllegalArgumentException] thrownBy {
+      FlintSparkIndexOptions(Map(
+        "auto_refresh" -> "true",
+        "indexSetting" -> "test"
+      ))
+    } should have message "requirement failed: option name indexSetting is invalid"
+  }
+}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -57,7 +57,7 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
          |        "columnType": "int"
          |     }],
          |     "source": "spark_catalog.default.ci_test",
-         |     "options": {},
+         |     "options": { "auto_refresh": "false" },
          |     "properties": {}
          |   },
          |   "properties": {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -79,7 +79,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
         |        "columnType": "int"
         |     }],
         |     "source": "spark_catalog.default.test",
-        |     "options": {},
+        |     "options": { "auto_refresh": "false" },
         |     "properties": {}
         |   },
         |   "properties": {
@@ -105,7 +105,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
         | }
         |""".stripMargin)
 
-    index.get.options shouldBe FlintSparkIndexOptions.empty
+    index.get.options shouldBe FlintSparkIndexOptions(Map("auto_refresh" -> "false"))
   }
 
   test("create skipping index with index options successfully") {
@@ -522,7 +522,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
          |        "columnType": "struct<subfield1:string,subfield2:int>"
          |     }],
          |     "source": "$testTable",
-         |     "options": {},
+         |     "options": { "auto_refresh": "false" },
          |     "properties": {}
          |   },
          |   "properties": {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
@@ -15,7 +15,7 @@ import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.storage.FlintOpenSearchClient
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
 import org.scalatest.matchers.must.Matchers.defined
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, the}
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.flint.FlintDataSourceV2.FLINT_DATASOURCE
@@ -97,6 +97,15 @@ class FlintSparkSkippingIndexSqlITSuite extends FlintSparkSuite {
     val settings = parse(flintClient.getIndexMetadata(testIndex).getIndexSettings)
     (settings \ "index.number_of_shards").extract[String] shouldBe "3"
     (settings \ "index.number_of_replicas").extract[String] shouldBe "2"
+  }
+
+  test("create skipping index with invalid option") {
+    the[IllegalArgumentException] thrownBy
+      sql(s"""
+             | CREATE SKIPPING INDEX ON $testTable
+             | ( year PARTITION )
+             | WITH (autoRefresh = true)
+             | """.stripMargin)
   }
 
   test("create skipping index with manual refresh") {


### PR DESCRIPTION
### Description

1. Added validation for option name provided in WITH clause and throw exception for invalid/unknown name
2. For clarity, Store option with default value in Flint metadata even if unspecified in SQL.

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/65

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
