### PR TITLE
Add AWS credentials provider for metadata access

### DIFF
--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
@@ -102,6 +102,7 @@ public interface FlintClient {
    * @return {@link FlintWriter}
    */
   FlintWriter createWriter(String indexName);
+
   /**
    * Create {@link IRestHighLevelClient}.
    * @return {@link IRestHighLevelClient}

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
@@ -106,5 +106,5 @@ public interface FlintClient {
    * Create {@link IRestHighLevelClient}.
    * @return {@link IRestHighLevelClient}
    */
-  public IRestHighLevelClient createClient();
+  IRestHighLevelClient createClient();
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.flint.core;
 
-import dev.failsafe.RetryPolicy;
 import java.io.Serializable;
 import java.util.Map;
 import org.opensearch.flint.core.http.FlintRetryOptions;
@@ -46,10 +45,14 @@ public class FlintOptions implements Serializable {
 
   public static final String CUSTOM_AWS_CREDENTIALS_PROVIDER = "customAWSCredentialsProvider";
 
+  public static final String SUPER_ADMIN_AWS_CREDENTIALS_PROVIDER = "superAdminAWSCredentialsProvider";
+
   /**
-   * By default, customAWSCredentialsProvider is empty. use DefaultAWSCredentialsProviderChain.
+   * By default, customAWSCredentialsProvider and superAdminAWSCredentialsProvider are empty. use DefaultAWSCredentialsProviderChain.
    */
-  public static final String DEFAULT_CUSTOM_AWS_CREDENTIALS_PROVIDER = "";
+  public static final String DEFAULT_AWS_CREDENTIALS_PROVIDER = "";
+
+  public static final String SYSTEM_INDEX_KEY_NAME = "spark.flint.job.requestIndex";
 
   /**
    * Used by {@link org.opensearch.flint.core.storage.OpenSearchScrollReader}
@@ -121,7 +124,11 @@ public class FlintOptions implements Serializable {
   }
 
   public String getCustomAwsCredentialsProvider() {
-    return options.getOrDefault(CUSTOM_AWS_CREDENTIALS_PROVIDER, "");
+    return options.getOrDefault(CUSTOM_AWS_CREDENTIALS_PROVIDER, DEFAULT_AWS_CREDENTIALS_PROVIDER);
+  }
+
+  public String getSuperAdminAwsCredentialsProvider() {
+    return options.getOrDefault(SUPER_ADMIN_AWS_CREDENTIALS_PROVIDER, DEFAULT_AWS_CREDENTIALS_PROVIDER);
   }
 
   public String getUsername() {
@@ -138,5 +145,9 @@ public class FlintOptions implements Serializable {
 
   public String getDataSourceName() {
     return options.getOrDefault(DATA_SOURCE_NAME, "");
+  }
+
+  public String getSystemIndexName() {
+    return options.getOrDefault(SYSTEM_INDEX_KEY_NAME, "");
   }
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -45,10 +45,10 @@ public class FlintOptions implements Serializable {
 
   public static final String CUSTOM_AWS_CREDENTIALS_PROVIDER = "customAWSCredentialsProvider";
 
-  public static final String SUPER_ADMIN_AWS_CREDENTIALS_PROVIDER = "superAdminAWSCredentialsProvider";
+  public static final String METADATA_ACCESS_AWS_CREDENTIALS_PROVIDER = "spark.metadata.accessAWSCredentialsProvider";
 
   /**
-   * By default, customAWSCredentialsProvider and superAdminAWSCredentialsProvider are empty. use DefaultAWSCredentialsProviderChain.
+   * By default, customAWSCredentialsProvider and accessAWSCredentialsProvider are empty. use DefaultAWSCredentialsProviderChain.
    */
   public static final String DEFAULT_AWS_CREDENTIALS_PROVIDER = "";
 
@@ -127,8 +127,8 @@ public class FlintOptions implements Serializable {
     return options.getOrDefault(CUSTOM_AWS_CREDENTIALS_PROVIDER, DEFAULT_AWS_CREDENTIALS_PROVIDER);
   }
 
-  public String getSuperAdminAwsCredentialsProvider() {
-    return options.getOrDefault(SUPER_ADMIN_AWS_CREDENTIALS_PROVIDER, DEFAULT_AWS_CREDENTIALS_PROVIDER);
+  public String getMetadataAccessAwsCredentialsProvider() {
+    return options.getOrDefault(METADATA_ACCESS_AWS_CREDENTIALS_PROVIDER, DEFAULT_AWS_CREDENTIALS_PROVIDER);
   }
 
   public String getUsername() {

--- a/flint-core/src/main/scala/org/opensearch/flint/core/auth/AWSRequestSigningApacheInterceptor.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/auth/AWSRequestSigningApacheInterceptor.java
@@ -59,8 +59,8 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
    * @param awsCredentialsProvider source of AWS credentials for signing
    */
   public AWSRequestSigningApacheInterceptor(final String service,
-                                            final Signer signer,
-                                            final AWSCredentialsProvider awsCredentialsProvider) {
+      final Signer signer,
+      final AWSCredentialsProvider awsCredentialsProvider) {
     this.service = service;
     this.signer = signer;
     this.awsCredentialsProvider = awsCredentialsProvider;
@@ -71,7 +71,7 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
    */
   @Override
   public void process(final HttpRequest request, final HttpContext context)
-          throws HttpException, IOException {
+      throws HttpException, IOException {
     URIBuilder uriBuilder;
     try {
       uriBuilder = new URIBuilder(request.getRequestLine().getUri());
@@ -87,7 +87,7 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
       signableRequest.setEndpoint(URI.create(host.toURI()));
     }
     final HttpMethodName httpMethod =
-            HttpMethodName.fromValue(request.getRequestLine().getMethod());
+        HttpMethodName.fromValue(request.getRequestLine().getMethod());
     signableRequest.setHttpMethod(httpMethod);
     try {
       signableRequest.setResourcePath(uriBuilder.build().getRawPath());
@@ -97,7 +97,7 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
 
     if (request instanceof HttpEntityEnclosingRequest) {
       HttpEntityEnclosingRequest httpEntityEnclosingRequest =
-              (HttpEntityEnclosingRequest) request;
+          (HttpEntityEnclosingRequest) request;
       if (httpEntityEnclosingRequest.getEntity() != null) {
         signableRequest.setContent(httpEntityEnclosingRequest.getEntity().getContent());
       }
@@ -112,7 +112,7 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
     request.setHeaders(mapToHeaderArray(signableRequest.getHeaders()));
     if (request instanceof HttpEntityEnclosingRequest) {
       HttpEntityEnclosingRequest httpEntityEnclosingRequest =
-              (HttpEntityEnclosingRequest) request;
+          (HttpEntityEnclosingRequest) request;
       if (httpEntityEnclosingRequest.getEntity() != null) {
         BasicHttpEntity basicHttpEntity = new BasicHttpEntity();
         basicHttpEntity.setContent(signableRequest.getContent());
@@ -130,7 +130,7 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
     Map<String, List<String>> parameterMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     for (NameValuePair nvp : params) {
       List<String> argsList =
-              parameterMap.computeIfAbsent(nvp.getName(), k -> new ArrayList<>());
+          parameterMap.computeIfAbsent(nvp.getName(), k -> new ArrayList<>());
       argsList.add(nvp.getValue());
     }
     return parameterMap;
@@ -156,8 +156,8 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
    */
   private static boolean skipHeader(final Header header) {
     return ("content-length".equalsIgnoreCase(header.getName())
-            && "0".equals(header.getValue())) // Strip Content-Length: 0
-            || "host".equalsIgnoreCase(header.getName()); // Host comes from endpoint
+        && "0".equals(header.getValue())) // Strip Content-Length: 0
+        || "host".equalsIgnoreCase(header.getName()); // Host comes from endpoint
   }
 
   /**

--- a/flint-core/src/main/scala/org/opensearch/flint/core/auth/ResourceBasedAWSRequestSigningApacheInterceptor.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/auth/ResourceBasedAWSRequestSigningApacheInterceptor.java
@@ -1,0 +1,99 @@
+package org.opensearch.flint.core.auth;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.Signer;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * Intercepts HTTP requests to sign them for AWS authentication, adjusting the signing process
+ * based on whether the request accesses metadata or not.
+ */
+public class ResourceBasedAWSRequestSigningApacheInterceptor implements HttpRequestInterceptor {
+
+    private final String service;
+    private final String metadataAccessIdentifier;
+    final AWSRequestSigningApacheInterceptor primaryInterceptor;
+    final AWSRequestSigningApacheInterceptor metadataAccessInterceptor;
+
+    /**
+     * Constructs an interceptor for AWS request signing with optional metadata access.
+     *
+     * @param service                             The AWS service name.
+     * @param signer                              The AWS request signer.
+     * @param primaryCredentialsProvider          The credentials provider for general access.
+     * @param metadataAccessCredentialsProvider   The credentials provider for metadata access.
+     * @param metadataAccessIdentifier            Identifier for operations requiring metadata access.
+     */
+    public ResourceBasedAWSRequestSigningApacheInterceptor(final String service,
+                                                           final Signer signer,
+                                                           final AWSCredentialsProvider primaryCredentialsProvider,
+                                                           final AWSCredentialsProvider metadataAccessCredentialsProvider,
+                                                           final String metadataAccessIdentifier) {
+        this(service,
+                new AWSRequestSigningApacheInterceptor(service, signer, primaryCredentialsProvider),
+                new AWSRequestSigningApacheInterceptor(service, signer, metadataAccessCredentialsProvider),
+                metadataAccessIdentifier);
+    }
+
+    // Test constructor allowing injection of mock interceptors
+    ResourceBasedAWSRequestSigningApacheInterceptor(final String service,
+                                                    final AWSRequestSigningApacheInterceptor primaryInterceptor,
+                                                    final AWSRequestSigningApacheInterceptor metadataAccessInterceptor,
+                                                    final String metadataAccessIdentifier) {
+        this.service = service == null ? "unknown" : service;
+        this.primaryInterceptor = primaryInterceptor;
+        this.metadataAccessInterceptor = metadataAccessInterceptor;
+        this.metadataAccessIdentifier = metadataAccessIdentifier;
+    }
+
+    /**
+     * Processes an HTTP request, signing it according to whether it requires metadata access.
+     *
+     * @param request The HTTP request to process.
+     * @param context The context in which the HTTP request is being processed.
+     * @throws HttpException If processing the HTTP request results in an exception.
+     * @throws IOException If an I/O error occurs.
+     */
+    @Override
+    public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
+        String resourcePath = parseUriToPath(request);
+        if ("es".equals(this.service) && isMetadataAccess(resourcePath)) {
+            metadataAccessInterceptor.process(request, context);
+        } else {
+            primaryInterceptor.process(request, context);
+        }
+    }
+
+    /**
+     * Extracts and returns the path component of a URI from an HTTP request.
+     *
+     * @param request The HTTP request from which to extract the URI path.
+     * @return The path component of the URI.
+     * @throws IOException If an error occurs parsing the URI.
+     */
+    private String parseUriToPath(HttpRequest request) throws IOException {
+        try {
+            URIBuilder uriBuilder = new URIBuilder(request.getRequestLine().getUri());
+            return uriBuilder.build().getRawPath();
+        } catch (URISyntaxException e) {
+            throw new IOException("Invalid URI", e);
+        }
+    }
+
+    /**
+     * Determines whether the accessed resource requires metadata credentials.
+     *
+     * @param resourcePath The path of the resource being accessed.
+     * @return true if the operation requires metadata access credentials, false otherwise.
+     */
+    private boolean isMetadataAccess(String resourcePath) {
+        return resourcePath.contains(metadataAccessIdentifier);
+    }
+}

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
@@ -269,21 +269,21 @@ public class FlintOpenSearchClient implements FlintClient {
         instantiateProvider(customProviderClass, customAWSCredentialsProvider);
       }
 
-      // Use the customAWSCredentialsProvider for superAdminAWSCredentialsProvider by default,
-      // unless a separate superAdmin provider class name is specified
-      String superAdminProviderClass = options.getSuperAdminAwsCredentialsProvider();
-      final AtomicReference<AWSCredentialsProvider> superAdminAWSCredentialsProvider =
+      // Set metadataAccessAWSCredentialsProvider to customAWSCredentialsProvider by default for backwards compatibility
+      // unless a specific metadata access provider class name is provided
+      String metadataAccessProviderClass = options.getMetadataAccessAwsCredentialsProvider();
+      final AtomicReference<AWSCredentialsProvider> metadataAccessAWSCredentialsProvider =
               new AtomicReference<>(new DefaultAWSCredentialsProviderChain());
-      if (Strings.isNullOrEmpty(superAdminProviderClass)) {
-        superAdminAWSCredentialsProvider.set(customAWSCredentialsProvider.get());
+      if (Strings.isNullOrEmpty(metadataAccessProviderClass)) {
+        metadataAccessAWSCredentialsProvider.set(customAWSCredentialsProvider.get());
       } else {
-        instantiateProvider(superAdminProviderClass, superAdminAWSCredentialsProvider);
+        instantiateProvider(metadataAccessProviderClass, metadataAccessAWSCredentialsProvider);
       }
 
       restClientBuilder.setHttpClientConfigCallback(builder -> {
                 HttpAsyncClientBuilder delegate = builder.addInterceptorLast(
                         new AWSRequestSigningApacheInterceptor(
-                                signer.getServiceName(), signer, customAWSCredentialsProvider.get(), superAdminAWSCredentialsProvider.get(), options.getSystemIndexName()));
+                                signer.getServiceName(), signer, customAWSCredentialsProvider.get(), metadataAccessAWSCredentialsProvider.get(), options.getSystemIndexName()));
                 return RetryableHttpAsyncClient.builder(delegate, options);
               }
       );

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
@@ -46,7 +46,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.flint.core.FlintClient;
 import org.opensearch.flint.core.FlintOptions;
 import org.opensearch.flint.core.IRestHighLevelClient;
-import org.opensearch.flint.core.auth.AWSRequestSigningApacheInterceptor;
+import org.opensearch.flint.core.auth.ResourceBasedAWSRequestSigningApacheInterceptor;
 import org.opensearch.flint.core.http.RetryableHttpAsyncClient;
 import org.opensearch.flint.core.metadata.FlintMetadata;
 import org.opensearch.flint.core.metadata.log.DefaultOptimisticTransaction;
@@ -282,7 +282,7 @@ public class FlintOpenSearchClient implements FlintClient {
 
       restClientBuilder.setHttpClientConfigCallback(builder -> {
                 HttpAsyncClientBuilder delegate = builder.addInterceptorLast(
-                        new AWSRequestSigningApacheInterceptor(
+                        new ResourceBasedAWSRequestSigningApacheInterceptor(
                                 signer.getServiceName(), signer, customAWSCredentialsProvider.get(), metadataAccessAWSCredentialsProvider.get(), options.getSystemIndexName()));
                 return RetryableHttpAsyncClient.builder(delegate, options);
               }

--- a/flint-core/src/test/scala/org/opensearch/flint/core/auth/ResourceBasedAWSRequestSigningApacheInterceptorTest.java
+++ b/flint-core/src/test/scala/org/opensearch/flint/core/auth/ResourceBasedAWSRequestSigningApacheInterceptorTest.java
@@ -1,0 +1,66 @@
+package org.opensearch.flint.core.auth;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.Signer;
+import org.apache.http.HttpRequest;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.*;
+
+public class ResourceBasedAWSRequestSigningApacheInterceptorTest {
+
+    @Mock
+    private Signer mockSigner;
+    @Mock
+    private AWSCredentialsProvider mockPrimaryCredentialsProvider;
+    @Mock
+    private AWSCredentialsProvider mockMetadataAccessCredentialsProvider;
+    @Mock
+    private HttpContext mockContext;
+    @Captor
+    private ArgumentCaptor<HttpRequest> httpRequestCaptor;
+
+    private ResourceBasedAWSRequestSigningApacheInterceptor interceptor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        AWSRequestSigningApacheInterceptor primaryInterceptorSpy = spy(new AWSRequestSigningApacheInterceptor("es", mockSigner, mockPrimaryCredentialsProvider));
+        AWSRequestSigningApacheInterceptor metadataInterceptorSpy = spy(new AWSRequestSigningApacheInterceptor("es", mockSigner, mockMetadataAccessCredentialsProvider));
+
+        interceptor = new ResourceBasedAWSRequestSigningApacheInterceptor(
+                "es",
+                primaryInterceptorSpy,
+                metadataInterceptorSpy,
+                "/metadata");
+    }
+
+    @Test
+    public void testProcessWithMetadataAccess() throws Exception {
+        HttpRequest request = new BasicHttpRequest("GET", "/es/metadata/resource");
+
+        interceptor.process(request, mockContext);
+
+        verify(interceptor.metadataAccessInterceptor).process(httpRequestCaptor.capture(), eq(mockContext));
+        verify(interceptor.primaryInterceptor, never()).process(any(HttpRequest.class), any(HttpContext.class));
+        assert httpRequestCaptor.getValue().getRequestLine().getUri().contains("/metadata");
+    }
+
+    @Test
+    public void testProcessWithoutMetadataAccess() throws Exception {
+        HttpRequest request = new BasicHttpRequest("GET", "/es/regular/resource");
+
+        interceptor.process(request, mockContext);
+
+        verify(interceptor.primaryInterceptor).process(httpRequestCaptor.capture(), eq(mockContext));
+        verify(interceptor.metadataAccessInterceptor, never()).process(any(HttpRequest.class), any(HttpContext.class));
+        assert !httpRequestCaptor.getValue().getRequestLine().getUri().contains("/metadata");
+    }
+}

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -77,12 +77,6 @@ object FlintSparkConf {
       .doc("AWS customAWSCredentialsProvider")
       .createWithDefault(FlintOptions.DEFAULT_AWS_CREDENTIALS_PROVIDER)
 
-  val SUPER_ADMIN_AWS_CREDENTIALS_PROVIDER =
-    FlintConfig("spark.datasource.flint.superAdminAWSCredentialsProvider")
-      .datasourceOption()
-      .doc("AWS credentials provider for super admin permission")
-      .createWithDefault(FlintOptions.DEFAULT_AWS_CREDENTIALS_PROVIDER)
-
   val DOC_ID_COLUMN_NAME = FlintConfig("spark.datasource.flint.write.id_name")
     .datasourceOption()
     .doc(
@@ -180,6 +174,10 @@ object FlintSparkConf {
     FlintConfig(s"spark.flint.job.inactivityLimitMillis")
       .doc("inactivity timeout")
       .createWithDefault(String.valueOf(FlintOptions.DEFAULT_INACTIVITY_LIMIT_MILLIS))
+  val METADATA_ACCESS_AWS_CREDENTIALS_PROVIDER =
+    FlintConfig("spark.metadata.accessAWSCredentialsProvider")
+      .doc("AWS credentials provider for metadata access permission")
+      .createOptional()
 }
 
 /**
@@ -227,7 +225,6 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
       RETRYABLE_HTTP_STATUS_CODES,
       REGION,
       CUSTOM_AWS_CREDENTIALS_PROVIDER,
-      SUPER_ADMIN_AWS_CREDENTIALS_PROVIDER,
       USERNAME,
       PASSWORD,
       SOCKET_TIMEOUT_MILLIS,
@@ -241,6 +238,7 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
       DATA_SOURCE_NAME,
       SESSION_ID,
       REQUEST_INDEX,
+      METADATA_ACCESS_AWS_CREDENTIALS_PROVIDER,
       EXCLUDE_JOB_IDS)
       .map(conf => (conf.optionKey, conf.readFrom(reader)))
       .flatMap {

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -75,7 +75,13 @@ object FlintSparkConf {
     FlintConfig("spark.datasource.flint.customAWSCredentialsProvider")
       .datasourceOption()
       .doc("AWS customAWSCredentialsProvider")
-      .createWithDefault(FlintOptions.DEFAULT_CUSTOM_AWS_CREDENTIALS_PROVIDER)
+      .createWithDefault(FlintOptions.DEFAULT_AWS_CREDENTIALS_PROVIDER)
+
+  val SUPER_ADMIN_AWS_CREDENTIALS_PROVIDER =
+    FlintConfig("spark.datasource.flint.superAdminAWSCredentialsProvider")
+      .datasourceOption()
+      .doc("AWS credentials provider for super admin permission")
+      .createWithDefault(FlintOptions.DEFAULT_AWS_CREDENTIALS_PROVIDER)
 
   val DOC_ID_COLUMN_NAME = FlintConfig("spark.datasource.flint.write.id_name")
     .datasourceOption()
@@ -221,6 +227,7 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
       RETRYABLE_HTTP_STATUS_CODES,
       REGION,
       CUSTOM_AWS_CREDENTIALS_PROVIDER,
+      SUPER_ADMIN_AWS_CREDENTIALS_PROVIDER,
       USERNAME,
       PASSWORD,
       SOCKET_TIMEOUT_MILLIS,

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -9,6 +9,7 @@ import java.util.Optional
 
 import scala.collection.JavaConverters._
 
+import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.http.FlintRetryOptions._
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
@@ -60,6 +61,18 @@ class FlintSparkConfSuite extends FlintSuite {
     retryOptions.getMaxRetries shouldBe 5
     retryOptions.getRetryableHttpStatusCodes shouldBe "429,502,503,504"
     retryOptions.getRetryableExceptionClassNames.get() shouldBe "java.net.ConnectException"
+  }
+
+  test("test super admin AWS credentials provider option") {
+    withSparkConf("spark.datasource.flint.superAdminAWSCredentialsProvider") {
+      spark.conf.set(
+        "spark.datasource.flint.superAdminAWSCredentialsProvider",
+        "com.example.superAdminAWSCredentialsProvider")
+      val flintOptions = FlintSparkConf().flintOptions()
+      assert(flintOptions.getCustomAwsCredentialsProvider == "")
+      assert(
+        flintOptions.getSuperAdminAwsCredentialsProvider == "com.example.superAdminAWSCredentialsProvider")
+    }
   }
 
   /**

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -63,15 +63,15 @@ class FlintSparkConfSuite extends FlintSuite {
     retryOptions.getRetryableExceptionClassNames.get() shouldBe "java.net.ConnectException"
   }
 
-  test("test super admin AWS credentials provider option") {
-    withSparkConf("spark.datasource.flint.superAdminAWSCredentialsProvider") {
+  test("test metadata access AWS credentials provider option") {
+    withSparkConf("spark.metadata.accessAWSCredentialsProvider") {
       spark.conf.set(
-        "spark.datasource.flint.superAdminAWSCredentialsProvider",
-        "com.example.superAdminAWSCredentialsProvider")
+        "spark.metadata.accessAWSCredentialsProvider",
+        "com.example.MetadataAccessCredentialsProvider")
       val flintOptions = FlintSparkConf().flintOptions()
       assert(flintOptions.getCustomAwsCredentialsProvider == "")
       assert(
-        flintOptions.getSuperAdminAwsCredentialsProvider == "com.example.superAdminAWSCredentialsProvider")
+        flintOptions.getMetadataAccessAwsCredentialsProvider == "com.example.MetadataAccessCredentialsProvider")
     }
   }
 


### PR DESCRIPTION
### Description
Add AWS credentials provider for metadata access

Sample log for POC purpose

```
24/03/15 00:05:51 INFO OpenSearchUpdater: Checking if index exists: flint_ql_sessions
24/03/15 00:05:51 INFO AWSRequestSigningApacheInterceptor: POC - sign - use superAdminAWSCredentialsProvider
24/03/15 00:05:51 INFO HttpStatusCodeResultPredicate: Checking if status code is retryable: 200
24/03/15 00:05:51 INFO HttpStatusCodeResultPredicate: Status code 200 check result: false
24/03/15 00:05:51 INFO AWSRequestSigningApacheInterceptor: POC - sign - use superAdminAWSCredentialsProvider
24/03/15 00:05:52 INFO HttpStatusCodeResultPredicate: Checking if status code is retryable: 200
24/03/15 00:05:52 INFO HttpStatusCodeResultPredicate: Status code 200 check result: false
24/03/15 00:05:52 INFO FlintREPL: Updated job: {"jobid": 00fhpt3oa974g80q, "sessionId": 14} from flint_ql_sessions
24/03/15 00:05:52 INFO RetryableHttpAsyncClient: Building retryable http async client with options: FlintRetryOptions{maxRetries=3, retryableStatusCodes=429,502, retryableExceptionClassNames=Optional.empty}


24/03/15 00:05:53 INFO OpenSearchUpdater: Checking if index exists: flint_ql_sessions
24/03/15 00:05:53 INFO AWSRequestSigningApacheInterceptor: POC - sign - use superAdminAWSCredentialsProvider
24/03/15 00:05:54 INFO HttpStatusCodeResultPredicate: Checking if status code is retryable: 200
24/03/15 00:05:54 INFO HttpStatusCodeResultPredicate: Status code 200 check result: false
24/03/15 00:05:54 INFO AWSRequestSigningApacheInterceptor: POC - sign - use superAdminAWSCredentialsProvider
24/03/15 00:05:54 INFO FlintREPL: command complete: FlintCommand(state=failed, query=select count(*) from my_glue1.default.http_logs_plain, statementId=DL-IIIsBIPWmei_EQWEY, queryId=202, submitTime=1710458790645, error=Some(wait timeout))
24/03/15 00:05:54 INFO RetryableHttpAsyncClient: Building retryable http async client with options: FlintRetryOptions{maxRetries=3, retryableStatusCodes=429,502, retryableExceptionClassNames=Optional.empty}
24/03/15 00:05:54 INFO AWSRequestSigningApacheInterceptor: POC - sign - use awsCredentialsProvider


```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
