### PR TITLE
Fix shutdown bug due to non-daemon thread in driver

### DIFF
--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -6,7 +6,6 @@
 package org.apache.spark.sql
 
 import java.util.Locale
-import java.util.concurrent.ThreadPoolExecutor
 
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import scala.concurrent.duration.{Duration, MINUTES}
@@ -313,6 +312,11 @@ trait FlintJobExecutor {
       case e: IllegalStateException
           if e.getCause().getMessage().contains("index_not_found_exception") =>
         createIndex(osClient, resultIndex, resultIndexMapping)
+      case e: InterruptedException =>
+        val error = s"Interrupted by the main thread: ${e.getMessage}"
+        Thread.currentThread().interrupt() // Preserve the interrupt status
+        logError(error, e)
+        Left(error)
       case e: Exception =>
         val error = s"Failed to verify existing mapping: ${e.getMessage}"
         logError(error, e)

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/util/ThreadPoolFactory.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/util/ThreadPoolFactory.scala
@@ -5,10 +5,66 @@
 
 package org.apache.spark.sql.util
 
-import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
 
-trait ThreadPoolFactory {
+import scala.collection.JavaConverters._
+
+import org.apache.spark.internal.Logging
+
+trait ThreadPoolFactory extends Logging {
   def newDaemonThreadPoolScheduledExecutor(
       threadNamePrefix: String,
       numThreads: Int): ScheduledExecutorService
+
+  def shutdownThreadPool(executor: ScheduledExecutorService): Unit = {
+    logInfo(s"terminate executor ${executor}")
+    executor.shutdown() // Disable new tasks from being submitted
+
+    try {
+      // Wait a while for existing tasks to terminate
+      if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+        logWarning("Executor did not terminate in the specified time.")
+        val tasksNotExecuted = executor.shutdownNow() // Cancel currently executing tasks
+        // Log the tasks that were awaiting execution
+        logInfo(s"The following tasks were cancelled: $tasksNotExecuted")
+
+        // Wait a while for tasks to respond to being cancelled
+        if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+          logError("Thread pool did not terminate after shutdownNow.")
+        }
+      }
+    } catch {
+      case ie: InterruptedException =>
+        // (Re-)Cancel if current thread also interrupted
+        executor.shutdownNow()
+        // Log the interrupted status
+        logError("Shutdown interrupted", ie)
+        // Preserve interrupt status
+        Thread.currentThread().interrupt()
+    }
+  }
+
+  /**
+   * Checks if there are any non-daemon threads other than the "main" thread.
+   *
+   * @return
+   *   true if non-daemon threads other than "main" are active, false otherwise.
+   */
+  def hasNonDaemonThreadsOtherThanMain(): Boolean = {
+    // Log thread information and check for non-daemon threads
+    Thread.getAllStackTraces.keySet.asScala.exists { t =>
+      val thread = t.asInstanceOf[Thread]
+      val isNonDaemon = !thread.isDaemon && thread.getName != "main"
+
+      // Log the thread information
+      logInfo(s"Name: ${thread.getName}; IsDaemon: ${thread.isDaemon}; State: ${thread.getState}")
+
+      // Log the stack trace
+      Option(Thread.getAllStackTraces.get(thread)).foreach(_.foreach(traceElement =>
+        logInfo(s"    at $traceElement")))
+
+      // Return true if a non-daemon thread is found
+      isNonDaemon
+    }
+  }
 }


### PR DESCRIPTION
### Description
Resolve an issue where a non-daemon thread, potentially created by a bug in dependencies, prevents the driver from shutting down properly. The fix ensures the JVM exits gracefully, avoiding resource leaks and preventing hanging EMR-s jobs.

Tests:
- Reproduced the bug to confirm the issue.
- Applied the fix and verified that the driver now shuts down as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
