### PR TITLE
Improve Flint index monitor error handling

### DIFF
--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/package.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/package.scala
@@ -5,14 +5,32 @@
 
 package org.apache.spark.sql
 
+import java.util.concurrent.ScheduledExecutorService
+
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.catalog._
-import org.apache.spark.util.ShutdownHookManager
+import org.apache.spark.util.{ShutdownHookManager, ThreadUtils}
 
 /**
  * Flint utility methods that rely on access to private code in Spark SQL package.
  */
 package object flint {
+
+  /**
+   * Create daemon thread pool with the given thread group name and size.
+   *
+   * @param threadNamePrefix
+   *   thread group name
+   * @param numThreads
+   *   thread pool size
+   * @return
+   *   thread pool executor
+   */
+  def newDaemonThreadPoolScheduledExecutor(
+      threadNamePrefix: String,
+      numThreads: Int): ScheduledExecutorService = {
+    ThreadUtils.newDaemonThreadPoolScheduledExecutor(threadNamePrefix, numThreads)
+  }
 
   /**
    * Add shutdown hook to SparkContext with default priority.

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{doAnswer, spy}
+import org.opensearch.flint.OpenSearchTransactionSuite
+import org.opensearch.flint.spark.FlintSpark.RefreshMode._
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.sql.flint.newDaemonThreadPoolScheduledExecutor
+
+class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matchers {
+
+  /** Test table and index name */
+  private val testTable = "spark_catalog.default.flint_index_monitor_test"
+  private val testFlintIndex = getSkippingIndexName(testTable)
+  private val testLatestId: String = Base64.getEncoder.encodeToString(testFlintIndex.getBytes)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    createPartitionedTable(testTable)
+
+    // Replace mock executor with real one and change its delay
+    val realExecutor = newDaemonThreadPoolScheduledExecutor("flint-index-heartbeat", 1)
+    FlintSparkIndexMonitor.executor = spy(realExecutor)
+    doAnswer(invocation => {
+      // Delay 5 seconds to wait for refresh index done
+      realExecutor.scheduleWithFixedDelay(invocation.getArgument(0), 5, 1, TimeUnit.SECONDS)
+    }).when(FlintSparkIndexMonitor.executor)
+      .scheduleWithFixedDelay(any[Runnable], any[Long], any[Long], any[TimeUnit])
+  }
+
+  test("test") {
+    flint
+      .skippingIndex()
+      .onTable(testTable)
+      .addValueSet("name")
+      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+      .create()
+    flint.refreshIndex(testFlintIndex, INCREMENTAL)
+
+    // Wait for refresh complete and monitor thread start
+    val jobId = spark.streams.active.find(_.name == testFlintIndex).get.id.toString
+    awaitStreamingComplete(jobId)
+    Thread.sleep(5000L)
+
+    var (prevJobStartTime, prevLastUpdateTime) = getLatestTimestamp
+
+    // jobStartTime should stay same while lastUpdateTime keep updated
+    3 times { (jobStartTime, lastUpdateTime) =>
+      jobStartTime shouldBe prevJobStartTime
+      lastUpdateTime should be > prevLastUpdateTime
+      prevLastUpdateTime = lastUpdateTime
+    }
+  }
+
+  private def getLatestTimestamp: (Long, Long) = {
+    val latest = latestLogEntry(testLatestId)
+    (latest("jobStartTime").asInstanceOf[Long], latest("lastUpdateTime").asInstanceOf[Long])
+  }
+
+  private implicit class intWithTimes(n: Int) {
+    def times(f: (Long, Long) => Unit): Unit = {
+      1 to n foreach { _ =>
+        {
+          // Sleep longer than monitor interval 1 second
+          Thread.sleep(3000)
+
+          val (jobStartTime, lastUpdateTime) = getLatestTimestamp
+          f(jobStartTime, lastUpdateTime)
+        }
+      }
+    }
+  }
+}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
@@ -8,8 +8,12 @@ package org.opensearch.flint.spark
 import java.util.Base64
 import java.util.concurrent.TimeUnit
 
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{doAnswer, spy}
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
+import org.opensearch.client.RequestOptions
 import org.opensearch.flint.OpenSearchTransactionSuite
 import org.opensearch.flint.spark.FlintSpark.RefreshMode._
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
@@ -27,6 +31,10 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
   override def beforeAll(): Unit = {
     super.beforeAll()
     createPartitionedTable(testTable)
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
 
     // Replace mock executor with real one and change its delay
     val realExecutor = newDaemonThreadPoolScheduledExecutor("flint-index-heartbeat", 1)
@@ -36,9 +44,8 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
       realExecutor.scheduleWithFixedDelay(invocation.getArgument(0), 5, 1, TimeUnit.SECONDS)
     }).when(FlintSparkIndexMonitor.executor)
       .scheduleWithFixedDelay(any[Runnable], any[Long], any[Long], any[TimeUnit])
-  }
 
-  test("test") {
+    // Create an auto refreshed index for test
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -51,12 +58,40 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
     val jobId = spark.streams.active.find(_.name == testFlintIndex).get.id.toString
     awaitStreamingComplete(jobId)
     Thread.sleep(5000L)
+  }
 
+  override def afterEach(): Unit = {
+    flint.deleteIndex(testFlintIndex)
+    FlintSparkIndexMonitor.executor.shutdownNow()
+    super.afterEach()
+  }
+
+  test("job start time should not change and last update time keep updated") {
     var (prevJobStartTime, prevLastUpdateTime) = getLatestTimestamp
-
-    // jobStartTime should stay same while lastUpdateTime keep updated
     3 times { (jobStartTime, lastUpdateTime) =>
       jobStartTime shouldBe prevJobStartTime
+      lastUpdateTime should be > prevLastUpdateTime
+      prevLastUpdateTime = lastUpdateTime
+    }
+  }
+
+  test("monitor task should not terminate if any exception") {
+    // Block write on metadata log index
+    setWriteBlockOnMetadataLogIndex(true)
+    Thread.sleep(2000)
+
+    // Monitor task should stop working after blocking writes
+    var (_, prevLastUpdateTime) = getLatestTimestamp
+    1 times { (_, lastUpdateTime) =>
+      lastUpdateTime shouldBe prevLastUpdateTime
+    }
+
+    // Unblock write and wait for monitor task attempt to update again
+    setWriteBlockOnMetadataLogIndex(false)
+    Thread.sleep(2000)
+
+    // Monitor task continue working after unblocking write
+    3 times { (_, lastUpdateTime) =>
       lastUpdateTime should be > prevLastUpdateTime
       prevLastUpdateTime = lastUpdateTime
     }
@@ -79,5 +114,11 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
         }
       }
     }
+  }
+
+  private def setWriteBlockOnMetadataLogIndex(isBlock: Boolean): Unit = {
+    val request = new UpdateSettingsRequest(testMetaLogIndex)
+      .settings(Map("blocks.write" -> isBlock).asJava) // Blocking write operations
+    openSearchClient.indices().putSettings(request, RequestOptions.DEFAULT)
   }
 }


### PR DESCRIPTION
### Description

1. Avoid throwing exception which will cause all subsequent task executions cancelled
2. Follow REPL heartbeat updater to use Spark daemon thread pool

### Issues Resolved

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
