### PR TITLE
Fix FlintMetadata conversion issue in FlintOpenSearchClient

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Integ Test
         run: sbt integtest/test
 
+      - name: Unit Test
+        run: sbt test
+
       - name: Style check
         run: sbt scalafmtCheckAll

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
@@ -6,6 +6,8 @@
 package org.opensearch.flint.core;
 
 import java.util.List;
+
+import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.flint.core.metadata.FlintMetadata;
 import org.opensearch.flint.core.storage.FlintReader;
 import org.opensearch.flint.core.storage.FlintWriter;
@@ -71,4 +73,10 @@ public interface FlintClient {
    * @return {@link FlintWriter}
    */
   FlintWriter createWriter(String indexName);
+
+  /**
+   * Create {@link RestHighLevelClient}.
+   * @return {@link RestHighLevelClient}
+   */
+  public RestHighLevelClient createClient();
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
@@ -163,7 +163,7 @@ public class FlintOpenSearchClient implements FlintClient {
     return new OpenSearchWriter(createClient(), toLowercase(indexName), options.getRefreshPolicy());
   }
 
-  private RestHighLevelClient createClient() {
+  @Override public RestHighLevelClient createClient() {
     RestClientBuilder
         restClientBuilder =
         RestClient.builder(new HttpHost(options.getHost(), options.getPort(), options.getScheme()));

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
@@ -286,9 +286,14 @@ object FlintJob extends Logging {
     } catch {
       case e: IllegalStateException
           if e.getCause().getMessage().contains("index_not_found_exception") =>
-        osClient.createIndex(resultIndex, mapping) match {
-          case Right(_) => Right(())
-          case Left(errorMsg) => Left(errorMsg)
+        try {
+          osClient.createIndex(resultIndex, mapping)
+          Right(())
+        } catch {
+          case e: Exception =>
+            val error = s"Failed to create result index $resultIndex"
+            logError(error, e)
+            Left(error)
         }
       case e: Exception =>
         val error = "Failed to verify existing mapping"

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/OSClient.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/OSClient.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql
+
+import org.opensearch.client.RequestOptions
+import org.opensearch.client.indices.{CreateIndexRequest, GetIndexRequest, GetIndexResponse}
+import org.opensearch.client.indices.CreateIndexRequest
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.flint.core.{FlintClientBuilder, FlintOptions}
+
+import org.apache.spark.internal.Logging
+
+class OSClient(val flintOptions: FlintOptions) extends Logging {
+
+  def getIndexMetadata(osIndexName: String): String = {
+
+    using(FlintClientBuilder.build(flintOptions).createClient()) { client =>
+      val request = new GetIndexRequest(osIndexName)
+      try {
+        val response = client.indices.get(request, RequestOptions.DEFAULT)
+        response.getMappings.get(osIndexName).source.string
+      } catch {
+        case e: Exception =>
+          throw new IllegalStateException(
+            s"Failed to get OpenSearch index mapping for $osIndexName",
+            e)
+      }
+    }
+  }
+
+  /**
+   * Create a new index with given mapping.
+   *
+   * @param osIndexName
+   *   the name of the index
+   * @param mapping
+   *   the mapping of the index
+   * @return
+   *   use Either for representing success or failure. A Right value indicates success, while a
+   *   Left value indicates an error.
+   */
+  def createIndex(osIndexName: String, mapping: String): Either[String, Unit] = {
+    logInfo(s"create $osIndexName")
+
+    using(FlintClientBuilder.build(flintOptions).createClient()) { client =>
+      val request = new CreateIndexRequest(osIndexName)
+      request.mapping(mapping, XContentType.JSON)
+
+      try {
+        client.indices.create(request, RequestOptions.DEFAULT)
+        logInfo(s"create $osIndexName successfully")
+        Right(())
+      } catch {
+        case e: Exception =>
+          val error = s"Failed to create result index $osIndexName"
+          logError(error, e)
+          Left(error)
+      }
+    }
+  }
+
+  /**
+   * the loan pattern to manage resource.
+   *
+   * @param resource
+   *   the resource to be managed
+   * @param f
+   *   the function to be applied to the resource
+   * @tparam A
+   *   the type of the resource
+   * @tparam B
+   *   the type of the result
+   * @return
+   *   the result of the function
+   */
+  def using[A <: AutoCloseable, B](resource: A)(f: A => B): B = {
+    try {
+      f(resource)
+    } finally {
+      // client is guaranteed to be non-null
+      resource.close()
+    }
+  }
+
+}

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/OSClient.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/OSClient.scala
@@ -42,7 +42,7 @@ class OSClient(val flintOptions: FlintOptions) extends Logging {
    *   use Either for representing success or failure. A Right value indicates success, while a
    *   Left value indicates an error.
    */
-  def createIndex(osIndexName: String, mapping: String): Either[String, Unit] = {
+  def createIndex(osIndexName: String, mapping: String): Unit = {
     logInfo(s"create $osIndexName")
 
     using(FlintClientBuilder.build(flintOptions).createClient()) { client =>
@@ -52,12 +52,9 @@ class OSClient(val flintOptions: FlintOptions) extends Logging {
       try {
         client.indices.create(request, RequestOptions.DEFAULT)
         logInfo(s"create $osIndexName successfully")
-        Right(())
       } catch {
         case e: Exception =>
-          val error = s"Failed to create result index $osIndexName"
-          logError(error, e)
-          Left(error)
+          throw new IllegalStateException(s"Failed to create index $osIndexName", e);
       }
     }
   }


### PR DESCRIPTION
### Description
In `flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java`, we encountered a conversion problem when transforming the index mapping to `FlintMetadata`. The root cause can be traced back to changes made in [this PR](https://github.com/opensearch-project/opensearch-spark/pull/70/files#diff-c3bdd10ec081d200e375aa601acff4c39b10bb4c34862634f56859f0054fedbf).

Previously, `FlintMetadata` stored its content as a simple string. However, the recent changes have made its structure more complex, introducing fields like `version`, `name`, `kind`, `source`, `indexedColumns`, `options`, `properties`, `schema`, and `indexSettings`.

Given that Flint index is specialized for storing covering index and materialized view metadata, it's not a typical data index. To address this, we've opted to use the OpenSearch rest client directly for the conversion.

Testing done:
1. manual verification

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/74

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
