### PR TITLE
Add materialized view in Flint Spark API

### DIFF
--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/package.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/package.scala
@@ -14,19 +14,7 @@ import org.apache.spark.sql.connector.catalog._
 package object flint {
 
   /**
-   * Convert data frame to logical plan.
-   *
-   * @param df
-   *   data frame
-   * @return
-   *   logical plan
-   */
-  def dataFrameToLogicalPlan(df: DataFrame): LogicalPlan = {
-    df.logicalPlan
-  }
-
-  /**
-   * Convert logical plan to data frame.
+   * Convert the given logical plan to Spark data frame.
    *
    * @param spark
    *   Spark session

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/package.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/package.scala
@@ -5,12 +5,39 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.catalog._
 
 /**
  * Flint utility methods that rely on access to private code in Spark SQL package.
  */
 package object flint {
+
+  /**
+   * Convert data frame to logical plan.
+   *
+   * @param df
+   *   data frame
+   * @return
+   *   logical plan
+   */
+  def dataFrameToLogicalPlan(df: DataFrame): LogicalPlan = {
+    df.logicalPlan
+  }
+
+  /**
+   * Convert logical plan to data frame.
+   *
+   * @param spark
+   *   Spark session
+   * @param logicalPlan
+   *   logical plan
+   * @return
+   *   data frame
+   */
+  def logicalPlanToDataFrame(spark: SparkSession, logicalPlan: LogicalPlan): DataFrame = {
+    Dataset.ofRows(spark, logicalPlan)
+  }
 
   /**
    * Qualify a given table name.

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -137,6 +137,7 @@ class FlintSpark(val spark: SparkSession) {
         batchRefresh()
         None
 
+      // Flint index has specialized logic and capability for incremental refresh
       case INCREMENTAL if index.isInstanceOf[StreamingRefresh] =>
         val job =
           index
@@ -152,6 +153,7 @@ class FlintSpark(val spark: SparkSession) {
             .start(indexName)
         Some(job.id.toString)
 
+      // Otherwise, fall back to foreachBatch + batch refresh
       case INCREMENTAL =>
         val job = spark.readStream
           .table(tableName)
@@ -256,6 +258,7 @@ class FlintSpark(val spark: SparkSession) {
     val indexOptions = FlintSparkIndexOptions(
       metadata.options.asScala.mapValues(_.asInstanceOf[String]).toMap)
 
+    // Convert generic Map[String,AnyRef] in metadata to specific data structure in Flint index
     metadata.kind match {
       case SKIPPING_INDEX_TYPE =>
         val strategies = metadata.indexedColumns.map { colInfo =>

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -254,6 +254,7 @@ class FlintSpark(val spark: SparkSession) {
       .getOrElse(Trigger.ProcessingTime(0L))
   }
 
+  // TODO: move this to Flint index factory
   private def deserialize(metadata: FlintMetadata): FlintSparkIndex = {
     val indexOptions = FlintSparkIndexOptions(
       metadata.options.asScala.mapValues(_.asInstanceOf[String]).toMap)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -152,7 +152,7 @@ class FlintSpark(val spark: SparkSession) {
         val job =
           index
             .asInstanceOf[StreamingRefresh]
-            .build(spark)
+            .buildStream(spark)
             .writeStream
             .queryName(indexName)
             .outputMode(Append())

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -120,7 +120,7 @@ object FlintSparkIndex {
     builder.kind(index.kind)
     builder.options(index.options.optionsWithDefault.mapValues(_.asInstanceOf[AnyRef]).asJava)
 
-    // Index properties
+    // Optional index properties
     val envs = populateEnvToMetadata
     if (envs.nonEmpty) {
       builder.addProperty("env", envs.asJava)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -8,16 +8,16 @@ package org.opensearch.flint.spark
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 import org.opensearch.flint.core.metadata.FlintMetadata
+import org.opensearch.flint.spark.FlintSparkIndex.BatchRefresh
 
-import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.flint.datatype.FlintDataType
-import org.apache.spark.sql.streaming.DataStreamWriter
 import org.apache.spark.sql.types.StructType
 
 /**
  * Flint index interface in Spark.
  */
-trait FlintSparkIndex {
+trait FlintSparkIndex extends BatchRefresh {
 
   /**
    * Index type
@@ -50,14 +50,26 @@ trait FlintSparkIndex {
    * @return
    *   index building data frame
    */
+  /*
   def build(df: DataFrame): DataFrame
 
   def buildBatch(spark: SparkSession): DataFrameWriter[Row]
 
   def buildStream(spark: SparkSession): DataStreamWriter[Row]
+   */
 }
 
 object FlintSparkIndex {
+
+  trait BatchRefresh {
+
+    def build(spark: SparkSession, df: Option[DataFrame]): DataFrame
+  }
+
+  trait StreamingRefresh {
+
+    def build(spark: SparkSession): DataFrame
+  }
 
   /**
    * ID column name.

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -8,7 +8,6 @@ package org.opensearch.flint.spark
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 import org.opensearch.flint.core.metadata.FlintMetadata
-import org.opensearch.flint.spark.FlintSparkIndex.BatchRefresh
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.flint.datatype.FlintDataType
@@ -17,7 +16,7 @@ import org.apache.spark.sql.types.StructType
 /**
  * Flint index interface in Spark.
  */
-trait FlintSparkIndex extends BatchRefresh {
+trait FlintSparkIndex {
 
   /**
    * Index type
@@ -45,30 +44,34 @@ trait FlintSparkIndex extends BatchRefresh {
    * Build a data frame to represent index data computation logic. Upper level code decides how to
    * use this, ex. batch or streaming, fully or incremental refresh.
    *
+   * @param spark
+   *   Spark session for implementation class to use as needed
    * @param df
-   *   data frame to append building logic
+   *   data frame to append building logic. If none, implementation class create source data frame
+   *   on its own
    * @return
    *   index building data frame
    */
-  /*
-  def build(df: DataFrame): DataFrame
-
-  def buildBatch(spark: SparkSession): DataFrameWriter[Row]
-
-  def buildStream(spark: SparkSession): DataStreamWriter[Row]
-   */
+  def build(spark: SparkSession, df: Option[DataFrame]): DataFrame
 }
 
 object FlintSparkIndex {
 
-  trait BatchRefresh {
-
-    def build(spark: SparkSession, df: Option[DataFrame]): DataFrame
-  }
-
+  /**
+   * Interface indicates a Flint index has custom streaming refresh capability other than foreach
+   * batch streaming.
+   */
   trait StreamingRefresh {
 
-    def build(spark: SparkSession): DataFrame
+    /**
+     * Build streaming refresh data frame.
+     *
+     * @param spark
+     *   Spark session
+     * @return
+     *   data frame represents streaming logic
+     */
+    def buildStream(spark: SparkSession): DataFrame
   }
 
   /**

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -9,8 +9,9 @@ import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 import org.opensearch.flint.core.metadata.FlintMetadata
 
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
 import org.apache.spark.sql.flint.datatype.FlintDataType
+import org.apache.spark.sql.streaming.DataStreamWriter
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -50,6 +51,10 @@ trait FlintSparkIndex {
    *   index building data frame
    */
   def build(df: DataFrame): DataFrame
+
+  def buildBatch(spark: SparkSession): DataFrameWriter[Row]
+
+  def buildStream(spark: SparkSession): DataStreamWriter[Row]
 }
 
 object FlintSparkIndex {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -120,7 +120,7 @@ object FlintSparkIndex {
     builder.kind(index.kind)
     builder.options(index.options.optionsWithDefault.mapValues(_.asInstanceOf[AnyRef]).asJava)
 
-    // Optional index properties
+    // Index properties
     val envs = populateEnvToMetadata
     if (envs.nonEmpty) {
       builder.addProperty("env", envs.asJava)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexFactory.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexFactory.scala
@@ -57,9 +57,9 @@ object FlintSparkIndexFactory {
               throw new IllegalStateException(s"Unknown skipping strategy: $other")
           }
         }
-        new FlintSparkSkippingIndex(metadata.source, strategies, indexOptions)
+        FlintSparkSkippingIndex(metadata.source, strategies, indexOptions)
       case COVERING_INDEX_TYPE =>
-        new FlintSparkCoveringIndex(
+        FlintSparkCoveringIndex(
           metadata.name,
           metadata.source,
           metadata.indexedColumns.map { colInfo =>
@@ -67,7 +67,7 @@ object FlintSparkIndexFactory {
           }.toMap,
           indexOptions)
       case MV_INDEX_TYPE =>
-        new FlintSparkMaterializedView(
+        FlintSparkMaterializedView(
           metadata.name,
           metadata.source,
           metadata.indexedColumns.map { colInfo =>

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexFactory.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexFactory.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import scala.collection.JavaConverters.mapAsScalaMapConverter
+
+import org.opensearch.flint.core.metadata.FlintMetadata
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.COVERING_INDEX_TYPE
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.MV_INDEX_TYPE
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.SKIPPING_INDEX_TYPE
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{MIN_MAX, PARTITION, VALUE_SET}
+import org.opensearch.flint.spark.skipping.minmax.MinMaxSkippingStrategy
+import org.opensearch.flint.spark.skipping.partition.PartitionSkippingStrategy
+import org.opensearch.flint.spark.skipping.valueset.ValueSetSkippingStrategy
+
+/**
+ * Flint Spark index factory that encapsulates specific Flint index instance creation. This is for
+ * internal code use instead of user facing API.
+ */
+object FlintSparkIndexFactory {
+
+  /**
+   * Creates Flint index from generic Flint metadata.
+   *
+   * @param metadata
+   *   Flint metadata
+   * @return
+   *   Flint index
+   */
+  def create(metadata: FlintMetadata): FlintSparkIndex = {
+    val indexOptions = FlintSparkIndexOptions(
+      metadata.options.asScala.mapValues(_.asInstanceOf[String]).toMap)
+
+    // Convert generic Map[String,AnyRef] in metadata to specific data structure in Flint index
+    metadata.kind match {
+      case SKIPPING_INDEX_TYPE =>
+        val strategies = metadata.indexedColumns.map { colInfo =>
+          val skippingKind = SkippingKind.withName(getString(colInfo, "kind"))
+          val columnName = getString(colInfo, "columnName")
+          val columnType = getString(colInfo, "columnType")
+
+          skippingKind match {
+            case PARTITION =>
+              PartitionSkippingStrategy(columnName = columnName, columnType = columnType)
+            case VALUE_SET =>
+              ValueSetSkippingStrategy(columnName = columnName, columnType = columnType)
+            case MIN_MAX =>
+              MinMaxSkippingStrategy(columnName = columnName, columnType = columnType)
+            case other =>
+              throw new IllegalStateException(s"Unknown skipping strategy: $other")
+          }
+        }
+        new FlintSparkSkippingIndex(metadata.source, strategies, indexOptions)
+      case COVERING_INDEX_TYPE =>
+        new FlintSparkCoveringIndex(
+          metadata.name,
+          metadata.source,
+          metadata.indexedColumns.map { colInfo =>
+            getString(colInfo, "columnName") -> getString(colInfo, "columnType")
+          }.toMap,
+          indexOptions)
+      case MV_INDEX_TYPE =>
+        new FlintSparkMaterializedView(
+          metadata.name,
+          metadata.source,
+          metadata.indexedColumns.map { colInfo =>
+            getString(colInfo, "columnName") -> getString(colInfo, "columnType")
+          }.toMap,
+          indexOptions)
+    }
+  }
+
+  private def getString(map: java.util.Map[String, AnyRef], key: String): String = {
+    map.get(key).asInstanceOf[String]
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -13,7 +13,9 @@ import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, generat
 import org.opensearch.flint.spark.FlintSparkIndexOptions.empty
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.{getFlintIndexName, COVERING_INDEX_TYPE}
 
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql._
+import org.apache.spark.sql.flint.FlintDataSourceV2.FLINT_DATASOURCE
+import org.apache.spark.sql.streaming.DataStreamWriter
 
 /**
  * Flint covering index in Spark.
@@ -57,6 +59,23 @@ case class FlintSparkCoveringIndex(
   override def build(df: DataFrame): DataFrame = {
     val colNames = indexedColumns.keys.toSeq
     df.select(colNames.head, colNames.tail: _*)
+  }
+
+  override def buildBatch(spark: SparkSession): DataFrameWriter[Row] = {
+    build(spark.read.table(tableName)).write
+  }
+
+  override def buildStream(spark: SparkSession): DataStreamWriter[Row] = {
+    spark.readStream
+      .table(tableName)
+      .writeStream
+      .foreachBatch { (batch: DataFrame, _: Long) =>
+        build(batch).write
+          .format(FLINT_DATASOURCE)
+          // .options(flint.flintSparkConf.properties)
+          .mode(SaveMode.Overwrite)
+          .save(name())
+      }
   }
 }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -14,8 +14,6 @@ import org.opensearch.flint.spark.FlintSparkIndexOptions.empty
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.{getFlintIndexName, COVERING_INDEX_TYPE}
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.flint.FlintDataSourceV2.FLINT_DATASOURCE
-import org.apache.spark.sql.streaming.DataStreamWriter
 
 /**
  * Flint covering index in Spark.
@@ -56,26 +54,10 @@ case class FlintSparkCoveringIndex(
       .build()
   }
 
-  override def build(df: DataFrame): DataFrame = {
+  override def build(spark: SparkSession, df: Option[DataFrame]): DataFrame = {
     val colNames = indexedColumns.keys.toSeq
-    df.select(colNames.head, colNames.tail: _*)
-  }
-
-  override def buildBatch(spark: SparkSession): DataFrameWriter[Row] = {
-    build(spark.read.table(tableName)).write
-  }
-
-  override def buildStream(spark: SparkSession): DataStreamWriter[Row] = {
-    spark.readStream
-      .table(tableName)
-      .writeStream
-      .foreachBatch { (batch: DataFrame, _: Long) =>
-        build(batch).write
-          .format(FLINT_DATASOURCE)
-          // .options(flint.flintSparkConf.properties)
-          .mode(SaveMode.Overwrite)
-          .save(name())
-      }
+    df.getOrElse(spark.read.table(tableName))
+      .select(colNames.head, colNames.tail: _*)
   }
 }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -22,6 +22,18 @@ import org.apache.spark.sql.catalyst.util.IntervalUtils
 import org.apache.spark.sql.flint.logicalPlanToDataFrame
 import org.apache.spark.unsafe.types.UTF8String
 
+/**
+ * Flint materialized view in Spark.
+ *
+ * @param mvName
+ *   MV name
+ * @param query
+ *   source query that generates MV data
+ * @param outputSchema
+ *   output schema
+ * @param options
+ *   index options
+ */
 case class FlintSparkMaterializedView(
     mvName: String,
     query: String,

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -11,9 +11,16 @@ import org.opensearch.flint.core.metadata.FlintMetadata
 import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex, FlintSparkIndexBuilder, FlintSparkIndexOptions}
 import org.opensearch.flint.spark.FlintSparkIndex.{generateSchemaJSON, metadataBuilder}
 import org.opensearch.flint.spark.FlintSparkIndexOptions.empty
+import org.opensearch.flint.spark.function.TumbleFunction
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.{getFlintIndexName, MV_INDEX_TYPE}
 
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedFunction, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, EventTimeWatermark}
+import org.apache.spark.sql.catalyst.util.IntervalUtils
+import org.apache.spark.sql.flint.{dataFrameToLogicalPlan, logicalPlanToDataFrame}
+import org.apache.spark.sql.streaming.DataStreamWriter
 import org.apache.spark.unsafe.types.UTF8String
 
 case class FlintSparkMaterializedView(
@@ -47,6 +54,42 @@ case class FlintSparkMaterializedView(
 
   override def build(df: DataFrame): DataFrame = {
     null
+  }
+
+  override def buildBatch(spark: SparkSession): DataFrameWriter[Row] = {
+    spark.sql(query).write
+  }
+
+  override def buildStream(spark: SparkSession): DataStreamWriter[Row] = {
+    val batchPlan = dataFrameToLogicalPlan(spark.sql(query))
+    val streamingPlan = batchPlan transform {
+
+      // Insert watermark operator between Aggregate and its child
+      case Aggregate(grouping, agg, child) =>
+        val timeCol = grouping.collect {
+          case UnresolvedFunction(identifier, args, _, _, _)
+              if identifier.mkString(".") == TumbleFunction.identifier.funcName =>
+            args.head
+        }
+
+        if (timeCol.isEmpty) {
+          throw new IllegalStateException(
+            "Windowing function is required for streaming aggregation")
+        }
+        Aggregate(
+          grouping,
+          agg,
+          EventTimeWatermark(
+            timeCol.head.asInstanceOf[Attribute],
+            IntervalUtils.stringToInterval(watermarkDelay),
+            child))
+
+      // Reset isStreaming flag in relation to true
+      case UnresolvedRelation(multipartIdentifier, options, _) =>
+        UnresolvedRelation(multipartIdentifier, options, isStreaming = true)
+    }
+
+    logicalPlanToDataFrame(spark, streamingPlan).writeStream
   }
 }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -141,7 +141,9 @@ object FlintSparkMaterializedView {
    *   Flint index name
    */
   def getFlintIndexName(mvName: String): String = {
-    require(mvName.contains("."), "Full table name database.mv is required")
+    require(
+      mvName.split("\\.").length >= 3,
+      "Qualified materialized view name catalog.database.mv is required")
 
     s"flint_${mvName.replace(".", "_")}"
   }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.mv
+
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
+import org.opensearch.flint.core.metadata.FlintMetadata
+import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex, FlintSparkIndexBuilder, FlintSparkIndexOptions}
+import org.opensearch.flint.spark.FlintSparkIndex.{generateSchemaJSON, metadataBuilder}
+import org.opensearch.flint.spark.FlintSparkIndexOptions.empty
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.{getFlintIndexName, MV_INDEX_TYPE}
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.unsafe.types.UTF8String
+
+case class FlintSparkMaterializedView(
+    mvName: String,
+    query: String,
+    outputSchema: Map[String, String],
+    override val options: FlintSparkIndexOptions = empty)
+    extends FlintSparkIndex {
+
+  /** TODO: add it to index option */
+  private val watermarkDelay = UTF8String.fromString("0 Minute")
+
+  override val kind: String = MV_INDEX_TYPE
+
+  override def name(): String = getFlintIndexName(mvName)
+
+  override def metadata(): FlintMetadata = {
+    val indexColumnMaps =
+      outputSchema.map { case (colName, colType) =>
+        Map[String, AnyRef]("columnName" -> colName, "columnType" -> colType).asJava
+      }.toArray
+    val schemaJson = generateSchemaJSON(outputSchema)
+
+    metadataBuilder(this)
+      .name(mvName)
+      .source(query)
+      .indexedColumns(indexColumnMaps)
+      .schema(schemaJson)
+      .build()
+  }
+
+  override def build(df: DataFrame): DataFrame = {
+    null
+  }
+}
+
+object FlintSparkMaterializedView {
+
+  /** MV index type name */
+  val MV_INDEX_TYPE = "mv"
+
+  /**
+   * Get index name following the convention "flint_" + qualified MV name (replace dot with
+   * underscore).
+   *
+   * @param mvName
+   *   MV name
+   * @return
+   *   Flint index name
+   */
+  def getFlintIndexName(mvName: String): String = {
+    require(mvName.contains("."), "Full table name database.mv is required")
+
+    s"flint_${mvName.replace(".", "_")}"
+  }
+
+  /** Builder class for MV build */
+  class Builder(flint: FlintSpark) extends FlintSparkIndexBuilder(flint) {
+    private var mvName: String = ""
+    private var query: String = ""
+
+    /**
+     * Set MV name.
+     *
+     * @param mvName
+     *   MV name
+     * @return
+     *   builder
+     */
+    def name(mvName: String): Builder = {
+      this.mvName = mvName
+      this
+    }
+
+    /**
+     * Set MV query.
+     *
+     * @param query
+     *   MV query
+     * @return
+     *   builder
+     */
+    def query(query: String): Builder = {
+      this.query = query
+      this
+    }
+
+    override protected def buildIndex(): FlintSparkIndex = {
+      // TODO: need to change this and Flint DS to support complex field type
+      val outputSchema = flint.spark
+        .sql(query)
+        .schema
+        .map { field =>
+          field.name -> field.dataType.typeName
+        }
+        .toMap
+      FlintSparkMaterializedView(mvName, query, outputSchema, indexOptions)
+    }
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -58,7 +58,7 @@ case class FlintSparkMaterializedView(
     spark.sql(query)
   }
 
-  override def build(spark: SparkSession): DataFrame = {
+  override def buildStream(spark: SparkSession): DataFrame = {
     val batchPlan = spark.sql(query).queryExecution.logical
     val streamingPlan = batchPlan transform {
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.analysis.{UnresolvedFunction, UnresolvedRel
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, EventTimeWatermark, LogicalPlan}
 import org.apache.spark.sql.catalyst.util.IntervalUtils
-import org.apache.spark.sql.flint.logicalPlanToDataFrame
+import org.apache.spark.sql.flint.{logicalPlanToDataFrame, qualifyTableName}
 
 /**
  * Flint materialized view in Spark.
@@ -160,7 +160,7 @@ object FlintSparkMaterializedView {
      *   builder
      */
     def name(mvName: String): Builder = {
-      this.mvName = mvName
+      this.mvName = qualifyTableName(flint.spark, mvName)
       this
     }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, EventTimeWatermark, LogicalPlan}
 import org.apache.spark.sql.catalyst.util.IntervalUtils
 import org.apache.spark.sql.flint.logicalPlanToDataFrame
-import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Flint materialized view in Spark.
@@ -92,10 +91,7 @@ case class FlintSparkMaterializedView(
   }
 
   private def watermark(timeCol: Attribute, delay: String, child: LogicalPlan) = {
-    EventTimeWatermark(
-      timeCol,
-      IntervalUtils.stringToInterval(UTF8String.fromString(delay)),
-      child)
+    EventTimeWatermark(timeCol, IntervalUtils.fromIntervalString(delay), child)
   }
 
   /**

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -80,7 +80,7 @@ class FlintSparkSkippingIndex(
     df.getOrElse(spark.read.table(tableName))
       .groupBy(input_file_name().as(FILE_PATH_COLUMN))
       .agg(namedAggFuncs.head, namedAggFuncs.tail: _*)
-      .withColumn(ID_COLUMN, sha1(col(FILE_PATH_COLUMN))) // TODO: no impact to just add it?
+      .withColumn(ID_COLUMN, sha1(col(FILE_PATH_COLUMN)))
   }
 }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -28,9 +28,9 @@ import org.apache.spark.sql.functions.{col, input_file_name, sha1}
  * @param indexedColumns
  *   indexed column list
  */
-class FlintSparkSkippingIndex(
+case class FlintSparkSkippingIndex(
     tableName: String,
-    val indexedColumns: Seq[FlintSparkSkippingStrategy],
+    indexedColumns: Seq[FlintSparkSkippingStrategy],
     override val options: FlintSparkIndexOptions = empty)
     extends FlintSparkIndex {
 

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
@@ -158,7 +158,7 @@ class FlintSparkMaterializedViewSuite extends FlintSuite {
     }
   }
 
-  test("build stream should fail if there is aggregation without windowing function") {
+  test("build stream should fail if there is aggregation but no windowing function") {
     val testTable = "mv_build_test"
     withTable(testTable) {
       sql(s"CREATE TABLE $testTable (time TIMESTAMP, name STRING, age INT) USING CSV")

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.mv
+
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
+import org.opensearch.flint.spark.FlintSparkIndexOptions
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.MV_INDEX_TYPE
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+import org.apache.spark.FlintSuite
+
+class FlintSparkMaterializedViewSuite extends FlintSuite {
+
+  val testMvName = "spark_catalog.default.mv"
+  val testQuery = "SELECT 1"
+
+  test("get MV name") {
+    val mv = FlintSparkMaterializedView(testMvName, testQuery, Map.empty)
+    mv.name() shouldBe "flint_spark_catalog_default_mv"
+  }
+
+  test("should fail if not full MV name") {
+    val mv = FlintSparkMaterializedView("mv", "SELECT 1", Map.empty)
+    assertThrows[IllegalArgumentException] {
+      mv.name()
+    }
+  }
+
+  test("get MV metadata") {
+    val mv = FlintSparkMaterializedView(testMvName, testQuery, Map("test_col" -> "integer"))
+
+    val metadata = mv.metadata()
+    metadata.name shouldBe mv.mvName
+    metadata.kind shouldBe MV_INDEX_TYPE
+    metadata.source shouldBe "SELECT 1"
+    metadata.indexedColumns shouldBe Array(
+      Map("columnName" -> "test_col", "columnType" -> "integer").asJava)
+    metadata.schema shouldBe Map("test_col" -> Map("type" -> "integer").asJava).asJava
+  }
+
+  test("get MV metadata with index options") {
+    val indexSettings = """{"number_of_shards": 2}"""
+    val indexOptions =
+      FlintSparkIndexOptions(Map("auto_refresh" -> "true", "index_settings" -> indexSettings))
+    val mv = FlintSparkMaterializedView(
+      testMvName,
+      testQuery,
+      Map("test_col" -> "integer"),
+      indexOptions)
+
+    mv.metadata().options shouldBe Map(
+      "auto_refresh" -> "true",
+      "index_settings" -> indexSettings).asJava
+    mv.metadata().indexSettings shouldBe Some(indexSettings)
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
@@ -40,11 +40,12 @@ class FlintSparkMaterializedViewSuite extends FlintSuite {
     mv.name() shouldBe "flint_spark_catalog_default_mv"
   }
 
-  test("should fail if not full MV name") {
-    val mv = FlintSparkMaterializedView("mv", "SELECT 1", Map.empty)
-    assertThrows[IllegalArgumentException] {
-      mv.name()
-    }
+  test("should fail if get name with unqualified MV name") {
+    the[IllegalArgumentException] thrownBy
+      FlintSparkMaterializedView("mv", testQuery, Map.empty).name()
+
+    the[IllegalArgumentException] thrownBy
+      FlintSparkMaterializedView("default.mv", testQuery, Map.empty).name()
   }
 
   test("get metadata") {

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
@@ -9,9 +9,11 @@ import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 import org.opensearch.flint.spark.FlintSparkIndexOptions
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.MV_INDEX_TYPE
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, the}
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.spark.FlintSuite
+import org.apache.spark.sql.{DataFrame, Row}
 
 class FlintSparkMaterializedViewSuite extends FlintSuite {
 
@@ -56,5 +58,15 @@ class FlintSparkMaterializedViewSuite extends FlintSuite {
       "auto_refresh" -> "true",
       "index_settings" -> indexSettings).asJava
     mv.metadata().indexSettings shouldBe Some(indexSettings)
+  }
+
+  test("build batch data frame") {
+    val mv = FlintSparkMaterializedView(testMvName, testQuery, Map.empty)
+    mv.build(spark, None).collect() shouldBe Array(Row(1))
+  }
+
+  test("should fail if build given other source data frame") {
+    val mv = FlintSparkMaterializedView(testMvName, testQuery, Map.empty)
+    the[IllegalArgumentException] thrownBy mv.build(spark, Some(mock[DataFrame]))
   }
 }

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndexSuite.scala
@@ -56,7 +56,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     val index = new FlintSparkSkippingIndex(testTable, Seq(indexCol))
 
     val df = spark.createDataFrame(Seq(("hello", 20))).toDF("name", "age")
-    val indexDf = index.build(df)
+    val indexDf = index.build(spark, Some(df))
     indexDf.schema.fieldNames should contain only ("name", FILE_PATH_COLUMN, ID_COLUMN)
   }
 

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import com.stephenn.scalatest.jsonassert.JsonMatchers.matchJson
+import org.opensearch.flint.core.FlintVersion.current
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.getFlintIndexName
+import org.scalatest.matchers.must.Matchers.defined
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
+
+  private val testTable = "spark_catalog.default.ci_test"
+  private val testMvName = "spark_catalog.default.mv_test"
+  private val testFlintIndex = getFlintIndexName(testMvName)
+  private val testQuery =
+    s"""
+       | SELECT
+       |   window.start AS startTime,
+       |   COUNT(*) AS count
+       | FROM $testTable
+       | GROUP BY TUMBLE(time, '10 Minutes')
+       |""".stripMargin
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    createTimeSeriesTable(testTable)
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+
+    // Delete all test indices
+    flint.deleteIndex(testFlintIndex)
+  }
+
+  test("create materialized view") {
+    flint
+      .materializedView()
+      .name(testMvName)
+      .query(testQuery)
+      .create()
+
+    val index = flint.describeIndex(testFlintIndex)
+    index shouldBe defined
+    index.get.metadata().getContent should matchJson(s"""
+         | {
+         |  "_meta": {
+         |    "version": "${current()}",
+         |    "name": "spark_catalog.default.mv_test",
+         |    "kind": "mv",
+         |    "source": "$testQuery",
+         |    "indexedColumns": [
+         |    {
+         |      "columnName": "startTime",
+         |      "columnType": "timestamp"
+         |    },{
+         |      "columnName": "count",
+         |      "columnType": "long"
+         |    }],
+         |    "options": {},
+         |    "properties": {}
+         |  },
+         |  "properties": {
+         |    "startTime": {
+         |      "type": "date",
+         |      "format": "strict_date_optional_time_nanos"
+         |    },
+         |    "count": {
+         |      "type": "long"
+         |    }
+         |  }
+         | }
+         |""".stripMargin)
+
+  }
+}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -42,10 +42,13 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
   }
 
   test("create materialized view with metadata successfully") {
+    val indexOptions =
+      FlintSparkIndexOptions(Map("auto_refresh" -> "true", "checkpoint_location" -> "s3://test/"))
     flint
       .materializedView()
       .name(testMvName)
       .query(testQuery)
+      .options(indexOptions)
       .create()
 
     val index = flint.describeIndex(testFlintIndex)
@@ -65,7 +68,10 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
          |      "columnName": "count",
          |      "columnType": "long"
          |    }],
-         |    "options": {},
+         |    "options": {
+         |      "auto_refresh": "true",
+         |      "checkpoint_location": "s3://test/"
+         |    },
          |    "properties": {}
          |  },
          |  "properties": {
@@ -102,13 +108,13 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
 
   test("incremental refresh materialized view") {
     withTempDir { checkpointDir =>
-      val checkpointOption =
-        FlintSparkIndexOptions(Map("checkpoint_location" -> checkpointDir.getAbsolutePath))
+      val indexOptions = FlintSparkIndexOptions(
+        Map("auto_refresh" -> "true", "checkpoint_location" -> checkpointDir.getAbsolutePath))
       flint
         .materializedView()
         .name(testMvName)
         .query(testQuery)
-        .options(checkpointOption)
+        .options(indexOptions)
         .create()
 
       flint

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -15,11 +15,7 @@ import org.apache.spark.sql.streaming.StreamTest
 /**
  * Flint Spark suite trait that initializes [[FlintSpark]] API instance.
  */
-trait FlintSparkSuite
-    extends QueryTest
-    with FlintSuite
-    with OpenSearchSuite
-    with StreamTest {
+trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite with StreamTest {
 
   /** Flint Spark high level API being tested */
   lazy protected val flint: FlintSpark = new FlintSpark(spark)
@@ -33,8 +29,7 @@ trait FlintSparkSuite
   }
 
   protected def createPartitionedTable(testTable: String): Unit = {
-    sql(
-      s"""
+    sql(s"""
          | CREATE TABLE $testTable
          | (
          |   name STRING,
@@ -52,18 +47,39 @@ trait FlintSparkSuite
          | )
          |""".stripMargin)
 
-    sql(
-      s"""
+    sql(s"""
          | INSERT INTO $testTable
          | PARTITION (year=2023, month=4)
          | VALUES ('Hello', 30, 'Seattle')
          | """.stripMargin)
 
-    sql(
-      s"""
+    sql(s"""
          | INSERT INTO $testTable
          | PARTITION (year=2023, month=5)
          | VALUES ('World', 25, 'Portland')
          | """.stripMargin)
+  }
+
+  protected def createTimeSeriesTable(testTable: String): Unit = {
+    sql(s"""
+         | CREATE TABLE $testTable
+         | (
+         |   time TIMESTAMP,
+         |   name STRING,
+         |   age INT,
+         |   address STRING
+         | )
+         | USING CSV
+         | OPTIONS (
+         |  header 'false',
+         |  delimiter '\t'
+         | )
+         |""".stripMargin)
+
+    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:01:00', 'A', 30, 'Seattle')")
+    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:10:00', 'B', 20, 'Seattle')")
+    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:15:00', 'C', 35, 'Portland')")
+    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 01:00:00', 'D', 40, 'Portland')")
+    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 03:00:00', 'E', 15, 'Vancouver')")
   }
 }

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -28,6 +28,13 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
     setFlintSparkConf(REFRESH_POLICY, "true")
   }
 
+  protected def awaitStreamingComplete(jobId: String): Unit = {
+    val job = spark.streams.get(jobId)
+    failAfter(streamingTimeout) {
+      job.processAllAvailable()
+    }
+  }
+
   protected def createPartitionedTable(testTable: String): Unit = {
     sql(s"""
          | CREATE TABLE $testTable


### PR DESCRIPTION
### Description

1. Add materialized view implementation in Flint Spark API layer
2. Refactor index `build()` API with a new `buildStream()` API. See details below.
3. Extract remaining deserialize logic to new `FlintSparkIndexFactory`.

#### TODO

Will publish separate PR for issues below:

1. Fix issue that windowing function, tumble() or built-in window(), cannot be used in manual/batch refresh job
2. Add more index options for incremental refreshing: watermark_delay, output mode and generic JSON map for any params we can pass to DataStreamWriter.options directly.
3. Need to handle issues with large backlog
    a. control initial micro batch size (config `maxFilesPerTrigger` seems unlimited by default?)
    b. process oldest data first to avoid data dropped due to watermark
4. If we can support JOIN query in future [TBD]

#### Refactoring: Flint Index Build API

| Refresh Type               | Skipping Index                                                                                                                                                                                                                         | Covering Index                                                                                                                                                                                           | Materialized View                                                                                                                           | API Used                                                                                                                                                                 |
|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
|      Manual<br>(Batch)     | spark<br>  .read<br>  .table("alb_logs")<br>  ... aggregate ...<br>  .write<br>  .format("flint")<br>  .options(flint ops)<br>  .save                                                                                                  | spark<br>  .read<br>  .table("alb_logs")<br>  ... select(fields) ...<br>  .write<br>  .format("flint")<br>  .options(flint ops)<br>  .save                                                               | spark<br>  .sql(query)<br>  .write<br>  .format("flint")<br>  .options(flint ops)<br>  .save                                                | each Flint index<br>provide implementation<br>by existing **build()** API                                                                                               |
| Incremental<br>(Streaming) | spark<br>  .readStream<br>  .table("alb_logs")<br>  .writeStream<br>  .foreachBatch {<br>    batch<br>      .write<br>      .format("flint")<br>      ... aggregate ...<br>      .options(flint ops)<br>      .save<br>  }<br>  .start | spark<br>  .readStream<br>  .table("alb_logs")<br>  ... select(fields) ...<br>  .writeStream<br>  .format("flint")<br>  .options(flint ops)<br>  .start<br><br>or foreach streaming<br>as skipping index | spark<br>  .sql(query)<br>  ... rewrite to stream DF ...<br>  .writeStream<br>  .format("flint")<br>  .options(flint ops)<br>  .start<br>   | generate foreach<br>streaming job for<br>skipping and covering<br>index by **build()** API<br><br>MV provides custom<br>streaming logic by<br>new **buildStream()** API |

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/24, https://github.com/opensearch-project/opensearch-spark/issues/25

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
