### PR TITLE
Migrate resutIndex and requestIndex state inconsistency issue

### DIFF
--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -273,7 +273,8 @@ object FlintREPL extends Logging with FlintJobExecutor {
       var canPickUpNextStatement = true
       while (currentTimeProvider
           .currentEpochMillis() - lastActivityTime <= commandContext.inactivityLimitMillis && canPickUpNextStatement) {
-        logDebug(s"""read from ${commandContext.sessionIndex}""")
+        logInfo(
+          s"""read from ${commandContext.sessionIndex}, sessionId: $commandContext.sessionId""")
         val flintReader: FlintReader =
           createQueryReader(
             commandContext.osClient,
@@ -339,7 +340,7 @@ object FlintREPL extends Logging with FlintJobExecutor {
 
     flintSessionIndexUpdater.upsert(sessionId, serializedFlintInstance)
 
-    logDebug(
+    logInfo(
       s"""Updated job: {"jobid": ${flintJob.jobId}, "sessionId": ${flintJob.sessionId}} from $sessionIndex""")
   }
 
@@ -524,6 +525,9 @@ object FlintREPL extends Logging with FlintJobExecutor {
       osClient: OSClient): Unit = {
     try {
       dataToWrite.foreach(df => writeDataFrameToOpensearch(df, resultIndex, osClient))
+      // todo. it is migration plan to handle https://github
+      //  .com/opensearch-project/sql/issues/2436. Remove sleep after issue fixed in plugin.
+      Thread.sleep(2000)
       if (flintCommand.isRunning() || flintCommand.isWaiting()) {
         // we have set failed state in exception handling
         flintCommand.complete()
@@ -691,7 +695,7 @@ object FlintREPL extends Logging with FlintJobExecutor {
           queryWaitTimeMillis)
     }
 
-    logDebug(s"command complete: $flintCommand")
+    logInfo(s"command complete: $flintCommand")
     (dataToWrite, verificationResult)
   }
 


### PR DESCRIPTION
### Description
* Add sleep 2 seconds between write result index and update state.
  * choose 2 seconds because by default index refresh interval is 1s. add 1s as buffer.
  * sleep 2s does not impact current query latency.
  * sleep 2s increase query latency of query in waiting state. we does not expect much query in the queue, we accept this risk for now.
* It is a migration plan, it does fix the bug.
* Test with script and spark, 50 times, not issue found.

More detail in https://github.com/opensearch-project/opensearch-spark/issues/171

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/171

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
