### PR TITLE
Fix recover index bug when Flint data index is deleted accidentally

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -298,6 +298,8 @@ WITH (
 
 Currently Flint index job ID is same as internal Flint index name in [OpenSearch](./index.md#OpenSearch) section below.
 
+- **Recover Job**: Initiates a restart of the index refresh job and transition the Flint index to the 'refreshing' state. Additionally, it includes functionality to clean up the metadata log entry in the event that the Flint data index is no longer present in OpenSearch.
+
 ```sql
 RECOVER INDEX JOB <id>
 ```

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -303,6 +303,20 @@ class FlintSpark(val spark: SparkSession) extends Logging {
       }
     } else {
       logInfo("Index to be recovered either doesn't exist or not auto refreshed")
+      if (index.isEmpty) {
+        /*
+         * If execution reaches this point, it indicates that the Flint index is corrupted.
+         * In such cases, clean up the metadata log, as the index data no longer exists.
+         * There is a very small possibility that users may recreate the index in the
+         * interim, but metadata log get deleted by this cleanup process.
+         */
+        logWarning("Cleaning up metadata log as index data has been deleted")
+        flintClient
+          .startTransaction(indexName, dataSourceName)
+          .initialLog(_ => true)
+          .finalLog(_ => NO_LOG_ENTRY)
+          .commit(_ => {})
+      }
       false
     }
   }

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkTransactionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkTransactionITSuite.scala
@@ -142,4 +142,23 @@ class FlintSparkTransactionITSuite extends OpenSearchTransactionSuite with Match
         .create()
     } should have message s"Flint index $testFlintIndex already exists"
   }
+
+  test("should clean up metadata log entry if index data has been deleted") {
+    flint
+      .skippingIndex()
+      .onTable(testTable)
+      .addPartitions("year", "month")
+      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+      .create()
+    flint.refreshIndex(testFlintIndex)
+
+    // Simulate the situation that user delete index data directly and then refresh exits
+    spark.streams.active.find(_.name == testFlintIndex).get.stop()
+    deleteIndex(testFlintIndex)
+
+    // Index state is refreshing and expect recover API clean it up
+    latestLogEntry(testLatestId) should contain("state" -> "refreshing")
+    flint.recoverIndex(testFlintIndex)
+    latestLogEntry(testLatestId) shouldBe empty
+  }
 }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -84,8 +84,8 @@ case class JobOperator(
     }
 
     try {
-      // Stop SparkSession if streaming job succeeds
-      if (!exceptionThrown && streaming) {
+      // Wait for streaming job complete if no error and there is streaming job running
+      if (!exceptionThrown && streaming && spark.streams.active.nonEmpty) {
         // wait if any child thread to finish before the main thread terminates
         spark.streams.awaitAnyTermination()
       }


### PR DESCRIPTION
### Description

To address the 2 issues related:

1. Quick fixed recover index API to clean up metadata log entry if Flint data index is gone. This prevents index stuck in refreshing state and infinite attempt on recover index API.
2. Added check to prevent FlintJob hang even though no streaming job launched by recover statement.

#### Documentation

Updated user manual: https://github.com/dai-chen/opensearch-spark/blob/fix-recover-index-for-index-data-deleted/docs/index.md#index-job-management

#### TODO

1. Integration test with FlintJob *[Checking with @kaituo if possible to add IT]*
3. https://github.com/opensearch-project/opensearch-spark/issues/244

### Testing

Manual test to double confirm. First of all, replicate the problematic scenario as outlined below:

<pre>
CREATE SKIPPING INDEX ON stream.lineitem_tiny
(l_shipdate VALUE_SET)
WITH ( auto_refresh = true );

# Delete Flint data index
<b>DELETE flint_myglue_stream_lineitem_tiny_skipping_index</b>

# Check index state metadata log
GET .query_execution_request_myglue/_search
      {
        "_index": ".query_execution_request_myglue",
        "_id": "ZmxpbnRfbXlnbHVlX3N0cmVhbV9saW5laXRlbV90aW55X3NraXBwaW5nX2luZGV4",
        "_score": 1,
        "_source": {
          "version": "1.0",
          "latestId": "ZmxpbnRfbXlnbHVlX3N0cmVhbV9saW5laXRlbV90aW55X3NraXBwaW5nX2luZGV4",
          "type": "flintindexstate",
          <b>"state": "refreshing",</b>
          "applicationId": "unknown",
          "jobId": "unknown",
          "dataSourceName": "myglue",
          "jobStartTime": 1706916312007,
          "lastUpdateTime": 1706916452474,
          "error": ""
        }
      }
</pre>

Now verify the enhanced recover index API:

<pre>
spark-sql> RECOVER INDEX JOB flint_myglue_stream_lineitem_tiny_skipping_index;
<b>24/02/02 23:48:31 WARN FlintSpark: Cleaning up metadata log as index data has been deleted</b>

# The metadata log is gone
GET .query_execution_request_myglue/_search
</pre>

### Issues Resolved

- https://github.com/opensearch-project/opensearch-spark/issues/227
- https://github.com/opensearch-project/opensearch-spark/issues/237

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
