### PR TITLE
Trigger barkport workflow when a pull request merges

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,6 +12,17 @@ jobs:
       contents: write
       pull-requests: write
     name: Backport
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
     steps:
       - name: GitHub App token
         id: github_app_token


### PR DESCRIPTION
Context:
This [PR](https://github.com/opensearch-project/opensearch-spark/actions/runs/7587593648/job/20668300157?pr=209) has a backport label before merged, which failed the backport workflow. To fix this, we need to trigger barkport workflow when a pull request merges

Ref https://github.com/opensearch-project/OpenSearch/blob/main/.github/workflows/backport.yml#L12-L22

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
