### PR TITLE
Fixed the GitHub id column for Yang-DB in Maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,7 +12,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Chen Dai        | [dai-chen](https://github.com/dai-chen)         | Amazon      |
 | Vamsi Manohar   | [vamsi-amazon](https://github.com/vamsi-amazon) | Amazon      |
 | Peng Huo        | [penghuo](https://github.com/penghuo)           | Amazon      |
-| Lior Perry      | [yangdb](https://github.com/YANG-DB)            | Amazon      |
+| Lior Perry      | [YANG-DB](https://github.com/YANG-DB)            | Amazon      |
 | Sean Kao        | [seankao-az](https://github.com/seankao-az)     | Amazon      |
 | Anirudha Jadhav | [anirudha](https://github.com/anirudha)         | Amazon      |
 | Kaituo Li       | [kaituo](https://github.com/kaituo)             | Amazon      |


### PR DESCRIPTION
### Description
Our workflow for checking maintainers file against codeowners checks the username in the square brackets. I've updated this accordingly. 

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
