### PR TITLE
Implement BloomFilter query pushdown optimization

### DIFF
--- a/flint-spark-integration/src/main/resources/bloom_filter_query.script
+++ b/flint-spark-integration/src/main/resources/bloom_filter_query.script
@@ -1,38 +1,35 @@
 int hashLong(long input, int seed) {
-int low = (int) input;
-int high = (int) (input >>> 32);
-
-int k1 = mixK1(low);
-int h1 = mixH1(seed, k1);
-
-k1 = mixK1(high);
-h1 = mixH1(h1, k1);
-
-return fmix(h1, 8);
+  int low = (int) input;
+  int high = (int) (input >>> 32);
+  int k1 = mixK1(low);
+  int h1 = mixH1(seed, k1);
+  k1 = mixK1(high);
+  h1 = mixH1(h1, k1);
+  return fmix(h1, 8);
 }
 
 int mixK1(int k1) {
-k1 *= 0xcc9e2d51L;
-k1 = Integer.rotateLeft(k1, 15);
-k1 *= 0x1b873593L;
-return k1;
+  k1 *= 0xcc9e2d51L;
+  k1 = Integer.rotateLeft(k1, 15);
+  k1 *= 0x1b873593L;
+  return k1;
 }
 
 int mixH1(int h1, int k1) {
-h1 ^= k1;
-h1 = Integer.rotateLeft(h1, 13);
-h1 = h1 * 5 + (int) 0xe6546b64L;
-return h1;
+  h1 ^= k1;
+  h1 = Integer.rotateLeft(h1, 13);
+  h1 = h1 * 5 + (int) 0xe6546b64L;
+  return h1;
 }
 
 int fmix(int h1, int length) {
-h1 ^= length;
-h1 ^= h1 >>> 16;
-h1 *= 0x85ebca6bL;
-h1 ^= h1 >>> 13;
-h1 *= 0xc2b2ae35L;
-h1 ^= h1 >>> 16;
-return h1;
+  h1 ^= length;
+  h1 ^= h1 >>> 16;
+  h1 *= 0x85ebca6bL;
+  h1 ^= h1 >>> 13;
+  h1 *= 0xc2b2ae35L;
+  h1 ^= h1 >>> 16;
+  return h1;
 }
 
 BytesRef bfBytes = doc[params.fieldName].value;
@@ -58,55 +55,54 @@ int numWords = ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
 long[] data = new long[numWords];
 byte[] readBuffer = new byte[8];
 for (int i = 0; i < numWords; i++) {
+  int n = 0;
+  while (n < 8) {
+    int count2;
+    int off = n;
+    int len = 8 - n;
+    if (pos >= count) {
+      count2 = -1;
+    } else {
+      int avail = count - pos;
+      if (len > avail) {
+        len = avail;
+      }
+      if (len <= 0) {
+        count2 = 0;
+      } else {
+        System.arraycopy(buf, pos, readBuffer, off, len);
+        pos += len;
+        count2 = len;
+      }
+    }
+    n += count2;
+  }
+  data[i] = (((long) readBuffer[0] << 56) +
+    ((long) (readBuffer[1] & 255) << 48) +
+    ((long) (readBuffer[2] & 255) << 40) +
+    ((long) (readBuffer[3] & 255) << 32) +
+    ((long) (readBuffer[4] & 255) << 24) +
+    ((readBuffer[5] & 255) << 16) +
+    ((readBuffer[6] & 255) << 8) +
+    ((readBuffer[7] & 255) << 0));
+}
 
-int n = 0;
-while (n < 8) {
-int count2;
-int off = n;
-int len = 8 - n;
-if (pos >= count) {
-count2 = -1;
-} else {
-int avail = count - pos;
-if (len > avail) {
-len = avail;
-}
-if (len <= 0) {
-count2 = 0;
-} else {
-System.arraycopy(buf, pos, readBuffer, off, len);
-pos += len;
-count2 = len;
-}
-}
-n += count2;
-}
-data[i] = (((long) readBuffer[0] << 56) +
-((long) (readBuffer[1] & 255) << 48) +
-((long) (readBuffer[2] & 255) << 40) +
-((long) (readBuffer[3] & 255) << 32) +
-((long) (readBuffer[4] & 255) << 24) +
-((readBuffer[5] & 255) << 16) +
-((readBuffer[6] & 255) << 8) +
-((readBuffer[7] & 255) << 0));
-}
 long bitCount = 0;
 for (long word : data) {
-bitCount += Long.bitCount(word);
+  bitCount += Long.bitCount(word);
 }
 
 long item = params.value;
 int h1 = hashLong(item, 0);
 int h2 = hashLong(item, h1);
