### PR TITLE
Fix spark extension path in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Version compatibility:
 To use this application, you can run Spark with Flint extension:
 
 ```
-spark-sql --conf "spark.sql.extensions=org.opensearch.flint.FlintSparkExtensions"
+spark-sql --conf "spark.sql.extensions=org.opensearch.flint.spark.FlintSparkExtensions"
 ```
 
 ## PPL Extension Usage
@@ -34,7 +34,7 @@ spark-sql --conf "spark.sql.extensions=org.opensearch.flint.FlintSparkExtensions
 To use PPL to Spark translation, you can run Spark with PPL extension:
 
 ```
-spark-sql --conf "spark.sql.extensions=org.opensearch.flint.FlintPPLSparkExtensions"
+spark-sql --conf "spark.sql.extensions=org.opensearch.flint.spark.FlintPPLSparkExtensions"
 ```
 
 ### Running With both Extension 

--- a/docs/PPL-on-Spark.md
+++ b/docs/PPL-on-Spark.md
@@ -42,7 +42,7 @@ bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.3.0-SNAPS
 To use PPL to Spark translation, you can run Spark with PPL extension:
 
 ```
-spark-sql --conf "spark.sql.extensions=org.opensearch.flint.FlintPPLSparkExtensions"
+spark-sql --conf "spark.sql.extensions=org.opensearch.flint.spark.FlintPPLSparkExtensions"
 ```
 
 ### Running With both Flint & PPL Extensions
@@ -51,7 +51,7 @@ classpath.
 
 Next need to configure both extensions :
 ```
-spark-sql --conf "spark.sql.extensions='org.opensearch.flint.FlintPPLSparkExtensions, org.opensearch.flint.FlintSparkExtensions'"
+spark-sql --conf "spark.sql.extensions='org.opensearch.flint.spark.FlintPPLSparkExtensions, org.opensearch.flint.spark.FlintSparkExtensions'"
 ```
 
 Once this is done, spark will allow both extensions to parse the query (SQL / PPL) and allow the correct execution of the query.


### PR DESCRIPTION
### Description
The extension class name is not correct in the README.md.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
