### PR TITLE
Enhance Session Job Handling and Heartbeat Mechanism

### DIFF
--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/app/FlintInstanceTest.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/app/FlintInstanceTest.scala
@@ -39,7 +39,7 @@ class FlintInstanceTest extends SparkFunSuite with Matchers {
       1620000001000L,
       excludedJobIds)
     val currentTime = System.currentTimeMillis()
-    val json = FlintInstance.serialize(instance, currentTime)
+    val json = FlintInstance.serializeWithoutJobId(instance, currentTime)
 
     json should include(""""applicationId":"app-123"""")
     json should not include (""""jobId":"job-456"""")
@@ -80,7 +80,7 @@ class FlintInstanceTest extends SparkFunSuite with Matchers {
       Seq.empty[String],
       Some("Some error occurred"))
     val currentTime = System.currentTimeMillis()
-    val json = FlintInstance.serialize(instance, currentTime)
+    val json = FlintInstance.serializeWithoutJobId(instance, currentTime)
 
     json should include(""""error":"Some error occurred"""")
   }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -317,16 +317,23 @@ object FlintREPL extends Logging with FlintJobExecutor {
   }
 
   private def setupFlintJob(
-                             applicationId: String,
-                             jobId: String,
-                             sessionId: String,
-                             flintSessionIndexUpdater: OpenSearchUpdater,
-                             sessionIndex: String,
-                             jobStartTime: Long,
-                             excludeJobIds: Seq[String] = Seq.empty[String]): Unit = {
+      applicationId: String,
+      jobId: String,
+      sessionId: String,
+      flintSessionIndexUpdater: OpenSearchUpdater,
+      sessionIndex: String,
+      jobStartTime: Long,
+      excludeJobIds: Seq[String] = Seq.empty[String]): Unit = {
     val includeJobId = !excludeJobIds.isEmpty && !excludeJobIds.contains(jobId)
     val currentTime = currentTimeProvider.currentEpochMillis()
-    val flintJob = new FlintInstance(applicationId, jobId, sessionId, "running", currentTime, jobStartTime, excludeJobIds)
+    val flintJob = new FlintInstance(
+      applicationId,
+      jobId,
+      sessionId,
+      "running",
+      currentTime,
+      jobStartTime,
+      excludeJobIds)
 
     val serializedFlintInstance = if (includeJobId) {
       FlintInstance.serialize(flintJob, currentTime, true)
@@ -336,7 +343,8 @@ object FlintREPL extends Logging with FlintJobExecutor {
 
     flintSessionIndexUpdater.upsert(sessionId, serializedFlintInstance)
 
-    logDebug(s"""Updated job: {"jobid": ${flintJob.jobId}, "sessionId": ${flintJob.sessionId}} from $sessionIndex""")
+    logDebug(
+      s"""Updated job: {"jobid": ${flintJob.jobId}, "sessionId": ${flintJob.sessionId}} from $sessionIndex""")
   }
 
   def handleSessionError(

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -81,7 +81,8 @@ class FlintREPLTest
       "session1",
       threadPool,
       osClient,
-      "sessionIndex")
+      "sessionIndex",
+      0)
 
     // Verifications
     verify(osClient, atLeastOnce()).getDoc("sessionIndex", "session1")


### PR DESCRIPTION
### Description
This commit introduces two key improvements:
1. An initial delay is added to start the heartbeat mechanism, reducing the risk of concurrent update conflicts.
2. The 'jobId' in the session store is updated at the beginning to properly manage and evict old jobs for the same session.

Testing Performed:
1. Manual sanity testing was conducted.
2. It was ensured that old jobs eventually exit after a new job for the same session starts.
3. The functionality of the heartbeat mechanism was verified to still work effectively.

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/162
https://github.com/opensearch-project/opensearch-spark/issues/159
https://github.com/opensearch-project/opensearch-spark/issues/145

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
