### PR TITLE
bug fix, support array datatype in MV

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -198,7 +198,7 @@ object FlintSparkMaterializedView {
         .sql(query)
         .schema
         .map { field =>
-          field.name -> field.dataType.typeName
+          field.name -> field.dataType.simpleString
         }
         .toMap
       FlintSparkMaterializedView(mvName, query, outputSchema, indexOptions)

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
@@ -42,6 +42,9 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
                           |    },
                           |    "textField": {
                           |      "type": "text"
+                          |    },
+                          |    "binaryField": {
+                          |      "type": "binary"
                           |    }
                           |  }
                           |}""".stripMargin
@@ -59,6 +62,7 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
           StringType,
           true,
           new MetadataBuilder().putString("osType", "text").build()) ::
+        StructField("binaryField", BinaryType, true) ::
         Nil)
 
     FlintDataType.serialize(sparkStructType) shouldBe compactJson(flintDataType)
@@ -190,6 +194,40 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
         Nil)
     FlintDataType.deserialize(flintDataType) should contain theSameElementsAs sparkStructType
     FlintDataType.serialize(sparkStructType) shouldBe compactJson(flintDataType)
+  }
+
+  test("spark array type map to should map to array element type in OpenSearch") {
+    val flintDataType = """{
+                          |  "properties": {
+                          |    "varcharField": {
+                          |      "type": "keyword"
+                          |    },
+                          |    "charField": {
+                          |      "type": "keyword"
+                          |    }
+                          |  }
+                          |}""".stripMargin
+    val sparkStructType =
+      StructType(
+        StructField("arrayIntField", ArrayType(IntegerType), true) ::
+          StructField(
+            "arrayObjectField",
+            StructType(StructField("booleanField", BooleanType, true) :: Nil),
+            true) :: Nil)
+    FlintDataType.serialize(sparkStructType) shouldBe compactJson(s"""{
+         |  "properties": {
+         |    "arrayIntField": {
+         |      "type": "integer"
+         |    },
+         |    "arrayObjectField": {
+         |      "properties": {
+         |        "booleanField":{
+         |          "type": "boolean"
+         |        }
+         |      }
+         |    }
+         |  }
+         |}""".stripMargin)
   }
 
   def compactJson(json: String): String = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -70,7 +70,7 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
          |      "columnType": "timestamp"
          |    },{
          |      "columnName": "count",
-         |      "columnType": "long"
+         |      "columnType": "bigint"
          |    }],
          |    "options": {
          |      "auto_refresh": "true",
@@ -197,7 +197,9 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
         Map(
           "auto_refresh" -> "true",
           "checkpoint_location" -> checkpointDir.getAbsolutePath,
-          "watermark_delay" -> "1 Minute")) // This must be small to ensure window closed soon
+          "watermark_delay" -> "1 Minute"
+        )
+      ) // This must be small to ensure window closed soon
 
       flint
         .materializedView()

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -157,6 +157,48 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
     sql(s"CREATE MATERIALIZED VIEW IF NOT EXISTS $testMvName AS $testQuery")
   }
 
+  test("issue 112, https://github.com/opensearch-project/opensearch-spark/issues/112") {
+    val tableName = "spark_catalog.default.issue112"
+    createTableIssue112(tableName)
+    sql(s"""
+           |CREATE MATERIALIZED VIEW $testMvName AS
+           |    SELECT
+           |    rs.resource.attributes.key as resource_key,
+           |    rs.resource.attributes.value.stringValue as resource_value,
+           |    ss.scope.name as scope_name,
+           |    ss.scope.version as scope_version,
+           |    span.attributes.key as span_key,
+           |    span.attributes.value.intValue as span_int_value,
+           |    span.attributes.value.stringValue as span_string_value,
+           |    span.endTimeUnixNano,
+           |    span.kind,
+           |    span.name as span_name,
+           |    span.parentSpanId,
+           |    span.spanId,
+           |    span.startTimeUnixNano,
+           |    span.traceId
+           |    FROM $tableName
+           |    LATERAL VIEW
+           |    EXPLODE(resourceSpans) as rs
+           |    LATERAL VIEW
+           |    EXPLODE(rs.scopeSpans) as ss
+           |    LATERAL VIEW
+           |    EXPLODE(ss.spans) as span
+           |    LATERAL VIEW
+           |    EXPLODE(span.attributes) as span_attr 
+           |WITH (
+           |  auto_refresh = false 
+           |)
+           """.stripMargin)
+
+    val indexData = spark.read.format(FLINT_DATASOURCE).load(testFlintIndex)
+    flint.describeIndex(testFlintIndex) shouldBe defined
+    indexData.count() shouldBe 0
+
+    sql(s"REFRESH MATERIALIZED VIEW $testMvName")
+    indexData.count() shouldBe 2
+  }
+
   test("create materialized view with quoted name and column name") {
     val testQuotedQuery =
       """ SELECT
@@ -182,9 +224,7 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
   test("show all materialized views in catalog and database") {
     // Show in catalog
     flint.materializedView().name("spark_catalog.default.mv1").query(testQuery).create()
-    checkAnswer(
-      sql(s"SHOW MATERIALIZED VIEW IN spark_catalog"),
-      Seq(Row("mv1")))
+    checkAnswer(sql(s"SHOW MATERIALIZED VIEW IN spark_catalog"), Seq(Row("mv1")))
 
     // Show in catalog.database
     flint.materializedView().name("spark_catalog.default.mv2").query(testQuery).create()

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -248,7 +248,7 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
 
     checkAnswer(
       sql(s"DESC MATERIALIZED VIEW $testMvName"),
-      Seq(Row("startTime", "timestamp"), Row("count", "long")))
+      Seq(Row("startTime", "timestamp"), Row("count", "bigint")))
   }
 
   test("should return empty when describe nonexistent materialized view") {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -185,9 +185,9 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
            |    LATERAL VIEW
            |    EXPLODE(ss.spans) as span
            |    LATERAL VIEW
-           |    EXPLODE(span.attributes) as span_attr 
+           |    EXPLODE(span.attributes) as span_attr
            |WITH (
-           |  auto_refresh = false 
+           |  auto_refresh = false
            |)
            """.stripMargin)
 

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -149,8 +149,8 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
            |                        named_struct(
            |                            'attributes',
            |                            array(
-           |                                named_struct('key', 'total_time_microseconds', 
-           |                                'value', named_struct('stringValue', null, 'intValue', 
+           |                                named_struct('key', 'total_time_microseconds',
+           |                                'value', named_struct('stringValue', null, 'intValue',
            |                                '31286')),
            |                                named_struct('key', 'source', 'value', named_struct
            |                                ('stringValue', 'featureflags', 'intValue', null))


### PR DESCRIPTION
### Description
1.  Fix bug of array type support when create materialized view. Instead of using `array` using `array<elementType>`.
2. Add data type mapping between spark datatype and OpenSearch datatype.
  * Spark ArrayType<ElementType> map to ElementType in OpenSearch
  * Spark BinaryType map to binary type in OpenSearch

### Issues Resolved
#112 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
