### PR TITLE
Fix column name with special character when create materialized view

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -135,9 +135,10 @@ object FlintSparkIndex {
   }
 
   def generateSchemaJSON(allFieldTypes: Map[String, String]): String = {
+    // Backtick column names to escape special characters, otherwise fromDDL() will fail
     val catalogDDL =
       allFieldTypes
-        .map { case (colName, colType) => s"$colName $colType not null" }
+        .map { case (colName, colType) => s"`$colName` $colType not null" }
         .mkString(",")
 
     val structType = StructType.fromDDL(catalogDDL)

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -142,7 +142,7 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
   test("create materialized view with quoted name and column name") {
     val testQuotedQuery =
       """ SELECT
-        |   window.start AS `startTime`,
+        |   window.start AS `start.time`,
         |   COUNT(*) AS `count`
         | FROM `spark_catalog`.`default`.`mv_test`
         | GROUP BY TUMBLE(`time`, '10 Minutes')""".stripMargin.trim
@@ -158,7 +158,7 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
     val metadata = index.get.metadata()
     metadata.name shouldBe testMvName
     metadata.source shouldBe testQuotedQuery
-    metadata.indexedColumns.map(_.asScala("columnName")) shouldBe Seq("startTime", "count")
+    metadata.indexedColumns.map(_.asScala("columnName")) shouldBe Seq("start.time", "count")
   }
 
   test("show all materialized views in catalog and database") {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -8,7 +8,7 @@ package org.opensearch.flint.spark
 import java.sql.Timestamp
 
 import scala.Option.empty
-import scala.collection.JavaConverters.mapAsJavaMapConverter
+import scala.collection.JavaConverters.{mapAsJavaMapConverter, mapAsScalaMapConverter}
 
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.native.JsonMethods.parse
@@ -137,6 +137,28 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
       sql(s"CREATE MATERIALIZED VIEW $testMvName AS $testQuery")
 
     sql(s"CREATE MATERIALIZED VIEW IF NOT EXISTS $testMvName AS $testQuery")
+  }
+
+  test("create materialized view with quoted name and column name") {
+    val testQuotedQuery =
+      """ SELECT
+        |   window.start AS `startTime`,
+        |   COUNT(*) AS `count`
+        | FROM `spark_catalog`.`default`.`mv_test`
+        | GROUP BY TUMBLE(`time`, '10 Minutes')""".stripMargin.trim
+
+    sql(s"""
+           | CREATE MATERIALIZED VIEW `spark_catalog`.`default`.`mv_test_metrics`
+           | AS $testQuotedQuery
+           |""".stripMargin)
+
+    val index = flint.describeIndex(testFlintIndex)
+    index shouldBe defined
+
+    val metadata = index.get.metadata()
+    metadata.name shouldBe testMvName
+    metadata.source shouldBe testQuotedQuery
+    metadata.indexedColumns.map(_.asScala("columnName")) shouldBe Seq("startTime", "count")
   }
 
   test("show all materialized views in catalog and database") {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
@@ -6,7 +6,7 @@
 package org.opensearch.flint.spark
 
 import scala.Option.empty
-import scala.collection.JavaConverters.mapAsJavaMapConverter
+import scala.collection.JavaConverters.{mapAsJavaMapConverter, mapAsScalaMapConverter}
 
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.native.JsonMethods.parse
@@ -148,6 +148,24 @@ class FlintSparkSkippingIndexSqlITSuite extends FlintSparkSuite {
            | IF NOT EXISTS
            | ON $testTable ( year PARTITION )
            | """.stripMargin)
+  }
+
+  test("create skipping index with quoted table and column name") {
+    sql(s"""
+           | CREATE SKIPPING INDEX ON `spark_catalog`.`default`.`skipping_sql_test`
+           | (
+           |   `year` PARTITION,
+           |   `name` VALUE_SET,
+           |   `age` MIN_MAX
+           | )
+           | """.stripMargin)
+
+    val index = flint.describeIndex(testIndex)
+    index shouldBe defined
+
+    val metadata = index.get.metadata()
+    metadata.source shouldBe testTable
+    metadata.indexedColumns.map(_.asScala("columnName")) shouldBe Seq("year", "name", "age")
   }
 
   test("describe skipping index") {


### PR DESCRIPTION
### Description

Spark `StructType.fromDDL()` requires all columns quoted if any special character. Previously all table/index/column names after Flint parser has been unquoted. Quote them before calling fromDDL method and finally it is unquoted in OpenSearch doc as before.

#### Reproducing the bug

```
CREATE MATERIALIZED VIEW test
AS
SELECT startTime AS `start.time`
...

start.time string not null,count long not null
----^^^

at org.apache.spark.sql.catalyst.parser.ParseException.withCommand(ParseDriver.scala:306)
at org.apache.spark.sql.catalyst.parser.AbstractSqlParser.parse(ParseDriver.scala:143)
at org.apache.spark.sql.catalyst.parser.AbstractSqlParser.parseTableSchema(ParseDriver.scala:76)
at org.apache.spark.sql.types.StructType$.fromDDL(StructType.scala:543)
at org.opensearch.flint.spark.FlintSparkIndex$.generateSchemaJSON(FlintSparkIndex.scala:143
at org.opensearch.flint.spark.mv.FlintSparkMaterializedView.metadata(FlintSparkMaterializedView.scala:58)
   ...
```

### Issues Resolved

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
