### PR TITLE
Bump Flint version to 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ logs/
 *.class
 *.log
 *.zip
+
+gen/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Version compatibility:
 |---------------|-------------|---------------|---------------|------------|
 | 0.1.0         | 11+         | 3.3.1         | 2.12.14       | 2.6+       |
 | 0.2.0         | 11+         | 3.3.1         | 2.12.14       | 2.6+       |
+| 0.3.0         | 11+         | 3.3.2         | 2.12.14       | 2.6+       |
 
 ## Flint Extension Usage 
 
@@ -50,7 +51,7 @@ sbt clean standaloneCosmetic/publishM2
 ```
 then add org.opensearch:opensearch-spark_2.12 when run spark application, for example,
 ```
-bin/spark-shell --packages "org.opensearch:opensearch-spark_2.12:0.2.0-SNAPSHOT"
+bin/spark-shell --packages "org.opensearch:opensearch-spark_2.12:0.3.0-SNAPSHOT"
 ```
 
 ### PPL Build & Run 
@@ -62,7 +63,7 @@ sbt clean sparkPPLCosmetic/publishM2
 ```
 then add org.opensearch:opensearch-spark_2.12 when run spark application, for example,
 ```
-bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.2.0-SNAPSHOT"
+bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.3.0-SNAPSHOT"
 ```
 
 ## Code of Conduct

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val opensearchVersion = "2.6.0"
 
 ThisBuild / organization := "org.opensearch"
 
-ThisBuild / version := "0.2.0-SNAPSHOT"
+ThisBuild / version := "0.3.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := scala212
 

--- a/docs/PPL-on-Spark.md
+++ b/docs/PPL-on-Spark.md
@@ -34,7 +34,7 @@ sbt clean sparkPPLCosmetic/publishM2
 ```
 then add org.opensearch:opensearch-spark_2.12 when run spark application, for example,
 ```
-bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.2.0-SNAPSHOT"
+bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.3.0-SNAPSHOT"
 ```
 
 ### PPL Extension Usage
@@ -46,7 +46,7 @@ spark-sql --conf "spark.sql.extensions=org.opensearch.flint.FlintPPLSparkExtensi
 ```
 
 ### Running With both Flint & PPL Extensions
-In order to make use of both flint and ppl extension, one can simply add both jars (`org.opensearch:opensearch-spark-ppl_2.12:0.2.0-SNAPSHOT`,`org.opensearch:opensearch-spark_2.12:0.2.0-SNAPSHOT`) to the cluster's
+In order to make use of both flint and ppl extension, one can simply add both jars (`org.opensearch:opensearch-spark-ppl_2.12:0.3.0-SNAPSHOT`,`org.opensearch:opensearch-spark_2.12:0.3.0-SNAPSHOT`) to the cluster's
 classpath.
 
 Next need to configure both extensions :

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ Currently, Flint metadata is only static configuration without version control a
 
 ```json
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "name": "...",
   "kind": "skipping",
   "source": "...",
@@ -570,7 +570,7 @@ For now, only single or conjunct conditions (conditions connected by AND) in WHE
 ### AWS EMR Spark Integration - Using execution role
 Flint use [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html). When running in EMR Spark, Flint use executionRole credentials
 ```
---conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.2.0-SNAPSHOT \
+--conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.3.0-SNAPSHOT \
 --conf spark.jars.repositories=https://aws.oss.sonatype.org/content/repositories/snapshots \
 --conf spark.emr-serverless.driverEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
@@ -612,7 +612,7 @@ Flint use [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJa
 ```
 3. Set the spark.datasource.flint.customAWSCredentialsProvider property with value as com.amazonaws.emr.AssumeRoleAWSCredentialsProvider. Set the environment variable ASSUME_ROLE_CREDENTIALS_ROLE_ARN with the ARN value of CrossAccountRoleB.
 ```
---conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.2.0-SNAPSHOT \
+--conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.3.0-SNAPSHOT \
 --conf spark.jars.repositories=https://aws.oss.sonatype.org/content/repositories/snapshots \
 --conf spark.emr-serverless.driverEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintVersion.scala
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintVersion.scala
@@ -16,6 +16,7 @@ case class FlintVersion(version: String) {
 object FlintVersion {
   val V_0_1_0: FlintVersion = FlintVersion("0.1.0")
   val V_0_2_0: FlintVersion = FlintVersion("0.2.0")
+  val V_0_3_0: FlintVersion = FlintVersion("0.3.0")
 
-  def current(): FlintVersion = V_0_2_0
+  def current(): FlintVersion = V_0_3_0
 }


### PR DESCRIPTION
### Description
Bump Flint current version to 0.3.0 in main branch

Testing
Version in artifact name:
```
$ sbt clean assembly
$ find . -name "*-0.3.0-SNAPSHOT.jar"
./spark-sql-application/target/scala-2.12/sql-job-assembly-0.3.0-SNAPSHOT.jar
./flint-spark-integration/target/scala-2.12/flint-spark-integration-assembly-0.3.0-SNAPSHOT.jar
./ppl-spark-integration/target/scala-2.12/ppl-spark-integration-assembly-0.3.0-SNAPSHOT.jar
```

Version in Flint index metadata (currently version field represents Flint code version. We can add another field specVersion for specification version as needed):

```
./bin/spark-sql --jars /Users/penghuo/oss/opensearch-spark/flint-spark-integration/target/scala-2.12/flint-spark-integration-assembly-0.3.0-SNAPSHOT.jar --conf spark.sql.extensions=org.opensearch.flint.spark.FlintSparkExtensions

{
  "flint_spark_catalog_default_http_logs_full_skipping_index": {
    "aliases": {},
    "mappings": {
      "_meta": {
        "latestId": "ZmxpbnRfc3BhcmtfY2F0YWxvZ19kZWZhdWx0X2h0dHBfbG9nc19mdWxsX3NraXBwaW5nX2luZGV4",
        "kind": "skipping",
        "indexedColumns": [
          {
            "columnType": "int",
            "kind": "VALUE_SET",
            "parameters": {
              "max_size": "100"
            },
            "columnName": "status"
          }
        ],
        "name": "flint_spark_catalog_default_http_logs_full_skipping_index",
        "options": {
          "auto_refresh": "false",
          "incremental_refresh": "false"
        },
        "source": "spark_catalog.default.http_logs_full",
        "version": "0.3.0",
        "properties": {}
      },
      "properties": {
        "file_path": {
          "type": "keyword"
        },
        "status": {
          "type": "integer"
        }
      }
    }
  }
}
```


### Issues Resolved
#254 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
