### PR TITLE
Changes for adding default dimensions in CWSink.

### DIFF
--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/reporter/DimensionedName.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/reporter/DimensionedName.java
@@ -28,7 +28,8 @@ public class DimensionedName {
         if (matcher.find() && matcher.groupCount() == 2) {
             final DimensionedNameBuilder builder = new DimensionedNameBuilder(matcher.group(1).trim());
             for (String t : matcher.group(2).split(",")) {
-                final String[] keyAndValue = t.split(":");
+                //## acts as a distinct separator.
+                final String[] keyAndValue = t.split("##");
                 builder.withDimension(keyAndValue[0].trim(), keyAndValue[1].trim());
             }
             return builder.build();
@@ -59,7 +60,7 @@ public class DimensionedName {
                 final StringBuilder sb = new StringBuilder(this.name);
                 sb.append('[');
                 sb.append(this.dimensions.values().stream()
-                        .map(dimension -> dimension.getName() + ":" + dimension.getValue())
+                        .map(dimension -> dimension.getName() + "##" + dimension.getValue())
                         .collect(Collectors.joining(",")));
                 sb.append(']');
 

--- a/flint-core/src/test/java/opensearch/flint/core/metrics/reporter/DimensionedNameTest.java
+++ b/flint-core/src/test/java/opensearch/flint/core/metrics/reporter/DimensionedNameTest.java
@@ -11,7 +11,7 @@ import org.opensearch.flint.core.metrics.reporter.DimensionedName;
 public class DimensionedNameTest {
     @Test
     public void canDecodeDimensionedString() {
-        final String dimensioned = "test[key1:val1,key2:val2,key3:val3]";
+        final String dimensioned = "test[key1##val1,key2##val2,key3##val3]";
 
         final DimensionedName dimensionedName = DimensionedName.decode(dimensioned);
 
@@ -32,7 +32,7 @@ public class DimensionedNameTest {
                 .withDimension("key3", "val3")
                 .build();
 
-        Assertions.assertEquals("test[key1:val1,key2:val2,key3:val3]", dimensionedName.encode());
+        Assertions.assertEquals("test[key1##val1,key2##val2,key3##val3]", dimensionedName.encode());
     }
 
     @Test
@@ -48,8 +48,8 @@ public class DimensionedNameTest {
                 .withDimension("key3", "new_value")
                 .withDimension("key4", "val4").build();
 
-        Assertions.assertEquals("test[key1:val1,key2:val2,key3:val3]", dimensionedName.encode());
-        Assertions.assertEquals("test[key1:val1,key2:val2,key3:new_value,key4:val4]",
+        Assertions.assertEquals("test[key1##val1,key2##val2,key3##val3]", dimensionedName.encode());
+        Assertions.assertEquals("test[key1##val1,key2##val2,key3##new_value,key4##val4]",
             derivedDimensionedName.encode());
     }
 }


### PR DESCRIPTION
### Description
* Added FlintMetricSource, which will be used in upcoming PRs for publish all kinds of metrics.
* Added default dimensions of domainId, jobId, applicationId while publishing metrics in CloudWatch Sink.
* Removed prefixes appended to metricNames. For eg:
Previous Metric Name: 
**driver.00fg29jd50i99g0m.LiveListenerBus.queue.appStatus.listenerProcessingTime**
Current Metric Name:
**LiveListenerBus.queue.appStatus.listenerProcessingTime** 
* Changed the separator in DimensionedName encoder to "##" to remove conflicts with names containing ": "


Sample Metrics Testing:
<img width="1135" alt="Screenshot 2024-01-08 at 8 10 32 AM" src="https://github.com/opensearch-project/opensearch-spark/assets/99925918/11077084-2eb0-4368-8a76-ca824e331a4c">




### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