-
 long bitSize = (long) data.length * Long.SIZE;
 for (int i = 1; i <= numHashFunctions; i++) {
-int combinedHash = h1 + (i * h2);
-if (combinedHash < 0) {
-combinedHash = ~combinedHash;
-}
-if ((data[(int) (combinedHash % bitSize >>> 6)] & (1L << combinedHash % bitSize)) == 0) {
-return false;
-}
+  int combinedHash = h1 + (i * h2);
+  if (combinedHash < 0) {
+    combinedHash = ~combinedHash;
+  }
+  if ((data[(int) (combinedHash % bitSize >>> 6)] & (1L << combinedHash % bitSize)) == 0) {
+    return false;
+  }
 }
 return true;

--- a/flint-spark-integration/src/main/resources/bloom_filter_query.script
+++ b/flint-spark-integration/src/main/resources/bloom_filter_query.script
@@ -57,25 +57,25 @@ byte[] readBuffer = new byte[8];
 for (int i = 0; i < numWords; i++) {
   int n = 0;
   while (n < 8) {
-    int count2;
+    int readCount;
     int off = n;
     int len = 8 - n;
     if (pos >= count) {
-      count2 = -1;
+      readCount = -1;
     } else {
       int avail = count - pos;
       if (len > avail) {
         len = avail;
       }
       if (len <= 0) {
-        count2 = 0;
+        readCount = 0;
       } else {
         System.arraycopy(buf, pos, readBuffer, off, len);
         pos += len;
-        count2 = len;
+        readCount = len;
       }
     }
-    n += count2;
+    n += readCount;
   }
   data[i] = (((long) readBuffer[0] << 56) +
     ((long) (readBuffer[1] & 255) << 48) +
@@ -101,7 +101,8 @@ for (int i = 1; i <= numHashFunctions; i++) {
   if (combinedHash < 0) {
     combinedHash = ~combinedHash;
   }
-  if ((data[(int) (combinedHash % bitSize >>> 6)] & (1L << combinedHash % bitSize)) == 0) {
+  long index = combinedHash % bitSize;
+  if ((data[(int) (index >>> 6)] & (1L << index)) == 0) {
     return false;
   }
 }

--- a/flint-spark-integration/src/main/resources/bloom_filter_query.txt
+++ b/flint-spark-integration/src/main/resources/bloom_filter_query.txt
@@ -1,0 +1,112 @@
+int hashLong(long input, int seed) {
+int low = (int) input;
+int high = (int) (input >>> 32);
+
+int k1 = mixK1(low);
+int h1 = mixH1(seed, k1);
+
+k1 = mixK1(high);
+h1 = mixH1(h1, k1);
+
+return fmix(h1, 8);
+}
+
+int mixK1(int k1) {
+k1 *= 0xcc9e2d51L;
+k1 = Integer.rotateLeft(k1, 15);
+k1 *= 0x1b873593L;
+return k1;
+}
+
+int mixH1(int h1, int k1) {
+h1 ^= k1;
+h1 = Integer.rotateLeft(h1, 13);
+h1 = h1 * 5 + (int) 0xe6546b64L;
+return h1;
+}
+
+int fmix(int h1, int length) {
+h1 ^= length;
+h1 ^= h1 >>> 16;
+h1 *= 0x85ebca6bL;
+h1 ^= h1 >>> 13;
+h1 *= 0xc2b2ae35L;
+h1 ^= h1 >>> 16;
+return h1;
+}
+
+BytesRef bfBytes = doc[params.fieldName].value;
+byte[] buf = bfBytes.bytes;
+int pos = 0;
+int count = buf.length;
+int ch1 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+int ch2 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+int ch3 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+int ch4 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+int version = ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
+ch1 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+ch2 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+ch3 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+ch4 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+int numHashFunctions = ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
+ch1 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+ch2 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+ch3 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+ch4 = (pos < count) ? (buf[pos++] & (int) 0xffL) : -1;
+int numWords = ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
+
+long[] data = new long[numWords];
+byte[] readBuffer = new byte[8];
+for (int i = 0; i < numWords; i++) {
+
+int n = 0;
+while (n < 8) {
+int count2;
+int off = n;
+int len = 8 - n;
+if (pos >= count) {
+count2 = -1;
+} else {
+int avail = count - pos;
+if (len > avail) {
+len = avail;
+}
+if (len <= 0) {
+count2 = 0;
+} else {
+System.arraycopy(buf, pos, readBuffer, off, len);
+pos += len;
+count2 = len;
+}
+}
+n += count2;
+}
+data[i] = (((long) readBuffer[0] << 56) +
+((long) (readBuffer[1] & 255) << 48) +
+((long) (readBuffer[2] & 255) << 40) +
+((long) (readBuffer[3] & 255) << 32) +
+((long) (readBuffer[4] & 255) << 24) +
+((readBuffer[5] & 255) << 16) +
+((readBuffer[6] & 255) << 8) +
+((readBuffer[7] & 255) << 0));
+}
+long bitCount = 0;
+for (long word : data) {
+bitCount += Long.bitCount(word);
+}
+
+long item = params.value;
+int h1 = hashLong(item, 0);
+int h2 = hashLong(item, h1);
+
+long bitSize = (long) data.length * Long.SIZE;
+for (int i = 1; i <= numHashFunctions; i++) {
+int combinedHash = h1 + (i * h2);
+if (combinedHash < 0) {
+combinedHash = ~combinedHash;
+}
+if ((data[(int) (combinedHash % bitSize >>> 6)] & (1L << combinedHash % bitSize)) == 0) {
+return false;
+}
+}
+return true;

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -7,6 +7,7 @@ package org.apache.spark.sql.flint.datatype
 
 import org.json4s.{Formats, JField, JValue, NoTypeHints}
 import org.json4s.JsonAST.{JNothing, JObject, JString}
+import org.json4s.JsonAST.JBool.True
 import org.json4s.jackson.JsonMethods
 import org.json4s.native.Serialization
 
@@ -156,7 +157,11 @@ object FlintDataType {
       case ArrayType(elementType, _) => serializeField(elementType, Metadata.empty)
 
       // binary
-      case BinaryType => JObject("type" -> JString("binary"))
+      case BinaryType =>
+        JObject(
+          "type" -> JString("binary"),
+          "doc_values" -> True // enable doc value required by painless script filtering
+        )
 
       case unknown => throw new IllegalStateException(s"unsupported data type: ${unknown.sql}")
     }

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/storage/FlintQueryCompiler.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/storage/FlintQueryCompiler.scala
@@ -5,6 +5,8 @@
 
 package org.apache.spark.sql.flint.storage
 
+import scala.io.Source
+
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.util.{DateTimeUtils, TimestampFormatter}
 import org.apache.spark.sql.connector.expressions.{Expression, FieldReference, LiteralValue}
@@ -12,8 +14,6 @@ import org.apache.spark.sql.connector.expressions.filter.{And, Predicate}
 import org.apache.spark.sql.flint.datatype.FlintDataType.STRICT_DATE_OPTIONAL_TIME_FORMATTER_WITH_NANOS
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-
-import scala.io.Source
 
 /**
  * Todo. find the right package.
@@ -115,23 +115,23 @@ case class FlintQueryCompiler(schema: StructType) {
             p.children()(1),
             false)}"}}}"""
       case "BLOOM_FILTER_MIGHT_CONTAIN" =>
-        val code = Source.fromResource("bloom_filter_query.txt").getLines().mkString(" ")
+        val code = Source.fromResource("bloom_filter_query.script").getLines().mkString(" ")
         s"""
            |{
-           |    "bool": {
-           |      "filter": {
+           |  "bool": {
+           |    "filter": {
+           |      "script": {
            |        "script": {
-           |          "script": {
-           |            "lang": "painless",
-           |            "source": "$code",
-           |            "params": {
-           |              "fieldName": "${compile(p.children()(0))}",
-           |              "value": ${compile(p.children()(1))}
-           |            }
+           |          "lang": "painless",
+           |          "source": "$code",
+           |          "params": {
+           |            "fieldName": "${compile(p.children()(0))}",
+           |            "value": ${compile(p.children()(1))}
            |          }
            |        }
            |      }
            |    }
+           |  }
            |}
            |""".stripMargin
       case _ => ""

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
@@ -44,7 +44,8 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
                           |      "type": "text"
                           |    },
                           |    "binaryField": {
-                          |      "type": "binary"
+                          |      "type": "binary",
+                          |      "doc_values": true
                           |    }
                           |  }
                           |}""".stripMargin

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/storage/FlintQueryCompilerSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/storage/FlintQueryCompilerSuite.scala
@@ -139,30 +139,30 @@ class FlintQueryCompilerSuite extends FlintSuite {
     assertResult("""{"exists":{"field":"aString"}}""")(query)
   }
 
-  test("compile bloom_filter_might_contain(aInt, 1) successfully") {
+  test("compile BLOOM_FILTER_MIGHT_CONTAIN(aInt, 1) successfully") {
     val query =
       FlintQueryCompiler(schema()).compile(
         new Predicate(
           "BLOOM_FILTER_MIGHT_CONTAIN",
           Array(FieldReference("aInt"), LiteralValue(1, IntegerType))))
 
-    val code = Source.fromResource("bloom_filter_query.txt").getLines().mkString(" ")
+    val code = Source.fromResource("bloom_filter_query.script").getLines().mkString(" ")
     assertResult(s"""
          |{
-         |    "bool": {
-         |      "filter": {
+         |  "bool": {
+         |    "filter": {
+         |      "script": {
          |        "script": {
-         |          "script": {
-         |            "lang": "painless",
-         |            "source": "$code",
-         |            "params": {
-         |              "fieldName": "aInt",
-         |              "value": 1
-         |            }
+         |          "lang": "painless",
+         |          "source": "$code",
+         |          "params": {
+         |            "fieldName": "aInt",
+         |            "value": 1
          |          }
          |        }
          |      }
          |    }
+         |  }
          |}
          |""".stripMargin)(query)
   }

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/storage/FlintQueryCompilerSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/storage/FlintQueryCompilerSuite.scala
@@ -5,8 +5,10 @@
 
 package org.apache.spark.sql.flint.storage
 
+import scala.io.Source
+
 import org.apache.spark.FlintSuite
-import org.apache.spark.sql.connector.expressions.{FieldReference, GeneralScalarExpression}
+import org.apache.spark.sql.connector.expressions.{FieldReference, GeneralScalarExpression, LiteralValue}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
@@ -135,6 +137,34 @@ class FlintQueryCompilerSuite extends FlintSuite {
     val query =
       FlintQueryCompiler(schema()).compile(IsNotNull("aString").toV2)
     assertResult("""{"exists":{"field":"aString"}}""")(query)
+  }
+
+  test("compile bloom_filter_might_contain(aInt, 1) successfully") {
+    val query =
+      FlintQueryCompiler(schema()).compile(
+        new Predicate(
+          "BLOOM_FILTER_MIGHT_CONTAIN",
+          Array(FieldReference("aInt"), LiteralValue(1, IntegerType))))
+
+    val code = Source.fromResource("bloom_filter_query.txt").getLines().mkString(" ")
+    assertResult(s"""
+         |{
+         |    "bool": {
+         |      "filter": {
+         |        "script": {
+         |          "script": {
+         |            "lang": "painless",
+         |            "source": "$code",
+         |            "params": {
+         |              "fieldName": "aInt",
+         |              "value": 1
+         |            }
+         |          }
+         |        }
+         |      }
+         |    }
+         |}
+         |""".stripMargin)(query)
   }
 
   protected def schema(): StructType = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -121,7 +121,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
         |       "type": "integer"
         |     },
         |     "name" : {
-        |       "type": "binary"
+        |       "type": "binary",
+        |       "doc_values": true
         |     },
         |     "file_path": {
         |       "type": "keyword"


### PR DESCRIPTION
### Description

This PR introduces BloomFilter query pushdown optimization in OpenSearch by using a Painless script. Without dependency on OpenSearch SQL or another new mapper plugin, the following BloomFilter deserialization and membership check code are encoded in a Painless script https://github.com/dai-chen/opensearch-spark/blob/implement-bloom-filter-query-pushdown/flint-spark-integration/src/main/resources/bloom_filter_query.script.

```
  public static BloomFilter readFrom(InputStream in) {
      DataInputStream dis = new DataInputStream(in);
      int version = dis.readInt();
      int numHashFunctions = dis.readInt();
      BitArray bits = BitArray.readFrom(dis);
      ...
  }

 public boolean mightContainLong(long item) {
    int h1 = Murmur3_x86_32.hashLong(item, 0);
    int h2 = Murmur3_x86_32.hashLong(item, h1);

    long bitSize = bits.bitSize();
    for (int i = 1; i <= numHashFunctions; i++) {
      int combinedHash = h1 + (i * h2);
      // Flip all the bits if it's negative (guaranteed positive number)
      if (combinedHash < 0) {
        combinedHash = ~combinedHash;
      }
      if (!bits.get(combinedHash % bitSize)) {
        return false;
      }
    }
    return true;
  }
```

Because Painless language only support basic JDK API, API in `Murmur3`, `DataInputStream` and `ByteArrayInputStream` needs to be inlined accordingly. The Painless script length is 15.4k while OpenSearch default limit is 64k.

#### TODO

If any limitation or performance issue, we can either store the script by https://opensearch.org/docs/latest/api-reference/script-apis/create-stored-script/ or add dependency on SQL or a new plugin.

#### PR Planned

- [x] https://github.com/opensearch-project/opensearch-spark/pull/242
- [x] https://github.com/opensearch-project/opensearch-spark/pull/248
- [ ] https://github.com/opensearch-project/opensearch-spark/pull/271 *[Current]*
- [ ] https://github.com/opensearch-project/opensearch-spark/pull/251
- [ ] Support bloom filter type in Flint SQL

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/206

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
