### PR TITLE
Add checkpoint mandatory option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -341,6 +341,7 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.datasource.flint.read.scroll_size`: default value is 100.
 - `spark.flint.optimizer.enabled`: default is true.
 - `spark.flint.index.hybridscan.enabled`: default is false.
+- `spark.flint.index.checkpoint.mandatory`: default is true.
 
 #### Data Type Mapping
 

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -113,6 +113,10 @@ object FlintSparkConf {
   val HYBRID_SCAN_ENABLED = FlintConfig("spark.flint.index.hybridscan.enabled")
     .doc("Enable hybrid scan to include latest source data not refreshed to index yet")
     .createWithDefault("false")
+
+  val CHECKPOINT_MANDATORY = FlintConfig("spark.flint.index.checkpoint.mandatory")
+    .doc("Checkpoint location for incremental refresh index will be mandatory if enabled")
+    .createWithDefault("true")
 }
 
 /**
@@ -136,6 +140,8 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
   def isOptimizerEnabled: Boolean = OPTIMIZER_RULE_ENABLED.readFrom(reader).toBoolean
 
   def isHybridScanEnabled: Boolean = HYBRID_SCAN_ENABLED.readFrom(reader).toBoolean
+
+  def isCheckpointMandatory: Boolean = CHECKPOINT_MANDATORY.readFrom(reader).toBoolean
 
   /**
    * spark.sql.session.timeZone

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -6,10 +6,9 @@
 package org.opensearch.flint.spark
 
 import org.opensearch.flint.OpenSearchSuite
-
 import org.apache.spark.FlintSuite
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.flint.config.FlintSparkConf.{HOST_ENDPOINT, HOST_PORT, REFRESH_POLICY}
+import org.apache.spark.sql.flint.config.FlintSparkConf.{CHECKPOINT_MANDATORY, HOST_ENDPOINT, HOST_PORT, REFRESH_POLICY}
 import org.apache.spark.sql.streaming.StreamTest
 
 /**
@@ -26,6 +25,9 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
     setFlintSparkConf(HOST_ENDPOINT, openSearchHost)
     setFlintSparkConf(HOST_PORT, openSearchPort)
     setFlintSparkConf(REFRESH_POLICY, "true")
+
+    // Disable mandatory checkpoint for test convenience
+    setFlintSparkConf(CHECKPOINT_MANDATORY, "false")
   }
 
   protected def awaitStreamingComplete(jobId: String): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -6,6 +6,7 @@
 package org.opensearch.flint.spark
 
 import org.opensearch.flint.OpenSearchSuite
+
 import org.apache.spark.FlintSuite
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.flint.config.FlintSparkConf.{CHECKPOINT_MANDATORY, HOST_ENDPOINT, HOST_PORT, REFRESH_POLICY}


### PR DESCRIPTION
### Description

Add new Flint config for checkpoint mandatory option. It is enabled by default which means all incremental refresh (`CREATE` statement with `auto_refresh=true`) must provide `checkpoint_location`. Doc: https://github.com/dai-chen/opensearch-spark/blob/add-mandatory-checkpoint-option/docs/index.md#configurations

#### TODO

Currently all Spark streaming job related validation happens when job start. For example, OS index is created even though job start failed due to missing checkpoint location. For this checkpoint validation, it can be solved by building streaming job early. However, other check on table/options maybe performed only when job start. Need to figure out how to validate early in general. Issue: https://github.com/opensearch-project/opensearch-spark/issues/65

#### Example

```
spark-sql> CREATE SKIPPING INDEX ON ds_tables.http_logs
         > (status VALUE_SET)
         > WITH (
         >   auto_refresh=true
         > );
java.lang.IllegalStateException: Checkpoint location is mandatory for incremental refresh 
if spark.flint.index.checkpoint.mandatory enabled

# Currently create OS index succeeds. Will improve as TODO above.
spark-sql> DROP SKIPPING INDEX ON ds_tables.http_logs;

spark-sql> SET spark.flint.index.checkpoint.mandatory=false;
spark.flint.index.checkpoint.mandatory	false

spark-sql> CREATE SKIPPING INDEX ON ds_tables.http_logs
         > (status VALUE_SET)
         > WITH (
         >   auto_refresh=true
         > );

spark-sql> DESC SKIPPING INDEX ON ds_tables.http_logs;
status	int	VALUE_SET
```

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/87

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
