### PR TITLE
Enhance Logging for Job Cleanup and Reduce REPL Inactivity Timeout

### DIFF
--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
@@ -52,7 +52,6 @@ object FlintJob extends Logging with FlintJobExecutor {
      * Without this setup, Spark would not recognize names in the format `my_glue1.default`.
      */
     conf.set("spark.sql.defaultCatalog", dataSource)
-    val spark = createSparkSession(conf)
 
     val jobOperator =
       JobOperator(conf, query, dataSource, resultIndex, wait.equalsIgnoreCase("streaming"))

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -44,7 +44,7 @@ import org.apache.spark.util.ThreadUtils
 object FlintREPL extends Logging with FlintJobExecutor {
 
   private val HEARTBEAT_INTERVAL_MILLIS = 60000L
-  private val DEFAULT_INACTIVITY_LIMIT_MILLIS = 30 * 60 * 1000
+  private val DEFAULT_INACTIVITY_LIMIT_MILLIS = 10 * 60 * 1000
   private val MAPPING_CHECK_TIMEOUT = Duration(1, MINUTES)
   private val DEFAULT_QUERY_EXECUTION_TIMEOUT = Duration(10, MINUTES)
   private val DEFAULT_QUERY_WAIT_TIMEOUT_MILLIS = 10 * 60 * 1000

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -95,6 +95,7 @@ case class JobOperator(
 
     try {
       threadPool.shutdown()
+      logInfo("shut down thread threadpool")
     } catch {
       case e: Exception => logError("Fail to close threadpool", e)
     }
@@ -103,9 +104,10 @@ case class JobOperator(
   def stop(): Unit = {
     Try {
       spark.stop()
+      logInfo("stopped spark session")
     } match {
       case Success(_) =>
-      case Failure(e) => logError("unexpected error while shutdown", e)
+      case Failure(e) => logError("unexpected error while stopping spark session", e)
     }
   }
 }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql
+
+import java.util.concurrent.ThreadPoolExecutor
+
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
+import scala.concurrent.duration.{Duration, MINUTES}
+import scala.util.{Failure, Success, Try}
+
+import org.opensearch.flint.core.storage.OpenSearchUpdater
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.FlintJob.createSparkSession
+import org.apache.spark.sql.FlintREPL.{executeQuery, logInfo, updateFlintInstanceBeforeShutdown}
+import org.apache.spark.sql.flint.config.FlintSparkConf
+import org.apache.spark.util.ThreadUtils
+
+case class JobOperator(
+    sparkConf: SparkConf,
+    query: String,
+    dataSource: String,
+    resultIndex: String,
+    streaming: Boolean)
+    extends Logging
+    with FlintJobExecutor {
+  private val spark = createSparkSession(sparkConf)
+
+  // jvm shutdown hook
+  sys.addShutdownHook(stop())
+
+  def start(): Unit = {
+    val threadPool = ThreadUtils.newDaemonFixedThreadPool(1, "check-create-index")
+    implicit val executionContext = ExecutionContext.fromExecutor(threadPool)
+
+    var dataToWrite: Option[DataFrame] = None
+    val startTime = System.currentTimeMillis()
+    // osClient needs spark session to be created first to get FlintOptions initialized.
+    // Otherwise, we will have connection exception from EMR-S to OS.
+    val osClient = new OSClient(FlintSparkConf().flintOptions())
+    var exceptionThrown = true
+    try {
+      val futureMappingCheck = Future {
+        checkAndCreateIndex(osClient, resultIndex)
+      }
+      val data = executeQuery(spark, query, dataSource, "", "")
+
+      val mappingCheckResult = ThreadUtils.awaitResult(futureMappingCheck, Duration(1, MINUTES))
+      dataToWrite = Some(mappingCheckResult match {
+        case Right(_) => data
+        case Left(error) =>
+          getFailedData(spark, dataSource, error, "", query, "", startTime, currentTimeProvider)
+      })
+      exceptionThrown = false
+    } catch {
+      case e: TimeoutException =>
+        val error = s"Getting the mapping of index $resultIndex timed out"
+        logError(error, e)
+        dataToWrite = Some(
+          getFailedData(spark, dataSource, error, "", query, "", startTime, currentTimeProvider))
+      case e: Exception =>
+        val error = processQueryException(e, spark, dataSource, query, "", "")
+        dataToWrite = Some(
+          getFailedData(spark, dataSource, error, "", query, "", startTime, currentTimeProvider))
+    } finally {
+      cleanUpResources(exceptionThrown, threadPool, dataToWrite, resultIndex, osClient)
+    }
+  }
+
+  def cleanUpResources(
+      exceptionThrown: Boolean,
+      threadPool: ThreadPoolExecutor,
+      dataToWrite: Option[DataFrame],
+      resultIndex: String,
+      osClient: OSClient): Unit = {
+    try {
+      dataToWrite.foreach(df => writeDataFrameToOpensearch(df, resultIndex, osClient))
+    } catch {
+      case e: Exception => logError("fail to write to result index", e)
+    }
+
+    try {
+      // Stop SparkSession if streaming job succeeds
+      if (!exceptionThrown && streaming) {
+        // wait if any child thread to finish before the main thread terminates
+        spark.streams.awaitAnyTermination()
+      }
+    } catch {
+      case e: Exception => logError("streaming job failed", e)
+    }
+
+    try {
+      threadPool.shutdown()
+    } catch {
+      case e: Exception => logError("Fail to close threadpool", e)
+    }
+  }
+
+  def stop(): Unit = {
+    Try {
+      spark.stop()
+    } match {
+      case Success(_) =>
+      case Failure(e) => logError("unexpected error while shutdown", e)
+    }
+  }
+}

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -117,7 +117,7 @@ class FlintREPLTest
     }
 
     // Here, we're injecting our mockShutdownHookManager into the method
-    FlintREPL.createShutdownHook(
+    FlintREPL.addShutdownHook(
       flintSessionIndexUpdater,
       osClient,
       sessionIndex,


### PR DESCRIPTION
### Description

- Added detailed logging to improve visibility during streaming job cleanup.
- Decreased REPL job inactivity timeout from 30 to 10 minutes..

Tested manually to ensure new logs are correctly displayed during streaming job cleanup.

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/157

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
