### PR TITLE
Handle Missing jobStartTime in JSON Deserialization

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/app/FlintInstance.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/app/FlintInstance.scala
@@ -10,7 +10,7 @@ import java.util.{Map => JavaMap}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-import org.json4s.{Formats, NoTypeHints}
+import org.json4s.{Formats, JNothing, JNull, NoTypeHints}
 import org.json4s.JsonAST.{JArray, JString}
 import org.json4s.native.JsonMethods.parse
 import org.json4s.native.Serialization
@@ -24,7 +24,7 @@ class FlintInstance(
     var state: String,
     val lastUpdateTime: Long,
     // We need jobStartTime to check if HMAC token is expired or not
-    val jobStartTime: Long,
+    val jobStartTime: Long = 0,
     val excludedJobIds: Seq[String] = Seq.empty[String],
     val error: Option[String] = None) {}
 
@@ -39,7 +39,10 @@ object FlintInstance {
     val jobId = (meta \ "jobId").extract[String]
     val sessionId = (meta \ "sessionId").extract[String]
     val lastUpdateTime = (meta \ "lastUpdateTime").extract[Long]
-    val jobStartTime = (meta \ "jobStartTime").extract[Long]
+    val jobStartTime: Long = meta \ "jobStartTime" match {
+      case JNothing | JNull => 0L // Default value for missing or null jobStartTime
+      case value => value.extract[Long]
+    }
     // To handle the possibility of excludeJobIds not being present,
     // we use extractOpt which gives us an Option[Seq[String]].
     // If it is not present, it will return None, which we can then
@@ -75,7 +78,13 @@ object FlintInstance {
     val jobId = scalaSource("jobId").asInstanceOf[String]
     val sessionId = scalaSource("sessionId").asInstanceOf[String]
     val lastUpdateTime = scalaSource("lastUpdateTime").asInstanceOf[Long]
-    val jobStartTime = scalaSource("jobStartTime").asInstanceOf[Long]
+    // Safely extract 'jobStartTime' considering potential null or absence
+    // Safely extract 'jobStartTime' considering potential null or absence
+    val jobStartTime: Long = scalaSource.get("jobStartTime") match {
+      case Some(value: java.lang.Long) =>
+        value.longValue() // Convert java.lang.Long to Scala Long
+      case _ => 0L // Default value if 'jobStartTime' is null or not present
+    }
 
     // We safely handle the possibility of excludeJobIds being absent or not a list.
     val excludeJobIds: Seq[String] = scalaSource.get("excludeJobIds") match {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/app/FlintInstance.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/app/FlintInstance.scala
@@ -23,7 +23,6 @@ class FlintInstance(
     val sessionId: String,
     var state: String,
     val lastUpdateTime: Long,
-    // We need jobStartTime to check if HMAC token is expired or not
     val jobStartTime: Long = 0,
     val excludedJobIds: Seq[String] = Seq.empty[String],
     val error: Option[String] = None) {}
@@ -78,7 +77,7 @@ object FlintInstance {
     val jobId = scalaSource("jobId").asInstanceOf[String]
     val sessionId = scalaSource("sessionId").asInstanceOf[String]
     val lastUpdateTime = scalaSource("lastUpdateTime").asInstanceOf[Long]
-    // Safely extract 'jobStartTime' considering potential null or absence
+
     // Safely extract 'jobStartTime' considering potential null or absence
     val jobStartTime: Long = scalaSource.get("jobStartTime") match {
       case Some(value: java.lang.Long) =>

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -224,7 +224,7 @@ object FlintREPL extends Logging with FlintJobExecutor {
         val excludeJobIds = confExcludeJobs.split(",").toList // Convert Array to Lis
 
         if (excludeJobIds.contains(jobId)) {
-          // Edge case, current job is excluded, exit the application
+          logInfo(s"current job is excluded, exit the application.")
           return true
         }
 
@@ -234,7 +234,7 @@ object FlintREPL extends Logging with FlintJobExecutor {
           if (source != null) {
             val existingExcludedJobIds = parseExcludedJobIds(source)
             if (excludeJobIds.sorted == existingExcludedJobIds.sorted) {
-              // Edge case, duplicate job running, exit the application
+              logInfo("duplicate job running, exit the application.")
               return true
             }
           }


### PR DESCRIPTION
### Description
- Added handling for scenarios where jobStartTime is not present in the JSON input.
- Ensures FlintInstance deserialization remains robust and error-free even when jobStartTime is missing.

Testing:
  1. Extended unit tests to cover the new case.
  2. Conducted manual sanity tests to ensure stability and correctness.

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/152

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
