### PR TITLE
Implement blue/green deployment support in REPL mode

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/app/FlintCommand.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/app/FlintCommand.scala
@@ -41,6 +41,14 @@ class FlintCommand(
   def isFailed(): Boolean = {
     state == "failed"
   }
+
+  def isWaiting(): Boolean = {
+    state == "waiting"
+  }
+
+  override def toString: String = {
+    s"FlintCommand(state=$state, query=$query, statementId=$statementId, queryId=$queryId, submitTime=$submitTime, error=$error)"
+  }
 }
 
 object FlintCommand {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/app/FlintInstance.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/app/FlintInstance.scala
@@ -5,8 +5,13 @@
 
 package org.opensearch.flint.app
 
+import java.util.{Map => JavaMap}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
 import org.json4s.{Formats, NoTypeHints}
-import org.json4s.JsonAST.JString
+import org.json4s.JsonAST.{JArray, JString}
 import org.json4s.native.JsonMethods.parse
 import org.json4s.native.Serialization
 
@@ -16,10 +21,11 @@ class FlintInstance(
     val jobId: String,
     // sessionId is the session type doc id
     val sessionId: String,
-    val state: String,
+    var state: String,
     val lastUpdateTime: Long,
     // We need jobStartTime to check if HMAC token is expired or not
     val jobStartTime: Long,
+    val excludedJobIds: Seq[String] = Seq.empty[String],
     val error: Option[String] = None) {}
 
 object FlintInstance {
@@ -34,6 +40,16 @@ object FlintInstance {
     val sessionId = (meta \ "sessionId").extract[String]
     val lastUpdateTime = (meta \ "lastUpdateTime").extract[Long]
     val jobStartTime = (meta \ "jobStartTime").extract[Long]
+    // To handle the possibility of excludeJobIds not being present,
+    // we use extractOpt which gives us an Option[Seq[String]].
+    // If it is not present, it will return None, which we can then
+    // convert to an empty Seq[String] using getOrElse.
+    // Replace extractOpt with jsonOption and map
+    val excludeJobIds: Seq[String] = meta \ "excludeJobIds" match {
+      case JArray(lst) => lst.map(_.extract[String])
+      case _ => Seq.empty[String]
+    }
+
     val maybeError: Option[String] = (meta \ "error") match {
       case JString(str) => Some(str)
       case _ => None
@@ -46,6 +62,42 @@ object FlintInstance {
       state,
       lastUpdateTime,
       jobStartTime,
+      excludeJobIds,
+      maybeError)
+  }
+
+  def deserializeFromMap(source: JavaMap[String, AnyRef]): FlintInstance = {
+    // Since we are dealing with JavaMap, we convert it to a Scala mutable Map for ease of use.
+    val scalaSource = source.asScala
+
+    val applicationId = scalaSource("applicationId").asInstanceOf[String]
+    val state = scalaSource("state").asInstanceOf[String]
+    val jobId = scalaSource("jobId").asInstanceOf[String]
+    val sessionId = scalaSource("sessionId").asInstanceOf[String]
+    val lastUpdateTime = scalaSource("lastUpdateTime").asInstanceOf[Long]
+    val jobStartTime = scalaSource("jobStartTime").asInstanceOf[Long]
+
+    // We safely handle the possibility of excludeJobIds being absent or not a list.
+    val excludeJobIds: Seq[String] = scalaSource.get("excludeJobIds") match {
+      case Some(lst: java.util.List[_]) => lst.asScala.toList.map(_.asInstanceOf[String])
+      case _ => Seq.empty[String]
+    }
+
+    // Handle error similarly, ensuring we get an Option[String].
+    val maybeError: Option[String] = scalaSource.get("error") match {
+      case Some(str: String) => Some(str)
+      case _ => None
+    }
+
+    // Construct a new FlintInstance with the extracted values.
+    new FlintInstance(
+      applicationId,
+      jobId,
+      sessionId,
+      state,
+      lastUpdateTime,
+      jobStartTime,
+      excludeJobIds,
       maybeError)
   }
 
@@ -60,6 +112,7 @@ object FlintInstance {
         "state" -> job.state,
         // update last update time
         "lastUpdateTime" -> currentTime,
+        "excludeJobIds" -> job.excludedJobIds,
         "jobStartTime" -> job.jobStartTime))
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/app/FlintInstance.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/app/FlintInstance.scala
@@ -41,13 +41,13 @@ object FlintInstance {
   }
 
   def serialize(job: FlintInstance): String = {
+    // jobId is only readable by spark, thus we don't override jobId
     Serialization.write(
       Map(
         "type" -> "session",
         "sessionId" -> job.sessionId,
         "error" -> job.error.getOrElse(""),
         "applicationId" -> job.applicationId,
-        "jobId" -> job.jobId,
         "state" -> job.state,
         // update last update time
         "lastUpdateTime" -> System.currentTimeMillis()))

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/app/FlintInstanceTest.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/app/FlintInstanceTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.app
+
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.SparkFunSuite
+
+class FlintInstanceTest extends SparkFunSuite with Matchers {
+
+  test("deserialize should correctly parse a FlintInstance from JSON") {
+    val json =
+      """{"applicationId":"app-123","jobId":"job-456","sessionId":"session-789","state":"RUNNING","lastUpdateTime":1620000000000,"jobStartTime":1620000001000}"""
+    val instance = FlintInstance.deserialize(json)
+
+    instance.applicationId shouldBe "app-123"
+    instance.jobId shouldBe "job-456"
+    instance.sessionId shouldBe "session-789"
+    instance.state shouldBe "RUNNING"
+    instance.lastUpdateTime shouldBe 1620000000000L
+    instance.jobStartTime shouldBe 1620000001000L
+    instance.error shouldBe None
+  }
+
+  test("serialize should correctly produce JSON from a FlintInstance") {
+    val instance = new FlintInstance(
+      "app-123",
+      "job-456",
+      "session-789",
+      "RUNNING",
+      1620000000000L,
+      1620000001000L)
+    val currentTime = System.currentTimeMillis()
+    val json = FlintInstance.serialize(instance, currentTime)
+
+    json should include(""""applicationId":"app-123"""")
+    json should not include(""""jobId":"job-456"""")
+    json should include(""""sessionId":"session-789"""")
+    json should include(""""state":"RUNNING"""")
+    json should include(s""""lastUpdateTime":$currentTime""")
+    json should include(""""jobStartTime":1620000001000""")
+    json should include(""""error":""""")
+  }
+
+  test("deserialize should correctly handle error field in JSON") {
+    val jsonWithError =
+      """{"applicationId":"app-123","jobId":"job-456","sessionId":"session-789","state":"FAILED","lastUpdateTime":1620000000000,"jobStartTime":1620000001000,"error":"Some error occurred"}"""
+    val instance = FlintInstance.deserialize(jsonWithError)
+
+    instance.error shouldBe Some("Some error occurred")
+  }
+
+  test("serialize should include error when present in FlintInstance") {
+    val instance = new FlintInstance(
+      "app-123",
+      "job-456",
+      "session-789",
+      "FAILED",
+      1620000000000L,
+      1620000001000L,
+      Some("Some error occurred"))
+    val currentTime = System.currentTimeMillis()
+    val json = FlintInstance.serialize(instance, currentTime)
+
+    json should include(""""error":"Some error occurred"""")
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/app/FlintInstanceTest.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/app/FlintInstanceTest.scala
@@ -5,15 +5,17 @@
 
 package org.opensearch.flint.app
 
+import java.util.{HashMap => JavaHashMap}
+
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.SparkFunSuite
 
 class FlintInstanceTest extends SparkFunSuite with Matchers {
 
-  test("deserialize should correctly parse a FlintInstance from JSON") {
+  test("deserialize should correctly parse a FlintInstance with excludedJobIds from JSON") {
     val json =
-      """{"applicationId":"app-123","jobId":"job-456","sessionId":"session-789","state":"RUNNING","lastUpdateTime":1620000000000,"jobStartTime":1620000001000}"""
+      """{"applicationId":"app-123","jobId":"job-456","sessionId":"session-789","state":"RUNNING","lastUpdateTime":1620000000000,"jobStartTime":1620000001000,"excludeJobIds":["job-101","job-202"]}"""
     val instance = FlintInstance.deserialize(json)
 
     instance.applicationId shouldBe "app-123"
@@ -22,27 +24,39 @@ class FlintInstanceTest extends SparkFunSuite with Matchers {
     instance.state shouldBe "RUNNING"
     instance.lastUpdateTime shouldBe 1620000000000L
     instance.jobStartTime shouldBe 1620000001000L
+    instance.excludedJobIds should contain allOf ("job-101", "job-202")
     instance.error shouldBe None
   }
 
-  test("serialize should correctly produce JSON from a FlintInstance") {
+  test("serialize should correctly produce JSON from a FlintInstance with excludedJobIds") {
+    val excludedJobIds = Seq("job-101", "job-202")
     val instance = new FlintInstance(
       "app-123",
       "job-456",
       "session-789",
       "RUNNING",
       1620000000000L,
-      1620000001000L)
+      1620000001000L,
+      excludedJobIds)
     val currentTime = System.currentTimeMillis()
     val json = FlintInstance.serialize(instance, currentTime)
 
     json should include(""""applicationId":"app-123"""")
-    json should not include(""""jobId":"job-456"""")
+    json should not include (""""jobId":"job-456"""")
     json should include(""""sessionId":"session-789"""")
     json should include(""""state":"RUNNING"""")
     json should include(s""""lastUpdateTime":$currentTime""")
+    json should include(""""excludeJobIds":["job-101","job-202"]""")
     json should include(""""jobStartTime":1620000001000""")
     json should include(""""error":""""")
+  }
+
+  test("deserialize should correctly handle an empty excludedJobIds field in JSON") {
+    val jsonWithoutExcludedJobIds =
+      """{"applicationId":"app-123","jobId":"job-456","sessionId":"session-789","state":"RUNNING","lastUpdateTime":1620000000000,"jobStartTime":1620000001000}"""
+    val instance = FlintInstance.deserialize(jsonWithoutExcludedJobIds)
+
+    instance.excludedJobIds shouldBe empty
   }
 
   test("deserialize should correctly handle error field in JSON") {
@@ -61,10 +75,45 @@ class FlintInstanceTest extends SparkFunSuite with Matchers {
       "FAILED",
       1620000000000L,
       1620000001000L,
+      Seq.empty[String],
       Some("Some error occurred"))
     val currentTime = System.currentTimeMillis()
     val json = FlintInstance.serialize(instance, currentTime)
 
     json should include(""""error":"Some error occurred"""")
   }
+
+  test("deserializeFromMap should handle normal case") {
+    val sourceMap = new JavaHashMap[String, AnyRef]()
+    sourceMap.put("applicationId", "app1")
+    sourceMap.put("jobId", "job1")
+    sourceMap.put("sessionId", "session1")
+    sourceMap.put("state", "running")
+    sourceMap.put("lastUpdateTime", java.lang.Long.valueOf(1234567890L))
+    sourceMap.put("jobStartTime", java.lang.Long.valueOf(9876543210L))
+    sourceMap.put("excludeJobIds", java.util.Arrays.asList("job2", "job3"))
+    sourceMap.put("error", "An error occurred")
+
+    val result = FlintInstance.deserializeFromMap(sourceMap)
+
+    assert(result.applicationId == "app1")
+    assert(result.jobId == "job1")
+    assert(result.sessionId == "session1")
+    assert(result.state == "running")
+    assert(result.lastUpdateTime == 1234567890L)
+    assert(result.jobStartTime == 9876543210L)
+    assert(result.excludedJobIds == Seq("job2", "job3"))
+    assert(result.error.contains("An error occurred"))
+  }
+
+  test("deserializeFromMap should handle incorrect field types") {
+    val sourceMap = new JavaHashMap[String, AnyRef]()
+    sourceMap.put("applicationId", Integer.valueOf(123))
+    sourceMap.put("lastUpdateTime", "1234567890")
+
+    assertThrows[ClassCastException] {
+      FlintInstance.deserializeFromMap(sourceMap)
+    }
+  }
+
 }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/CommandContext.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/CommandContext.scala
@@ -6,18 +6,19 @@
 package org.apache.spark.sql
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.duration.Duration
 
 import org.opensearch.flint.core.storage.{FlintReader, OpenSearchUpdater}
 
 case class CommandContext(
-    flintReader: FlintReader,
     spark: SparkSession,
     dataSource: String,
     resultIndex: String,
     sessionId: String,
-    futureMappingCheck: Future[Either[String, Unit]],
-    executionContext: ExecutionContextExecutor,
     flintSessionIndexUpdater: OpenSearchUpdater,
     osClient: OSClient,
     sessionIndex: String,
-    jobId: String)
+    jobId: String,
+    queryExecutionTimeout: Duration,
+    inactivityLimitMillis: Long,
+    queryWaitTimeMillis: Long)

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/CommandContext.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/CommandContext.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql
+
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+import org.opensearch.flint.core.storage.{FlintReader, OpenSearchUpdater}
+
+case class CommandContext(
+    flintReader: FlintReader,
+    spark: SparkSession,
+    dataSource: String,
+    resultIndex: String,
+    sessionId: String,
+    futureMappingCheck: Future[Either[String, Unit]],
+    executionContext: ExecutionContextExecutor,
+    flintSessionIndexUpdater: OpenSearchUpdater,
+    osClient: OSClient,
+    sessionIndex: String,
+    jobId: String)

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/CommandState.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/CommandState.scala
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql
+
+case class CommandState(
+    recordedLastActivityTime: Long,
+    recordedVerificationResult: VerificationResult)

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/CommandState.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/CommandState.scala
@@ -5,6 +5,13 @@
 
 package org.apache.spark.sql
 
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+import org.opensearch.flint.core.storage.FlintReader
+
 case class CommandState(
     recordedLastActivityTime: Long,
-    recordedVerificationResult: VerificationResult)
+    recordedVerificationResult: VerificationResult,
+    flintReader: FlintReader,
+    futureMappingCheck: Future[Either[String, Unit]],
+    executionContext: ExecutionContextExecutor)

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -316,6 +316,8 @@ trait FlintJobExecutor {
       sessionId: String): DataFrame = {
     // Execute SQL query
     val startTime = System.currentTimeMillis()
+    // we have to set job group in the same thread that started the query according to spark doc
+    spark.sparkContext.setJobGroup(queryId, "Job group for " + queryId, interruptOnCancel = true)
     val result: DataFrame = spark.sql(query)
     // Get Data
     getFormattedData(
@@ -378,7 +380,7 @@ trait FlintJobExecutor {
       case r: SparkException =>
         handleQueryException(
           r,
-          "Fail to run query. Cause",
+          "Spark exception. Cause",
           spark,
           dataSource,
           query,
@@ -387,7 +389,7 @@ trait FlintJobExecutor {
       case r: Exception =>
         handleQueryException(
           r,
-          "Fail to write result, cause",
+          "Fail to run query, cause",
           spark,
           dataSource,
           query,

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -5,11 +5,15 @@
 
 package org.apache.spark.sql
 
+import java.net.ConnectException
 import java.time.Instant
-import java.util.concurrent.{ScheduledExecutorService, ThreadPoolExecutor}
+import java.util.concurrent.ScheduledExecutorService
 
+import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, TimeoutException}
-import scala.concurrent.duration.{Duration, MINUTES, SECONDS}
+import scala.concurrent.duration._
+import scala.concurrent.duration.{Duration, MINUTES}
+import scala.util.control.NonFatal
 
 import org.opensearch.action.get.GetResponse
 import org.opensearch.common.Strings
@@ -19,12 +23,9 @@ import org.opensearch.flint.core.storage.{FlintReader, OpenSearchUpdater}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.FlintJob.{currentTimeProvider, getFailedData, writeData}
-import org.apache.spark.sql.FlintREPL.executeQuery
 import org.apache.spark.sql.flint.config.FlintSparkConf
-import org.apache.spark.sql.types.{ArrayType, StringType, StructField, StructType}
 import org.apache.spark.sql.util.{DefaultShutdownHookManager, ShutdownHookManagerTrait}
-import org.apache.spark.util.{ShutdownHookManager, ThreadUtils}
+import org.apache.spark.util.ThreadUtils
 
 /**
  * Spark SQL Application entrypoint
@@ -60,6 +61,8 @@ object FlintREPL extends Logging with FlintJobExecutor {
     // init SparkContext
     val conf: SparkConf = createSparkConf()
     val dataSource = conf.get("spark.flint.datasource.name", "unknown")
+    // https://github.com/opensearch-project/opensearch-spark/issues/138
+    conf.set("spark.sql.defaultCatalog", dataSource)
     val wait = conf.get("spark.flint.job.type", "continue")
     // we don't allow default value for sessionIndex and sessionId. Throw exception if key not found.
     val sessionIndex: Option[String] = Option(conf.get("spark.flint.job.requestIndex", null))
@@ -83,27 +86,32 @@ object FlintREPL extends Logging with FlintJobExecutor {
       writeData(result, resultIndex)
       spark.streams.awaitAnyTermination()
     } else {
+      val flintSessionIndexUpdater = osClient.createUpdater(sessionIndex.get)
       try {
-        val flintSessionIndexUpdater = osClient.createUpdater(sessionIndex.get)
-        createShutdownHook(flintSessionIndexUpdater, osClient, sessionIndex.get, sessionId.get);
+        createShutdownHook(flintSessionIndexUpdater, osClient, sessionIndex.get, sessionId.get)
 
-        queryLoop(
-          resultIndex,
-          dataSource,
-          sessionIndex.get,
-          sessionId.get,
-          spark,
-          osClient,
-          jobId,
-          applicationId,
-          flintSessionIndexUpdater)
+        exponentialBackoffRetry(maxRetries = 5, initialDelay = 2.seconds) {
+          queryLoop(
+            resultIndex,
+            dataSource,
+            sessionIndex.get,
+            sessionId.get,
+            spark,
+            osClient,
+            jobId,
+            applicationId,
+            flintSessionIndexUpdater)
+        }
+      } catch {
+        case e: Exception =>
+          handleSessionError(e, applicationId, jobId, sessionId.get, flintSessionIndexUpdater)
       } finally {
         spark.stop()
       }
     }
   }
 
-  private def queryLoop(
+  def queryLoop(
       resultIndex: String,
       dataSource: String,
       sessionIndex: String,
@@ -116,7 +124,6 @@ object FlintREPL extends Logging with FlintJobExecutor {
     // 1 thread for updating heart beat
     val threadPool = ThreadUtils.newDaemonThreadPoolScheduledExecutor("flint-repl", 1)
     implicit val executionContext = ExecutionContext.fromExecutor(threadPool)
-
     try {
       val futureMappingCheck = Future {
         checkAndCreateIndex(osClient, resultIndex)
@@ -136,39 +143,47 @@ object FlintREPL extends Logging with FlintJobExecutor {
 
       var lastActivityTime = Instant.now().toEpochMilli()
       var verificationResult: VerificationResult = NotVerified
-
-      while (Instant.now().toEpochMilli() - lastActivityTime <= INACTIVITY_LIMIT_MILLIS) {
-        logInfo(s"""read from ${sessionIndex}""")
+      var canPickUpNextStatement = true
+      while (Instant
+          .now()
+          .toEpochMilli() - lastActivityTime <= INACTIVITY_LIMIT_MILLIS && canPickUpNextStatement) {
+        logDebug(s"""read from ${sessionIndex}""")
         val flintReader: FlintReader =
-          createQueryReader(osClient, applicationId, sessionId, sessionIndex, dataSource)
+          createQueryReader(osClient, sessionId, sessionIndex, dataSource)
 
         try {
-          val result: (Long, VerificationResult) = processCommands(
+          // Create instances of CommandContext and CommandState with the values
+          val commandContext = CommandContext(
             flintReader,
             spark,
             dataSource,
             resultIndex,
             sessionId,
             futureMappingCheck,
-            verificationResult,
             executionContext,
             flintSessionIndexUpdater,
-            lastActivityTime)
+            osClient,
+            sessionIndex,
+            jobId)
 
-          val (updatedLastActivityTime, updatedVerificationResult) = result
+          val commandState = CommandState(lastActivityTime, verificationResult)
+          val result: (Long, VerificationResult, Boolean) =
+            processCommands(commandContext, commandState)
+
+          val (
+            updatedLastActivityTime,
+            updatedVerificationResult,
+            updatedCanPickUpNextStatement) = result
 
           lastActivityTime = updatedLastActivityTime
           verificationResult = updatedVerificationResult
+          canPickUpNextStatement = updatedCanPickUpNextStatement
         } finally {
           flintReader.close()
         }
 
         Thread.sleep(100)
       }
-
-    } catch {
-      case e: Exception =>
-        handleSessionError(e, applicationId, jobId, sessionId, flintSessionIndexUpdater)
     } finally {
       if (threadPool != null) {
         threadPool.shutdown()
@@ -185,17 +200,17 @@ object FlintREPL extends Logging with FlintJobExecutor {
     val flintJob =
       new FlintInstance(applicationId, jobId, sessionId, "running", System.currentTimeMillis())
     flintSessionIndexUpdater.upsert(sessionId, FlintInstance.serialize(flintJob))
-    logInfo(
+    logDebug(
       s"""Updated job: {"jobid": ${flintJob.jobId}, "sessionId": ${flintJob.sessionId}} from $sessionIndex""")
   }
 
-  private def handleSessionError(
+  def handleSessionError(
       e: Exception,
       applicationId: String,
       jobId: String,
       sessionId: String,
       flintSessionIndexUpdater: OpenSearchUpdater): Unit = {
-    val error = s"Unexpected error: ${e.getMessage}"
+    val error = s"Session error: ${e.getMessage}"
     logError(error, e)
     val flintJob = new FlintInstance(
       applicationId,
@@ -209,7 +224,9 @@ object FlintREPL extends Logging with FlintJobExecutor {
 
   /**
    * handling the case where a command's execution fails, updates the flintCommand with the error
-   * and failure status, and then delegates to the second method for actual DataFrame creation
+   * and failure status, and then write the result to result index. Thus, an error is written to
+   * both result index or statement model in request index
+   *
    * @param spark
    *   spark session
    * @param dataSource
@@ -264,43 +281,43 @@ object FlintREPL extends Logging with FlintJobExecutor {
   }
 
   private def processCommands(
-      flintReader: FlintReader,
-      spark: SparkSession,
-      dataSource: String,
-      resultIndex: String,
-      sessionId: String,
-      futureMappingCheck: Future[Either[String, Unit]],
-      recordedVerificationResult: VerificationResult,
-      executionContext: ExecutionContextExecutor,
-      flintSessionIndexUpdater: OpenSearchUpdater,
-      recordedLastActivityTime: Long): (Long, VerificationResult) = {
+      context: CommandContext,
+      state: CommandState): (Long, VerificationResult, Boolean) = {
+    import context._
+    import state._
+
     var lastActivityTime = recordedLastActivityTime
     var verificationResult = recordedVerificationResult
+    var canProceed = true
+    var canPickNextStatementResult = true // Add this line to keep track of canPickNextStatement
 
-    while (flintReader.hasNext) {
-      lastActivityTime = Instant.now().toEpochMilli()
-      val flintCommand = processCommandInitiation(flintReader, flintSessionIndexUpdater)
+    while (canProceed) {
+      if (!canPickNextStatement(sessionId, jobId, osClient, sessionIndex)) {
+        canPickNextStatementResult = false
+        canProceed = false
+      } else if (!flintReader.hasNext) {
+        canProceed = false
+      } else {
+        lastActivityTime = Instant.now().toEpochMilli()
+        val flintCommand = processCommandInitiation(flintReader, flintSessionIndexUpdater)
 
-      spark.sparkContext.setJobGroup(
-        flintCommand.queryId,
-        "Job group for " + flintCommand.queryId,
-        interruptOnCancel = true)
-      val (dataToWrite, returnedVerificationResult) = processStatementOnVerification(
-        recordedVerificationResult,
-        spark,
-        flintCommand,
-        dataSource,
-        sessionId,
-        executionContext,
-        futureMappingCheck,
-        resultIndex)
+        val (dataToWrite, returnedVerificationResult) = processStatementOnVerification(
+          recordedVerificationResult,
+          spark,
+          flintCommand,
+          dataSource,
+          sessionId,
+          executionContext,
+          futureMappingCheck,
+          resultIndex)
 
-      verificationResult = returnedVerificationResult
-      finalizeCommand(dataToWrite, flintCommand, resultIndex, flintSessionIndexUpdater)
+        verificationResult = returnedVerificationResult
+        finalizeCommand(dataToWrite, flintCommand, resultIndex, flintSessionIndexUpdater)
+      }
     }
 
     // return tuple indicating if still active and mapping verification result
-    (lastActivityTime, verificationResult)
+    (lastActivityTime, verificationResult, canPickNextStatementResult)
   }
 
   /**
@@ -322,13 +339,14 @@ object FlintREPL extends Logging with FlintJobExecutor {
       flintSessionIndexUpdater: OpenSearchUpdater): Unit = {
     try {
       dataToWrite.foreach(df => writeData(df, resultIndex))
-      if (flintCommand.isRunning()) {
+      if (flintCommand.isRunning() || flintCommand.isWaiting()) {
         // we have set failed state in exception handling
         flintCommand.complete()
       }
       update(flintCommand, flintSessionIndexUpdater)
     } catch {
       // e.g., maybe due to authentication service connection issue
+      // or invalid catalog (e.g., we are operating on data not defined in provided data source)
       case e: Exception =>
         val error = s"""Fail to write result of ${flintCommand}, cause: ${e.getMessage}"""
         logError(error, e)
@@ -336,6 +354,78 @@ object FlintREPL extends Logging with FlintJobExecutor {
         update(flintCommand, flintSessionIndexUpdater)
     }
   }
+
+  private def handleCommandTimeout(
+      spark: SparkSession,
+      dataSource: String,
+      error: String,
+      flintCommand: FlintCommand,
+      sessionId: String,
+      startTime: Long): Option[DataFrame] = {
+    /*
+     * https://tinyurl.com/2ezs5xj9
+     *
+     * This only interrupts active Spark jobs that are actively running.
+     * This would then throw the error from ExecutePlan and terminate it.
+     * But if the query is not running a Spark job, but executing code on Spark driver, this
+     * would be a noop and the execution will keep running.
+     *
+     * In Apache Spark, actions that trigger a distributed computation can lead to the creation
+     * of Spark jobs. In the context of Spark SQL, this typically happens when we perform
+     * actions that require the computation of results that need to be collected or stored.
+     */
+    spark.sparkContext.cancelJobGroup(flintCommand.queryId)
+    logError(error)
+    Some(
+      handleCommandFailureAndGetFailedData(
+        spark,
+        dataSource,
+        error,
+        flintCommand,
+        sessionId,
+        startTime))
+  }
+
+  def executeAndHandle(
+      spark: SparkSession,
+      flintCommand: FlintCommand,
+      dataSource: String,
+      sessionId: String,
+      executionContext: ExecutionContextExecutor,
+      startTime: Long,
+      queryExecuitonTimeOut: Duration): Option[DataFrame] = {
+    try {
+      Some(
+        executeQueryAsync(
+          spark,
+          flintCommand,
+          dataSource,
+          sessionId,
+          executionContext,
+          startTime,
+          queryExecuitonTimeOut))
+    } catch {
+      case e: TimeoutException =>
+        handleCommandTimeout(
+          spark,
+          dataSource,
+          s"Executing ${flintCommand.query} timed out",
+          flintCommand,
+          sessionId,
+          startTime)
+      case e: Exception =>
+        val error = processQueryException(e, spark, dataSource, flintCommand.query, "", "")
+        Some(
+          handleCommandFailureAndGetFailedData(
+            spark,
+            dataSource,
+            error,
+            flintCommand,
+            sessionId,
+            startTime))
+    }
+  }
+
   private def processStatementOnVerification(
       recordedVerificationResult: VerificationResult,
       spark: SparkSession,
@@ -348,39 +438,23 @@ object FlintREPL extends Logging with FlintJobExecutor {
     val startTime: Long = System.currentTimeMillis()
     var verificationResult = recordedVerificationResult
     var dataToWrite: Option[DataFrame] = None
-    try {
-      verificationResult match {
-        case NotVerified =>
-          try {
-            val mappingCheckResult =
-              ThreadUtils.awaitResult(futureMappingCheck, MAPPING_CHECK_TIMEOUT)
-            // time out after 10 minutes
-            val result = executeQueryAsync(
-              spark,
-              flintCommand,
-              dataSource,
-              sessionId,
-              executionContext,
-              startTime)
 
-            dataToWrite = Some(mappingCheckResult match {
-              case Right(_) =>
-                verificationResult = VerifiedWithoutError
-                result
-              case Left(error) =>
-                verificationResult = VerifiedWithError(error)
-                handleCommandFailureAndGetFailedData(
-                  spark,
-                  dataSource,
-                  error,
-                  flintCommand,
-                  sessionId,
-                  startTime)
-            })
-          } catch {
-            case e: TimeoutException =>
-              val error = s"Getting the mapping of index $resultIndex timed out"
-              logError(error, e)
+    verificationResult match {
+      case NotVerified =>
+        try {
+          ThreadUtils.awaitResult(futureMappingCheck, MAPPING_CHECK_TIMEOUT) match {
+            case Right(_) =>
+              dataToWrite = executeAndHandle(
+                spark,
+                flintCommand,
+                dataSource,
+                sessionId,
+                executionContext,
+                startTime,
+                QUERY_EXECUTION_TIMEOUT)
+              verificationResult = VerifiedWithoutError
+            case Left(error) =>
+              verificationResult = VerifiedWithError(error)
               dataToWrite = Some(
                 handleCommandFailureAndGetFailedData(
                   spark,
@@ -390,51 +464,43 @@ object FlintREPL extends Logging with FlintJobExecutor {
                   sessionId,
                   startTime))
           }
-        case VerifiedWithError(err) =>
-          dataToWrite = Some(
-            handleCommandFailureAndGetFailedData(
-              spark,
-              dataSource,
-              err,
-              flintCommand,
-              sessionId,
-              startTime))
-        case VerifiedWithoutError =>
-          dataToWrite = Some(
-            executeQueryAsync(
-              spark,
-              flintCommand,
-              dataSource,
-              sessionId,
-              executionContext,
-              startTime))
-      }
-
-      logDebug(s"""command complete: ${flintCommand}""")
-    } catch {
-      case e: TimeoutException =>
-        val error = s"Executing ${flintCommand.query} timed out"
-        spark.sparkContext.cancelJobGroup(flintCommand.queryId)
-        logError(error, e)
+        } catch {
+          case e: TimeoutException =>
+            val error = s"Getting the mapping of index $resultIndex timed out"
+            dataToWrite =
+              handleCommandTimeout(spark, dataSource, error, flintCommand, sessionId, startTime)
+          case NonFatal(e) =>
+            val error = s"An unexpected error occurred: ${e.getMessage}"
+            dataToWrite = Some(
+              handleCommandFailureAndGetFailedData(
+                spark,
+                dataSource,
+                error,
+                flintCommand,
+                sessionId,
+                startTime))
+        }
+      case VerifiedWithError(err) =>
         dataToWrite = Some(
           handleCommandFailureAndGetFailedData(
             spark,
             dataSource,
-            error,
+            err,
             flintCommand,
             sessionId,
             startTime))
-      case e: Exception =>
-        val error = processQueryException(e, spark, dataSource, flintCommand, sessionId)
-        dataToWrite = Some(
-          handleCommandFailureAndGetFailedData(
-            spark,
-            dataSource,
-            error,
-            flintCommand,
-            sessionId,
-            startTime))
+      case VerifiedWithoutError =>
+        dataToWrite = executeAndHandle(
+          spark,
+          flintCommand,
+          dataSource,
+          sessionId,
+          executionContext,
+          startTime,
+          QUERY_EXECUTION_TIMEOUT)
     }
+
+    logDebug(s"command complete: $flintCommand")
     (dataToWrite, verificationResult)
   }
 
@@ -444,7 +510,8 @@ object FlintREPL extends Logging with FlintJobExecutor {
       dataSource: String,
       sessionId: String,
       executionContext: ExecutionContextExecutor,
-      startTime: Long): DataFrame = {
+      startTime: Long,
+      queryExecutionTimeOut: Duration): DataFrame = {
     if (Instant.now().toEpochMilli() - flintCommand.submitTime > QUERY_WAIT_TIMEOUT_MILLIS) {
       handleCommandFailureAndGetFailedData(
         spark,
@@ -459,7 +526,7 @@ object FlintREPL extends Logging with FlintJobExecutor {
       }(executionContext)
 
       // time out after 10 minutes
-      ThreadUtils.awaitResult(futureQueryExecution, QUERY_EXECUTION_TIMEOUT)
+      ThreadUtils.awaitResult(futureQueryExecution, queryExecutionTimeOut)
     }
   }
   private def processCommandInitiation(
@@ -477,21 +544,12 @@ object FlintREPL extends Logging with FlintJobExecutor {
 
   private def createQueryReader(
       osClient: OSClient,
-      applicationId: String,
       sessionId: String,
       sessionIndex: String,
       dataSource: String) = {
     // all state in index are in lower case
-    //
-    // add application to deal with emr-s deployment:
-    // Should the EMR-S application be terminated or halted (e.g., during deployments), OpenSearch associates each
-    // query to ascertain the latest EMR-S application ID. While existing EMR-S jobs continue executing queries sharing
-    // the same applicationId and sessionId, new requests with differing application IDs will not be processed by the
-    // current EMR-S job. Gradually, the queue with the same applicationId and sessionId diminishes, enabling the
-    // job to self-terminate due to inactivity timeout. Following the termination of all jobs, the CP can gracefully
-    // shut down the application. The session has a phantom state where the old application set the state to dead and
-    // then the new application job sets it to running through heartbeat. Also, application id can help in the case
-    // of job restart where the job id is different but application id is the same.
+    // we only search for statement submitted in the last hour in case of unexpected bugs causing infinite loop in the
+    // same doc
     val dsl =
       s"""{
          |  "bool": {
@@ -508,11 +566,6 @@ object FlintREPL extends Logging with FlintJobExecutor {
          |      },
          |      {
          |        "term": {
-         |          "applicationId": "$applicationId"
-         |        }
-         |      },
-         |      {
-         |        "term": {
          |          "sessionId": "$sessionId"
          |        }
          |      },
@@ -520,10 +573,16 @@ object FlintREPL extends Logging with FlintJobExecutor {
          |        "term": {
          |          "dataSourceName": "$dataSource"
          |        }
+         |      },
+         |      {
+         |        "range": {
+         |          "submitTime": { "gte": "now-1h" }
+         |        }
          |      }
          |    ]
          |  }
          |}""".stripMargin
+
     val flintReader = osClient.createReader(sessionIndex, dsl, "submitTime")
     flintReader
   }
@@ -633,5 +692,94 @@ object FlintREPL extends Logging with FlintJobExecutor {
       0L,
       currentInterval,
       java.util.concurrent.TimeUnit.MILLISECONDS)
+  }
+
+  /**
+   * Reads the session store to get excluded jobs and the current job ID. If the current job ID
+   * (myJobId) is not the running job ID (runJobId), or if myJobId is in the list of excluded
+   * jobs, it returns false. The first condition ensures we only have one active job for one
+   * session thus avoid race conditions on statement execution and states. The 2nd condition
+   * ensures we don't pick up a job that has been excluded from the session store and thus CP has
+   * a way to notify spark when deployments are happening. If excludeJobs is null or none of the
+   * above conditions are met, it returns true.
+   * @return
+   *   whether we can start fetching next statement or not
+   */
+  def canPickNextStatement(
+      sessionId: String,
+      jobId: String,
+      osClient: OSClient,
+      sessionIndex: String): Boolean = {
+    try {
+      val getResponse = osClient.getDoc(sessionIndex, sessionId)
+      if (getResponse.isExists()) {
+        val source = getResponse.getSourceAsMap
+        if (source == null) {
+          logError(s"""Session id ${sessionId} is empty""")
+          // still proceed since we are not sure what happened (e.g., OpenSearch cluster may be unresponsive)
+          return true
+        }
+
+        val runJobId = Option(source.get("jobId")).map(_.asInstanceOf[String]).orNull
+        val excludeJobIds: Seq[String] = {
+          val rawExcludeJobIds = source.get("excludeJobIds")
+          Option(rawExcludeJobIds)
+            .map {
+              case s: String => Seq(s)
+              case a: java.util.ArrayList[String] @unchecked =>
+                import scala.collection.JavaConverters._
+                a.asScala.toSeq // Convert the ArrayList to a Scala Seq
+              case other =>
+                logInfo(s"Unexpected type: ${other.getClass.getName}")
+                Seq.empty
+            }
+            .getOrElse(Seq.empty[String]) // In case of null, return an empty Seq
+        }
+
+        if (runJobId != null && jobId != runJobId) {
+          logInfo(s"""the current job ID ${jobId} is not the running job ID ${runJobId}""")
+          return false
+        }
+        if (excludeJobIds != null && excludeJobIds.contains(jobId)) {
+          logInfo(s"""${jobId} is in the list of excluded jobs""")
+          return false
+        }
+        true
+      } else {
+        // still proceed since we are not sure what happened (e.g., session doc may not be available yet)
+        logError(s"""Fail to find id ${sessionId} from session index""")
+        true
+      }
+    } catch {
+      // still proceed since we are not sure what happened (e.g., OpenSearch cluster may be unresponsive)
+      case e: Exception =>
+        logError(s"""Fail to find id ${sessionId} from session index.""", e)
+        true
+    }
+  }
+
+  def exponentialBackoffRetry[T](maxRetries: Int, initialDelay: FiniteDuration)(
+      block: => T): T = {
+    var retries = 0
+    var result: Option[T] = None
+    var toContinue = true
+    while (retries < maxRetries && toContinue) {
+      try {
+        result = Some(block)
+        toContinue = false
+      } catch {
+        case e: RuntimeException
+            if e.getCause != null && e.getCause.isInstanceOf[ConnectException] =>
+          retries += 1
+          val delay = initialDelay * math.pow(2, retries - 1).toLong
+          logError(s"Fail to connect to OpenSearch cluster. Retrying in $delay...", e)
+          Thread.sleep(delay.toMillis)
+
+        case e: Exception =>
+          throw e
+      }
+    }
+
+    result.getOrElse(throw new RuntimeException("Failed after retries"))
   }
 }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/OSClient.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/OSClient.scala
@@ -140,4 +140,16 @@ class OSClient(val flintOptions: FlintOptions) extends Logging {
     case e: IOException =>
       throw new RuntimeException(e)
   }
+
+  def doesIndexExist(indexName: String): Boolean = {
+    using(flintClient.createClient()) { client =>
+      try {
+        val request = new GetIndexRequest(indexName)
+        client.indices().exists(request, RequestOptions.DEFAULT)
+      } catch {
+        case e: Exception =>
+          throw new IllegalStateException(s"Failed to check if index $indexName exists", e)
+      }
+    }
+  }
 }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/util/DefaultThreadPoolFactory.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/util/DefaultThreadPoolFactory.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql.util
+
+import java.util.concurrent.ScheduledExecutorService
+
+import org.apache.spark.util.ThreadUtils
+
+class DefaultThreadPoolFactory extends ThreadPoolFactory {
+  override def newDaemonThreadPoolScheduledExecutor(
+      threadNamePrefix: String,
+      numThreads: Int): ScheduledExecutorService = {
+    ThreadUtils.newDaemonThreadPoolScheduledExecutor(threadNamePrefix, numThreads)
+  }
+}

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/util/ThreadPoolFactory.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/util/ThreadPoolFactory.scala
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql.util
+
+import java.util.concurrent.ScheduledExecutorService
+
+trait ThreadPoolFactory {
+  def newDaemonThreadPoolScheduledExecutor(
+      threadNamePrefix: String,
+      numThreads: Int): ScheduledExecutorService
+}

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintJobTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintJobTest.scala
@@ -7,6 +7,7 @@ package org.apache.spark.sql
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.MockTimeProvider
 
 class FlintJobTest extends SparkFunSuite with JobMatchers {
 

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -258,9 +258,6 @@ class FlintREPLTest
     when(getResponse.isExists()).thenReturn(true)
     when(getResponse.getSourceAsMap).thenReturn(null) // Simulate the source being null
 
-    // Capture the logs if your logger allows it or redirect System.out for System.log calls
-    // Assuming `logError` is the method you would call when the source is null
-
     // Execute the method under test
     val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
 
@@ -287,11 +284,6 @@ class FlintREPLTest
 
     when(getResponse.getSourceAsMap).thenReturn(sourceMap)
 
-    // Assuming logInfo is used for logging unexpected types and that it is a method on FlintREPL
-    // You would have a mock or a way to verify that logInfo was called with the expected message
-    // If you're using a logging framework that supports appending log messages to a list for tests,
-    // like logback-test.xml configuration with a ListAppender, set it up here.
-
     val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
 
     assert(result) // The function should return true
@@ -307,9 +299,6 @@ class FlintREPLTest
     val getResponse = mock[GetResponse]
     when(osClient.getDoc(sessionIndex, sessionId)).thenReturn(getResponse)
     when(getResponse.isExists()).thenReturn(false) // Simulate the document does not exist
-
-    // Redirect or mock the logger as appropriate for your setup
-    // If you're using a framework that allows capturing log messages in tests, prepare it here
 
     // Execute the function under test
     val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
@@ -327,9 +316,6 @@ class FlintREPLTest
     // Set up the mock OSClient to throw an exception
     when(osClient.getDoc(sessionIndex, sessionId))
       .thenThrow(new RuntimeException("OpenSearch cluster unresponsive"))
-
-    // Mock or redirect the logger if necessary
-    // For some logging frameworks, you might be able to use a TestAppender or similar mechanism
 
     // Execute the method under test and expect true, since the method is designed to return true even in case of an exception
     val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
@@ -457,7 +443,6 @@ class FlintREPLTest
             spark,
             osClient,
             jobId,
-            applicationId,
             flintSessionIndexUpdater)
         }
       } // (block)

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -5,21 +5,30 @@
 
 package org.apache.spark.sql
 
+import java.net.ConnectException
+import java.time.Instant
 import java.util.concurrent.{ScheduledExecutorService, ScheduledFuture, TimeUnit}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, TimeoutException}
+import scala.concurrent.duration._
+import scala.reflect.runtime.universe.TypeTag
 
-import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
+import org.mockito.ArgumentMatchersSugar
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 import org.opensearch.action.get.GetResponse
 import org.opensearch.flint.app.FlintCommand
-import org.opensearch.flint.core.storage.OpenSearchUpdater
+import org.opensearch.flint.core.storage.{OpenSearchReader, OpenSearchUpdater}
 import org.scalatestplus.mockito.MockitoSugar
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkContext, SparkFunSuite}
+import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.types.{ArrayType, LongType, NullType, StringType, StructField, StructType}
 import org.apache.spark.sql.util.ShutdownHookManagerTrait
+import org.apache.spark.util.ThreadUtils
 
 class FlintREPLTest
     extends SparkFunSuite
@@ -170,4 +179,396 @@ class FlintREPLTest
     assert("failed" == flintCommand.state)
     assert(error == flintCommand.error.get)
   }
+
+  test("test canPickNextStatement: Doc Exists and Valid JobId") {
+    val sessionId = "session123"
+    val jobId = "jobABC"
+    val osClient = mock[OSClient]
+    val sessionIndex = "sessionIndex"
+
+    val getResponse = mock[GetResponse]
+    when(osClient.getDoc(sessionIndex, sessionId)).thenReturn(getResponse)
+    when(getResponse.isExists()).thenReturn(true)
+
+    val sourceMap: java.util.Map[String, Object] = new java.util.HashMap[String, Object]()
+    sourceMap.put("jobId", jobId.asInstanceOf[Object])
+    when(getResponse.getSourceAsMap).thenReturn(sourceMap)
+
+    val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
+
+    assert(result)
+  }
+
+  test("test canPickNextStatement: Doc Exists but Different JobId") {
+    val sessionId = "session123"
+    val jobId = "jobABC"
+    val differentJobId = "jobXYZ"
+    val osClient = mock[OSClient]
+    val sessionIndex = "sessionIndex"
+
+    val getResponse = mock[GetResponse]
+    when(osClient.getDoc(sessionIndex, sessionId)).thenReturn(getResponse)
+    when(getResponse.isExists()).thenReturn(true)
+
+    val sourceMap: java.util.Map[String, Object] = new java.util.HashMap[String, Object]()
+    sourceMap.put("jobId", differentJobId.asInstanceOf[Object])
+    when(getResponse.getSourceAsMap).thenReturn(sourceMap)
+
+    // Execute the method under test
+    val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
+
+    // Assertions
+    assert(!result) // The function should return false
+  }
+
+  test("test canPickNextStatement: Doc Exists, JobId Matches, but JobId is Excluded") {
+    val sessionId = "session123"
+    val jobId = "jobABC"
+    val osClient = mock[OSClient]
+    val sessionIndex = "sessionIndex"
+
+    val getResponse = mock[GetResponse]
+    when(osClient.getDoc(sessionIndex, sessionId)).thenReturn(getResponse)
+    when(getResponse.isExists()).thenReturn(true)
+
+    val excludeJobIdsList = new java.util.ArrayList[String]()
+    excludeJobIdsList.add(jobId) // Add the jobId to the list to simulate exclusion
+
+    val sourceMap: java.util.Map[String, Object] = new java.util.HashMap[String, Object]()
+    sourceMap.put("jobId", jobId) // The jobId matches
+    sourceMap.put("excludeJobIds", excludeJobIdsList) // But jobId is in the exclude list
+    when(getResponse.getSourceAsMap).thenReturn(sourceMap)
+
+    // Execute the method under test
+    val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
+
+    // Assertions
+    assert(!result) // The function should return false because jobId is excluded
+  }
+
+  test("test canPickNextStatement: Doc Exists but Source is Null") {
+    val sessionId = "session123"
+    val jobId = "jobABC"
+    val osClient = mock[OSClient]
+    val sessionIndex = "sessionIndex"
+
+    // Mock the getDoc response
+    val getResponse = mock[GetResponse]
+    when(osClient.getDoc(sessionIndex, sessionId)).thenReturn(getResponse)
+    when(getResponse.isExists()).thenReturn(true)
+    when(getResponse.getSourceAsMap).thenReturn(null) // Simulate the source being null
+
+    // Capture the logs if your logger allows it or redirect System.out for System.log calls
+    // Assuming `logError` is the method you would call when the source is null
+
+    // Execute the method under test
+    val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
+
+    // Assertions
+    assert(result) // The function should return true despite the null source
+  }
+
+  test("test canPickNextStatement: Doc Exists with Unexpected Type in excludeJobIds") {
+    val sessionId = "session123"
+    val jobId = "jobABC"
+    val osClient = mock[OSClient]
+    val sessionIndex = "sessionIndex"
+
+    val getResponse = mock[GetResponse]
+    when(osClient.getDoc(sessionIndex, sessionId)).thenReturn(getResponse)
+    when(getResponse.isExists()).thenReturn(true)
+
+    val sourceMap: java.util.Map[String, Object] = new java.util.HashMap[String, Object]()
+    sourceMap.put("jobId", jobId)
+    sourceMap.put(
+      "excludeJobIds",
+      Integer.valueOf(123)
+    ) // Using an Integer here to represent an unexpected type
+
+    when(getResponse.getSourceAsMap).thenReturn(sourceMap)
+
+    // Assuming logInfo is used for logging unexpected types and that it is a method on FlintREPL
+    // You would have a mock or a way to verify that logInfo was called with the expected message
+    // If you're using a logging framework that supports appending log messages to a list for tests,
+    // like logback-test.xml configuration with a ListAppender, set it up here.
+
+    val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
+
+    assert(result) // The function should return true
+  }
+
+  test("test canPickNextStatement: Doc Does Not Exist") {
+    val sessionId = "session123"
+    val jobId = "jobABC"
+    val osClient = mock[OSClient]
+    val sessionIndex = "sessionIndex"
+
+    // Set up the mock GetResponse
+    val getResponse = mock[GetResponse]
+    when(osClient.getDoc(sessionIndex, sessionId)).thenReturn(getResponse)
+    when(getResponse.isExists()).thenReturn(false) // Simulate the document does not exist
+
+    // Redirect or mock the logger as appropriate for your setup
+    // If you're using a framework that allows capturing log messages in tests, prepare it here
+
+    // Execute the function under test
+    val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
+
+    // Assert the function returns true
+    assert(result)
+  }
+
+  test("test canPickNextStatement: OSClient Throws Exception") {
+    val sessionId = "session123"
+    val jobId = "jobABC"
+    val osClient = mock[OSClient]
+    val sessionIndex = "sessionIndex"
+
+    // Set up the mock OSClient to throw an exception
+    when(osClient.getDoc(sessionIndex, sessionId))
+      .thenThrow(new RuntimeException("OpenSearch cluster unresponsive"))
+
+    // Mock or redirect the logger if necessary
+    // For some logging frameworks, you might be able to use a TestAppender or similar mechanism
+
+    // Execute the method under test and expect true, since the method is designed to return true even in case of an exception
+    val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
+
+    // Verify the result is true despite the exception
+    assert(result)
+  }
+
+  test(
+    "test canPickNextStatement: Doc Exists and excludeJobIds is a Single String Not Matching JobId") {
+    val sessionId = "session123"
+    val jobId = "jobABC"
+    val nonMatchingExcludeJobId = "jobXYZ" // This ID does not match the jobId
+    val osClient = mock[OSClient]
+    val sessionIndex = "sessionIndex"
+
+    val getResponse = mock[GetResponse]
+    when(osClient.getDoc(sessionIndex, sessionId)).thenReturn(getResponse)
+    when(getResponse.isExists()).thenReturn(true)
+
+    // Create a sourceMap with excludeJobIds as a String that does NOT match jobId
+    val sourceMap: java.util.Map[String, Object] = new java.util.HashMap[String, Object]()
+    sourceMap.put("jobId", jobId.asInstanceOf[Object])
+    sourceMap.put("excludeJobIds", nonMatchingExcludeJobId.asInstanceOf[Object])
+
+    when(getResponse.getSourceAsMap).thenReturn(sourceMap)
+
+    // Execute the method under test
+    val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
+
+    // The function should return true since jobId is not excluded
+    assert(result)
+  }
+
+  test("Doc Exists and excludeJobIds is an ArrayList Containing JobId") {
+    val sessionId = "session123"
+    val jobId = "jobABC"
+    val osClient = mock[OSClient]
+    val sessionIndex = "sessionIndex"
+    val handleSessionError = mock[Function1[String, Unit]]
+
+    val getResponse = mock[GetResponse]
+    when(osClient.getDoc(sessionIndex, sessionId)).thenReturn(getResponse)
+    when(getResponse.isExists()).thenReturn(true)
+
+    // Create a sourceMap with excludeJobIds as an ArrayList containing jobId
+    val sourceMap: java.util.Map[String, Object] = new java.util.HashMap[String, Object]()
+    sourceMap.put("jobId", jobId.asInstanceOf[Object])
+
+    // Creating an ArrayList and adding the jobId to it
+    val excludeJobIdsList = new java.util.ArrayList[String]()
+    excludeJobIdsList.add(jobId)
+    sourceMap.put("excludeJobIds", excludeJobIdsList.asInstanceOf[Object])
+
+    when(getResponse.getSourceAsMap).thenReturn(sourceMap)
+
+    // Execute the method under test
+    val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
+
+    // The function should return false since jobId is excluded
+    assert(!result)
+  }
+
+  test("Doc Exists and excludeJobIds is an ArrayList Not Containing JobId") {
+    val sessionId = "session123"
+    val jobId = "jobABC"
+    val osClient = mock[OSClient]
+    val sessionIndex = "sessionIndex"
+
+    val getResponse = mock[GetResponse]
+    when(osClient.getDoc(sessionIndex, sessionId)).thenReturn(getResponse)
+    when(getResponse.isExists()).thenReturn(true)
+
+    // Create a sourceMap with excludeJobIds as an ArrayList not containing jobId
+    val sourceMap: java.util.Map[String, Object] = new java.util.HashMap[String, Object]()
+    sourceMap.put("jobId", jobId.asInstanceOf[Object])
+
+    // Creating an ArrayList and adding a different jobId to it
+    val excludeJobIdsList = new java.util.ArrayList[String]()
+    excludeJobIdsList.add("jobXYZ") // This ID does not match the jobId
+    sourceMap.put("excludeJobIds", excludeJobIdsList.asInstanceOf[Object])
+
+    when(getResponse.getSourceAsMap).thenReturn(sourceMap)
+
+    // Execute the method under test
+    val result = FlintREPL.canPickNextStatement(sessionId, jobId, osClient, sessionIndex)
+
+    // The function should return true since the jobId is not in the excludeJobIds list
+    assert(result)
+  }
+
+  test("exponentialBackoffRetry should retry on ConnectException") {
+    val mockReader = mock[OpenSearchReader]
+    val exception = new RuntimeException(
+      new ConnectException(
+        "Timeout connecting to [search-foo-1-bar.eu-west-1.es.amazonaws.com:443]"))
+    val osClient = mock[OSClient]
+    when(osClient.createReader(any[String], any[String], any[String])).thenReturn(mockReader)
+    when(mockReader.hasNext).thenThrow(exception)
+
+    val maxRetries = 1
+    var actualRetries = 0
+
+    val resultIndex = "testResultIndex"
+    val dataSource = "testDataSource"
+    val sessionIndex = "testSessionIndex"
+    val sessionId = "testSessionId"
+    val jobId = "testJobId"
+    val applicationId = "testApplicationId"
+
+    // Create a SparkSession for testing (use master("local") for local testing)
+    try {
+      val spark = SparkSession.builder().master("local").appName("FlintREPLTest").getOrCreate()
+
+      val flintSessionIndexUpdater = mock[OpenSearchUpdater]
+
+      intercept[RuntimeException] {
+        FlintREPL.exponentialBackoffRetry(maxRetries, 2.seconds) {
+          actualRetries += 1
+          FlintREPL.queryLoop(
+            resultIndex,
+            dataSource,
+            sessionIndex,
+            sessionId,
+            spark,
+            osClient,
+            jobId,
+            applicationId,
+            flintSessionIndexUpdater)
+        }
+      } // (block)
+
+      assert(actualRetries == maxRetries)
+    } finally {
+      // Stop the SparkSession
+      spark.stop()
+    }
+  }
+
+  test("executeAndHandle should handle TimeoutException properly") {
+    val mockSparkSession: SparkSession = mock[SparkSession]
+    val mockFlintCommand: FlintCommand = mock[FlintCommand]
+    // val mockExecutionContextExecutor: ExecutionContextExecutor = mock[ExecutionContextExecutor]
+    val threadPool = ThreadUtils.newDaemonThreadPoolScheduledExecutor("flint-repl", 1)
+    implicit val executionContext = ExecutionContext.fromExecutor(threadPool)
+
+    try {
+      val dataSource = "someDataSource"
+      val sessionId = "someSessionId"
+      val startTime = System.currentTimeMillis()
+      val expectedDataFrame = mock[DataFrame]
+
+      when(mockFlintCommand.query).thenReturn("SELECT 1")
+      when(mockFlintCommand.submitTime).thenReturn(Instant.now().toEpochMilli())
+      // When the `sql` method is called, execute the custom Answer that introduces a delay
+      when(mockSparkSession.sql(any[String])).thenAnswer(new Answer[DataFrame] {
+        override def answer(invocation: InvocationOnMock): DataFrame = {
+          // Introduce a delay of 60 seconds
+          Thread.sleep(60000)
+
+          expectedDataFrame
+        }
+      })
+
+      when(mockSparkSession.createDataFrame(any[Seq[Product]])(any[TypeTag[Product]]))
+        .thenReturn(expectedDataFrame)
+
+      when(expectedDataFrame.toDF(any[Seq[String]]: _*)).thenReturn(expectedDataFrame)
+
+      val sparkContext: SparkContext = mock[SparkContext]
+      when(mockSparkSession.sparkContext).thenReturn(sparkContext)
+
+      val result = FlintREPL.executeAndHandle(
+        mockSparkSession,
+        mockFlintCommand,
+        dataSource,
+        sessionId,
+        executionContext,
+        startTime,
+        // make sure it times out before mockSparkSession.sql can return, which takes 60 seconds
+        Duration(1, SECONDS))
+
+      verify(mockSparkSession, times(1)).sql(any[String])
+      verify(sparkContext, times(1)).cancelJobGroup(any[String])
+      result should not be None
+    } finally {
+      threadPool.shutdown()
+    }
+  }
+
+  test("executeAndHandle should handle ParseException properly") {
+    val mockSparkSession: SparkSession = mock[SparkSession]
+    val flintCommand: FlintCommand =
+      new FlintCommand(
+        "Running",
+        "select * from default.http_logs limit1 1",
+        "10",
+        "20",
+        Instant.now().toEpochMilli,
+        None)
+    val threadPool = ThreadUtils.newDaemonThreadPoolScheduledExecutor("flint-repl", 1)
+    implicit val executionContext = ExecutionContext.fromExecutor(threadPool)
+
+    try {
+      val dataSource = "someDataSource"
+      val sessionId = "someSessionId"
+      val startTime = System.currentTimeMillis()
+      val expectedDataFrame = mock[DataFrame]
+
+      // sql method can only throw RuntimeException
+      when(mockSparkSession.sql(any[String])).thenThrow(
+        new RuntimeException(new ParseException(None, "INVALID QUERY", Origin(), Origin())))
+      val sparkContext: SparkContext = mock[SparkContext]
+      when(mockSparkSession.sparkContext).thenReturn(sparkContext)
+
+      // Assume handleQueryException logs the error and returns an error message string
+      val mockErrorString = "Error due to syntax"
+      when(mockSparkSession.createDataFrame(any[Seq[Product]])(any[TypeTag[Product]]))
+        .thenReturn(expectedDataFrame)
+      when(expectedDataFrame.toDF(any[Seq[String]]: _*)).thenReturn(expectedDataFrame)
+
+      val result = FlintREPL.executeAndHandle(
+        mockSparkSession,
+        flintCommand,
+        dataSource,
+        sessionId,
+        executionContext,
+        startTime,
+        Duration.Inf // Use Duration.Inf or a large enough duration to avoid a timeout
+      )
+
+      // Verify that ParseException was caught and handled
+      result should not be None // or result.isDefined shouldBe true
+      flintCommand.error should not be None
+      flintCommand.error.get should include("Syntax error:")
+    } finally {
+      threadPool.shutdown()
+    }
+
+  }
+
 }

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/util/MockThreadPoolFactory.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/util/MockThreadPoolFactory.scala
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql.util
+
+import java.util.concurrent.ScheduledExecutorService
+
+class MockThreadPoolFactory(mockExecutor: ScheduledExecutorService) extends ThreadPoolFactory {
+  override def newDaemonThreadPoolScheduledExecutor(
+      threadNamePrefix: String,
+      numThreads: Int): ScheduledExecutorService = mockExecutor
+}

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/util/MockTimeProvider.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/util/MockTimeProvider.scala
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.apache.spark.sql
-
-import org.apache.spark.sql.util.TimeProvider
+package org.apache.spark.sql.util
 
 class MockTimeProvider(fixedTime: Long) extends TimeProvider {
   override def currentEpochMillis(): Long = fixedTime


### PR DESCRIPTION
### Description
Features:
- Add mutual exclusivity in session-based emr-s jobs to ensure only one job runs at a time, enhancing system stability during blue/green deployments. This allows active job exclusion and seamless task pickup by new jobs. Details in #94.

Fixes:
- Resolve a bug where long-running queries failed to cancel post-index mapping verification, by introducing timely query cancellation checks within the REPL loop.
- Address issue #138 with the proposed short-term fix, improving reliability.

Tests:
- Conducted manual testing to validate blue/green deployment support and query cancellation.
- Extended unit tests to cover new features and bug fixes.

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/138
https://github.com/opensearch-project/opensearch-spark/issues/94

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
