### PR TITLE
[Backport 0.1] Fix recover index bug when Flint data index is deleted accidentally

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -266,6 +266,8 @@ WITH (
 
 Currently Flint index job ID is same as internal Flint index name in [OpenSearch](./index.md#OpenSearch) section below.
 
+- **Recover Job**: Initiates a restart of the index refresh job and transition the Flint index to the 'refreshing' state. Additionally, it includes functionality to clean up the metadata log entry in the event that the Flint data index is no longer present in OpenSearch.
+
 ```sql
 RECOVER INDEX JOB <id>
 ```

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
@@ -104,8 +104,13 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
     try {
       T result = operation.apply(latest);
 
-      // Append final log
-      metadataLog.add(finalAction.apply(latest));
+      // Append final log or purge log entries
+      FlintMetadataLogEntry finalLog = finalAction.apply(latest);
+      if (finalLog == NO_LOG_ENTRY) {
+        metadataLog.purge();
+      } else {
+        metadataLog.add(finalLog);
+      }
       return result;
     } catch (Exception e) {
       LOG.log(SEVERE, "Rolling back transient log due to transaction operation failure", e);

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/FlintMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/FlintMetadataLog.java
@@ -26,4 +26,9 @@ public interface FlintMetadataLog<T> {
    * @return latest log entry
    */
   Optional<T> getLatest();
+
+  /**
+   * Remove all log entries.
+   */
+  void purge();
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/OptimisticTransaction.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/OptimisticTransaction.java
@@ -21,6 +21,11 @@ import java.util.function.Predicate;
 public interface OptimisticTransaction<T> {
 
   /**
+   * Constant that indicate log entry should be purged.
+   */
+  FlintMetadataLogEntry NO_LOG_ENTRY = null;
+
+  /**
    * @param initialCondition initial precondition that the subsequent transition and action can proceed
    * @return this transaction
    */

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -5,8 +5,17 @@
 
 package org.opensearch.flint.core.storage;
 
+import static java.util.logging.Level.SEVERE;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.logging.Logger;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
@@ -18,14 +27,6 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.flint.core.FlintClient;
 import org.opensearch.flint.core.metadata.log.FlintMetadataLog;
 import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry;
-
-import java.io.IOException;
-import java.util.Base64;
-import java.util.Optional;
-import java.util.logging.Logger;
-
-import static java.util.logging.Level.SEVERE;
-import static org.opensearch.action.support.WriteRequest.RefreshPolicy;
 
 /**
  * Flint metadata log in OpenSearch store. For now use single doc instead of maintaining history
@@ -95,6 +96,20 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
       }
     } catch (Exception e) {
       throw new IllegalStateException("Failed to fetch latest metadata log entry", e);
+    }
+  }
+
+  @Override
+  public void purge() {
+    LOG.info("Purging log entry with id " + latestId);
+    try (RestHighLevelClient client = flintClient.createClient()) {
+      DeleteResponse response =
+          client.delete(
+              new DeleteRequest(metaLogIndexName, latestId), RequestOptions.DEFAULT);
+
+      LOG.info("Purged log entry with result " + response.getResult());
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to purge log entry", e);
     }
   }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -11,6 +11,7 @@ import org.json4s.{Formats, NoTypeHints}
 import org.json4s.native.Serialization
 import org.opensearch.flint.core.{FlintClient, FlintClientBuilder}
 import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState._
+import org.opensearch.flint.core.metadata.log.OptimisticTransaction.NO_LOG_ENTRY
 import org.opensearch.flint.spark.FlintSpark.RefreshMode.{FULL, INCREMENTAL, RefreshMode}
 import org.opensearch.flint.spark.FlintSparkIndex.{quotedTableName, ID_COLUMN, StreamingRefresh}
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -84,8 +84,8 @@ case class JobOperator(
     }
 
     try {
-      // Stop SparkSession if streaming job succeeds
-      if (!exceptionThrown && streaming) {
+      // Wait for streaming job complete if no error and there is streaming job running
+      if (!exceptionThrown && streaming && spark.streams.active.nonEmpty) {
         // wait if any child thread to finish before the main thread terminates
         spark.streams.awaitAnyTermination()
       }


### PR DESCRIPTION
Backport https://github.com/opensearch-project/opensearch-spark/commit/f4744abf38caeb4f22758f112a32c8881842efad from https://github.com/opensearch-project/opensearch-spark/pull/241.

Note that the original PR depends on metadata log purge functionality introduced in https://github.com/opensearch-project/opensearch-spark/pull/189. To avoid the possible impact and API changes, I only cherry-picked minimal code changes instead of the complete https://github.com/opensearch-project/opensearch-spark/pull/189.

<pre>
CREATE SKIPPING INDEX ON stream.lineitem_tiny
(l_shipdate VALUE_SET)
WITH ( auto_refresh = true );

# Delete Flint data index
<b>DELETE flint_myglue_stream_lineitem_tiny_skipping_index</b>

# Check index state metadata log
GET .query_execution_request_myglue/_search
      {
        "_index": ".query_execution_request_myglue",
        "_id": "ZmxpbnRfbXlnbHVlX3N0cmVhbV9saW5laXRlbV90aW55X3NraXBwaW5nX2luZGV4",
        "_score": 1,
        "_source": {
          "version": "1.0",
          "latestId": "ZmxpbnRfbXlnbHVlX3N0cmVhbV9saW5laXRlbV90aW55X3NraXBwaW5nX2luZGV4",
          "type": "flintindexstate",
          <b>"state": "refreshing",</b>
          "applicationId": "unknown",
          "jobId": "unknown",
          "dataSourceName": "myglue",
          "jobStartTime": 1706916312007,
          "lastUpdateTime": 1706916452474,
          "error": ""
        }
      }

spark-sql> RECOVER INDEX JOB flint_myglue_stream_lineitem_tiny_skipping_index;
<b>24/02/02 23:48:31 WARN FlintSpark: Cleaning up metadata log as index data has been deleted</b>

# The metadata log is gone
GET .query_execution_request_myglue/_search
</pre>