### PR TITLE
GHA fix for backport and snapshot-publish

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,4 +26,3 @@ jobs:
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           head_template: backport/backport-<%= number %>-to-<%= base %>
-          files_to_skip: 'CHANGELOG.md'

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 0.*
 
 jobs:
   build-and-publish-snapshots:


### PR DESCRIPTION
### Description
* Fix backport GHA tries to skip non-existent file `CHANGELOG.md`
* Add target branch `0.*` to snapshot-publish

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
