### PR TITLE
Request index not exist handling

### DIFF
--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
@@ -29,6 +29,18 @@ public interface FlintClient {
   <T> OptimisticTransaction<T> startTransaction(String indexName, String dataSourceName);
 
   /**
+   *
+   * Start a new optimistic transaction.
+   *
+   * @param indexName index name
+   * @param dataSourceName TODO: read from elsewhere in future
+   * @param forceInit forceInit create empty translog if not exist.
+   * @return transaction handle
+   */
+  <T> OptimisticTransaction<T> startTransaction(String indexName, String dataSourceName,
+      boolean forceInit);
+
+  /**
    * Create a Flint index with the metadata given.
    *
    * @param indexName index name

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/FlintMetadataLogEntry.scala
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/FlintMetadataLogEntry.scala
@@ -7,6 +7,7 @@ package org.opensearch.flint.core.metadata.log
 
 import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState
 import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState.IndexState
+import org.opensearch.index.seqno.SequenceNumbers.{UNASSIGNED_PRIMARY_TERM, UNASSIGNED_SEQ_NO}
 
 /**
  * Flint metadata log entry. This is temporary and will merge field in FlintMetadata here and move
@@ -92,4 +93,80 @@ object FlintMetadataLogEntry {
         .getOrElse(IndexState.UNKNOWN)
     }
   }
+
+  val QUERY_EXECUTION_REQUEST_MAPPING: String =
+    """{
+      |  "dynamic": false,
+      |  "properties": {
+      |    "version": {
+      |      "type": "keyword"
+      |    },
+      |    "type": {
+      |      "type": "keyword"
+      |    },
+      |    "state": {
+      |      "type": "keyword"
+      |    },
+      |    "statementId": {
+      |      "type": "keyword"
+      |    },
+      |    "applicationId": {
+      |      "type": "keyword"
+      |    },
+      |    "sessionId": {
+      |      "type": "keyword"
+      |    },
+      |    "sessionType": {
+      |      "type": "keyword"
+      |    },
+      |    "error": {
+      |      "type": "text"
+      |    },
+      |    "lang": {
+      |      "type": "keyword"
+      |    },
+      |    "query": {
+      |      "type": "text"
+      |    },
+      |    "dataSourceName": {
+      |      "type": "keyword"
+      |    },
+      |    "submitTime": {
+      |      "type": "date",
+      |      "format": "strict_date_time||epoch_millis"
+      |    },
+      |    "jobId": {
+      |      "type": "keyword"
+      |    },
+      |    "lastUpdateTime": {
+      |      "type": "date",
+      |      "format": "strict_date_time||epoch_millis"
+      |    },
+      |    "queryId": {
+      |      "type": "keyword"
+      |    },
+      |    "excludeJobIds": {
+      |      "type": "keyword"
+      |    }
+      |  }
+      |}""".stripMargin
+
+  val QUERY_EXECUTION_REQUEST_SETTINGS: String =
+    """{
+      |  "index": {
+      |    "number_of_shards": "1",
+      |    "auto_expand_replicas": "0-2",
+      |    "number_of_replicas": "0"
+      |  }
+      |}""".stripMargin
+
+  def failLogEntry(dataSourceName: String, error: String): FlintMetadataLogEntry =
+    FlintMetadataLogEntry(
+      "",
+      UNASSIGNED_SEQ_NO,
+      UNASSIGNED_PRIMARY_TERM,
+      0L,
+      IndexState.FAILED,
+      dataSourceName,
+      error)
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -116,6 +116,7 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
             new IndexRequest()
                 .index(metaLogIndexName)
                 .id(logEntryWithId.id())
+                .setRefreshPolicy(RefreshPolicy.WAIT_UNTIL)
                 .source(logEntryWithId.toJson(), XContentType.JSON),
             RequestOptions.DEFAULT));
   }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -5,12 +5,6 @@
 
 package org.opensearch.flint.core.storage;
 
-import static org.opensearch.action.support.WriteRequest.RefreshPolicy;
-
-import java.io.IOException;
-import java.util.Base64;
-import java.util.Optional;
-import java.util.logging.Logger;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.get.GetRequest;
@@ -19,10 +13,19 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.flint.core.FlintClient;
 import org.opensearch.flint.core.metadata.log.FlintMetadataLog;
 import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.SEVERE;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy;
 
 /**
  * Flint metadata log in OpenSearch store. For now use single doc instead of maintaining history
@@ -57,6 +60,11 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
   public FlintMetadataLogEntry add(FlintMetadataLogEntry logEntry) {
     // TODO: use single doc for now. this will be always append in future.
     FlintMetadataLogEntry latest;
+    if (!exists()) {
+      String errorMsg = "Flint Metadata Log index not found " + metaLogIndexName;
+      LOG.log(SEVERE, errorMsg);
+      throw new IllegalStateException(errorMsg);
+    }
     if (logEntry.id().isEmpty()) {
       latest = createLogEntry(logEntry);
     } else {
@@ -145,6 +153,15 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
       return logEntry;
     } catch (OpenSearchException | IOException e) {
       throw new IllegalStateException("Failed to write log entry " + logEntry, e);
+    }
+  }
+
+  private boolean exists() {
+    LOG.info("Checking if Flint index exists " + metaLogIndexName);
+    try (RestHighLevelClient client = flintClient.createClient()) {
+      return client.indices().exists(new GetIndexRequest(metaLogIndexName), RequestOptions.DEFAULT);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to check if Flint index exists " + metaLogIndexName, e);
     }
   }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -104,7 +104,7 @@ class FlintSpark(val spark: SparkSession) extends Logging {
       val metadata = index.metadata()
       try {
         flintClient
-          .startTransaction(indexName, dataSourceName)
+          .startTransaction(indexName, dataSourceName, true)
           .initialLog(latest => latest.state == EMPTY || latest.state == DELETED)
           .transientLog(latest => latest.copy(state = CREATING))
           .finalLog(latest => latest.copy(state = ACTIVE))

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
@@ -16,7 +16,6 @@ import org.opensearch.client.opensearch.OpenSearchClient
 import org.opensearch.client.transport.rest_client.RestClientTransport
 import org.opensearch.flint.OpenSearchSuite
 import org.opensearch.flint.core.metadata.FlintMetadata
-import org.opensearch.flint.core.metadata.log.OptimisticTransaction.NoOptimisticTransaction
 import org.opensearch.flint.core.storage.{FlintOpenSearchClient, OpenSearchScrollReader}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -31,9 +30,10 @@ class FlintOpenSearchClientSuite extends AnyFlatSpec with OpenSearchSuite with M
 
   behavior of "Flint OpenSearch client"
 
-  it should "start no optimistic transaction if metadata log index doesn't exists" in {
-    val transaction = flintClient.startTransaction("test", "non-exist-index")
-    transaction shouldBe a[NoOptimisticTransaction[AnyRef]]
+  it should "throw IllegalStateException if metadata log index doesn't exists" in {
+    the[IllegalStateException] thrownBy {
+      flintClient.startTransaction("test", "non-exist-index")
+    }
   }
 
   it should "create index successfully" in {

--- a/integ-test/src/test/scala/org/opensearch/flint/core/OpenSearchUpdaterSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/OpenSearchUpdaterSuite.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core
+
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
+import org.opensearch.action.get.{GetRequest, GetResponse}
+import org.opensearch.client.RequestOptions
+import org.opensearch.flint.OpenSearchTransactionSuite
+import org.opensearch.flint.app.FlintInstance
+import org.opensearch.flint.core.storage.{FlintOpenSearchClient, OpenSearchUpdater}
+import org.scalatest.matchers.should.Matchers
+
+class OpenSearchUpdaterSuite extends OpenSearchTransactionSuite with Matchers {
+  val sessionId = "sessionId"
+  val timestamp = 1700090926955L
+  val flintJob =
+    new FlintInstance(
+      "applicationId",
+      "jobId",
+      sessionId,
+      "running",
+      timestamp,
+      timestamp,
+      Seq(""))
+  var flintClient: FlintClient = _
+  var updater: OpenSearchUpdater = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    flintClient = new FlintOpenSearchClient(new FlintOptions(openSearchOptions.asJava));
+    updater = new OpenSearchUpdater(
+      testMetaLogIndex,
+      new FlintOpenSearchClient(new FlintOptions(openSearchOptions.asJava)))
+  }
+
+  test("upsert flintJob should success") {
+    updater.upsert(sessionId, FlintInstance.serialize(flintJob, timestamp))
+    getFlintInstance(sessionId)._2.lastUpdateTime shouldBe timestamp
+  }
+
+  test("index is deleted when upsert flintJob should throw IllegalStateException") {
+    deleteIndex(testMetaLogIndex)
+
+    the[IllegalStateException] thrownBy {
+      updater.upsert(sessionId, FlintInstance.serialize(flintJob, timestamp))
+    }
+  }
+
+  test("update flintJob should success") {
+    updater.upsert(sessionId, FlintInstance.serialize(flintJob, timestamp))
+
+    val newTimestamp = 1700090926956L
+    updater.update(sessionId, FlintInstance.serialize(flintJob, newTimestamp))
+    getFlintInstance(sessionId)._2.lastUpdateTime shouldBe newTimestamp
+  }
+
+  test("index is deleted when update flintJob should throw IllegalStateException") {
+    deleteIndex(testMetaLogIndex)
+
+    the[IllegalStateException] thrownBy {
+      updater.update(sessionId, FlintInstance.serialize(flintJob, timestamp))
+    }
+  }
+
+  test("updateIf flintJob should success") {
+    updater.upsert(sessionId, FlintInstance.serialize(flintJob, timestamp))
+    val (resp, latest) = getFlintInstance(sessionId)
+
+    val newTimestamp = 1700090926956L
+    updater.updateIf(
+      sessionId,
+      FlintInstance.serialize(latest, newTimestamp),
+      resp.getSeqNo,
+      resp.getPrimaryTerm)
+    getFlintInstance(sessionId)._2.lastUpdateTime shouldBe newTimestamp
+  }
+
+  test("index is deleted when updateIf flintJob should throw IllegalStateException") {
+    updater.upsert(sessionId, FlintInstance.serialize(flintJob, timestamp))
+    val (resp, latest) = getFlintInstance(sessionId)
+
+    deleteIndex(testMetaLogIndex)
+
+    the[IllegalStateException] thrownBy {
+      updater.updateIf(
+        sessionId,
+        FlintInstance.serialize(latest, timestamp),
+        resp.getSeqNo,
+        resp.getPrimaryTerm)
+    }
+  }
+
+  def getFlintInstance(docId: String): (GetResponse, FlintInstance) = {
+    val response =
+      openSearchClient.get(new GetRequest(testMetaLogIndex, docId), RequestOptions.DEFAULT)
+    (response, FlintInstance.deserializeFromMap(response.getSourceAsMap))
+  }
+}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
@@ -29,8 +29,18 @@ class FlintSparkIndexJobITSuite extends OpenSearchTransactionSuite with Matchers
   }
 
   override def afterEach(): Unit = {
-    super.afterEach() // must clean up metadata log first and then delete
-    flint.deleteIndex(testIndex)
+
+    /**
+     * Todo, if state is not valid, will throw IllegalStateException. Should check flint
+     * .isRefresh before cleanup resource. Current solution, (1) try to delete flint index, (2) if
+     * failed, delete index itself.
+     */
+    try {
+      flint.deleteIndex(testIndex)
+    } catch {
+      case _: IllegalStateException => deleteIndex(testIndex)
+    }
+    super.afterEach()
   }
 
   test("recover should exit if index doesn't exist") {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkTransactionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkTransactionITSuite.scala
@@ -33,8 +33,18 @@ class FlintSparkTransactionITSuite extends OpenSearchTransactionSuite with Match
   }
 
   override def afterEach(): Unit = {
+
+    /**
+     * Todo, if state is not valid, will throw IllegalStateException. Should check flint
+     * .isRefresh before cleanup resource. Current solution, (1) try to delete flint index, (2) if
+     * failed, delete index itself.
+     */
+    try {
+      flint.deleteIndex(testFlintIndex)
+    } catch {
+      case _: IllegalStateException => deleteIndex(testFlintIndex)
+    }
     super.afterEach()
-    flint.deleteIndex(testFlintIndex)
   }
 
   test("create index") {

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -6,14 +6,10 @@
 package org.apache.spark.sql
 
 import java.net.ConnectException
-import java.time.Instant
-import java.util.Map
 import java.util.concurrent.ScheduledExecutorService
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, TimeoutException}
-import scala.concurrent.duration._
-import scala.concurrent.duration.{Duration, MINUTES}
+import scala.concurrent.duration.{Duration, MINUTES, _}
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
@@ -46,7 +42,7 @@ object FlintREPL extends Logging with FlintJobExecutor {
   private val HEARTBEAT_INTERVAL_MILLIS = 60000L
   private val DEFAULT_INACTIVITY_LIMIT_MILLIS = 10 * 60 * 1000
   private val MAPPING_CHECK_TIMEOUT = Duration(1, MINUTES)
-  private val DEFAULT_QUERY_EXECUTION_TIMEOUT = Duration(10, MINUTES)
+  private val DEFAULT_QUERY_EXECUTION_TIMEOUT = Duration(30, MINUTES)
   private val DEFAULT_QUERY_WAIT_TIMEOUT_MILLIS = 10 * 60 * 1000
   val INITIAL_DELAY_MILLIS = 3000L
 


### PR DESCRIPTION
### Description
* In **Flint.createIndex**, create ***query_execution_request*** index if not exist 
* Check ***query_execution_request,*** before write to ***query_execution_request* **index, if index not exist, throw IllegalStateException, emit metrics **QueryExecutionRequestIndexNotFound**.
* When write
    * In translog state update, ***query_execution_request* **index, service not available / write block, throw IllegalStateException. Emit metrics **QueryExecutionRequestIndexWriteFail** 
    * heartbeat update, ***query_execution_request* **index, service not available / write block, catch exception, Emit metrics **QueryExecutionRequestIndexWriteFail.** After 5 times, Monitor system detect the job lastUpdateTime is stale. if index is green, Monitor system retry EMR-S job. if index is RED / write block. Monitor system should cut ticket.
* When read 
    * In translog state init***, query_execution_request*** index, read block, throw IllegalStateException, Emit metrics **QueryExecutionRequestIndexReadFail**.
    * heartbeat update, ***query_execution_request* **index, service not available / write block, catch exception, Emit metrics **QueryExecutionRequestIndexReadFail.** After 5 times, Monitor system detect the job lastUpdateTime is stale. if index is green, Monitor system retry EMR-S job. if index is read block, Monitor system should cut ticket.

Detail info in https://github.com/opensearch-project/opensearch-spark/issues/166

### Issues Resolved
* https://github.com/opensearch-project/opensearch-spark/issues/166
* https://github.com/opensearch-project/opensearch-spark/issues/167

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
