### PR TITLE
Add BloomFilter skipping index SQL support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -153,7 +153,20 @@ High level API is dependent on query engine implementation. Please see Query Eng
 
 #### Skipping Index
 
-The default maximum size for the value set is 100. In cases where a file contains columns with high cardinality values, the value set will become null. This is the trade-off that prevents excessive memory consumption at the cost of not skipping the file.
+Provided below are the explanations for the parameters of the skipping algorithm. You can find the default values in the function signature below:
+
+- **VALUE_SET(limit=100):** If a file contains columns with high cardinality values, the value set will become null. This trade-off prevents excessive memory consumption at the expense of not skipping the file.
+
+- **BLOOM_FILTER**
+  - **BLOOM_FILTER(num_candidate=10, fpp=0.03):** By default, the adaptive BloomFilter algorithm is used. Users can configure:
+    1. The number of candidates (optional), starting with an expected number of distinct items at 1024 and doubling.
+    2. The false positive probability of each candidate (optional).
+    3. Examples: `BLOOM_FILTER`, `BLOOM_FILTER(20), BLOOM_FILTER(20, 0.01)`
+
+  - **BLOOM_FILTER(false, num_items=10000, fpp=0.03):** Setting the first parameter to `false` will revert to the non-adaptive algorithm. Users can configure:
+    1. The expected number of distinct values (optional).
+    2. The false positive probability (optional).
+    3. Examples: `BLOOM_FILTER(false)`, `BLOOM_FILTER(false, 1000000)`, `BLOOM_FILTER(false, 1000000, 0.01)`
 
 ```sql
 CREATE SKIPPING INDEX [IF NOT EXISTS]

--- a/docs/index.md
+++ b/docs/index.md
@@ -155,7 +155,7 @@ High level API is dependent on query engine implementation. Please see Query Eng
 
 Provided below are the explanations for the parameters of the skipping algorithm. You can find the default values in the function signature below:
 
-- **VALUE_SET(limit=100):** If a file contains columns with high cardinality values, the value set will become null. This trade-off prevents excessive memory consumption at the expense of not skipping the file.
+- **VALUE_SET(limit=100):** If the column values of a file has higher cardinality than the limit (optional, default is 100), the value set will become null. This trade-off prevents excessive memory consumption at the expense of not skipping the file.
 
 - **BLOOM_FILTER**
   - **BLOOM_FILTER(num_candidate=10, fpp=0.03):** By default, the adaptive BloomFilter algorithm is used. Users can configure:

--- a/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4
+++ b/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4
@@ -183,7 +183,7 @@ indexColTypeList
     ;
 
 indexColType
-    : identifier skipType=(PARTITION | VALUE_SET | MIN_MAX)
+    : identifier skipType=(PARTITION | VALUE_SET | MIN_MAX | BLOOM_FILTER)
         (LEFT_PAREN skipParams RIGHT_PAREN)?
     ;
 

--- a/flint-spark-integration/src/main/antlr4/SparkSqlBase.g4
+++ b/flint-spark-integration/src/main/antlr4/SparkSqlBase.g4
@@ -139,6 +139,7 @@ nonReserved
 
 // Flint lexical tokens
 
+BLOOM_FILTER: 'BLOOM_FILTER';
 MIN_MAX: 'MIN_MAX';
 SKIPPING: 'SKIPPING';
 VALUE_SET: 'VALUE_SET';

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSkippingIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSkippingIndexAstBuilder.scala
@@ -54,8 +54,9 @@ trait FlintSparkSkippingIndexAstBuilder extends FlintSparkSqlExtensionsVisitor[A
             indexBuilder.addValueSet(colName, valueSetParams)
           case MIN_MAX => indexBuilder.addMinMax(colName)
           case BLOOM_FILTER =>
+            // Determine if the given parameters are for adaptive algorithm by the first parameter
             val bloomFilterParamKeys =
-              if (skipParams.headOption.contains("false")) {
+              if (skipParams.headOption.exists(_.equalsIgnoreCase("false"))) {
                 Seq(
                   BLOOM_FILTER_ADAPTIVE_KEY,
                   CLASSIC_BLOOM_FILTER_NUM_ITEMS_KEY,


### PR DESCRIPTION
### Description

This PR introduces the SQL support and concludes the BloomFilter skipping index development. Please read more in user manual: https://github.com/dai-chen/opensearch-spark/blob/add-bloom-filter-sql-support/docs/index.md#skipping-index

#### PR Planned

- [x] https://github.com/opensearch-project/opensearch-spark/pull/242
- [x] https://github.com/opensearch-project/opensearch-spark/pull/248
- [x] https://github.com/opensearch-project/opensearch-spark/pull/271
- [x] https://github.com/opensearch-project/opensearch-spark/pull/251
- [ ] https://github.com/opensearch-project/opensearch-spark/pull/283 *[Current]*

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/206

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
