### PR TITLE
Rule out logical deleted skipping index in query rewrite

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/ApplyFlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/ApplyFlintSparkSkippingIndex.scala
@@ -40,7 +40,7 @@ class ApplyFlintSparkSkippingIndex(flint: FlintSpark) extends Rule[LogicalPlan] 
             false))
         if hasNoDisjunction(condition) && !location.isInstanceOf[FlintSparkSkippingFileIndex] =>
       val index = flint.describeIndex(getIndexName(table))
-      if (hasActiveSkippingIndex(index)) {
+      if (isActiveSkippingIndex(index)) {
         val skippingIndex = index.get.asInstanceOf[FlintSparkSkippingIndex]
         val indexFilter = rewriteToIndexFilter(skippingIndex, condition)
 
@@ -69,7 +69,7 @@ class ApplyFlintSparkSkippingIndex(flint: FlintSpark) extends Rule[LogicalPlan] 
           // Check if query plan already rewritten
           table.isInstanceOf[LogsTable] && !table.asInstanceOf[LogsTable].hasFileIndexScan() =>
       val index = flint.describeIndex(getIndexName(catalog, identifier))
-      if (hasActiveSkippingIndex(index)) {
+      if (isActiveSkippingIndex(index)) {
         val skippingIndex = index.get.asInstanceOf[FlintSparkSkippingIndex]
         val indexFilter = rewriteToIndexFilter(skippingIndex, condition)
         /*
@@ -123,7 +123,7 @@ class ApplyFlintSparkSkippingIndex(flint: FlintSpark) extends Rule[LogicalPlan] 
     }.isEmpty
   }
 
-  private def hasActiveSkippingIndex(index: Option[FlintSparkIndex]): Boolean = {
+  private def isActiveSkippingIndex(index: Option[FlintSparkIndex]): Boolean = {
     index.isDefined &&
     index.get.kind == SKIPPING_INDEX_TYPE &&
     index.get.latestLogEntry.exists(_.state != DELETED)

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -308,6 +308,28 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
     }
   }
 
+  test("should not rewrite original query if skipping index is logically deleted") {
+    flint
+      .skippingIndex()
+      .onTable(testTable)
+      .addPartitions("year", "month")
+      .create()
+    flint.deleteIndex(testIndex)
+
+    val query =
+      s"""
+         | SELECT name
+         | FROM $testTable
+         | WHERE year = 2023 AND month = 4
+         |""".stripMargin
+
+    val actual = sql(query).queryExecution.optimizedPlan
+    withFlintOptimizerDisabled {
+      val expect = sql(query).queryExecution.optimizedPlan
+      actual shouldBe expect
+    }
+  }
+
   test("can build partition skipping index and rewrite applicable query") {
     flint
       .skippingIndex()


### PR DESCRIPTION
### Description

Rule out the logical deleted skipping index in query rewrite. With changes in https://github.com/opensearch-project/opensearch-spark/pull/276, query writer has access to index state in log entry directly.

#### Testing

<pre>
spark-sql> SHOW FLINT INDEX IN myglue;
flint_myglue_ds_tables_http_logs_skipping_index  skipping  ds_tables  http_logs	NULL	false	<b>active</b>

spark-sql> EXPLAIN SELECT * FROM ds_tables.http_logs WHERE clientip = '127.0.0.1';
== Physical Plan ==
*(1) Filter (isnotnull(clientip#34) AND (clientip#34 = 127.0.0.1))
+- FileScan json ds_tables.http_logs[@timestamp#33,clientip#34,request#35,status#36,size#37,...]
  Batched: false, DataFilters: [isnotnull(clientip#34), (clientip#34 = 127.0.0.1)], Format: JSON,
  Location: <b>FlintSparkSkippingFileIndex</b>(1 paths)[s3://httplogs/http_logs_partitioned_json_bz2],...


spark-sql> DROP SKIPPING INDEX ON ds_tables.http_logs;
Time taken: 2.197 seconds


spark-sql> SHOW FLINT INDEX IN myglue;
flint_myglue_ds_tables_http_logs_skipping_index  skipping  ds_tables. http_logs	NULL	false	<b>deleted</b>

spark-sql> EXPLAIN SELECT * FROM ds_tables.http_logs WHERE clientip = '127.0.0.1';
== Physical Plan ==
*(1) Filter (isnotnull(clientip#34) AND (clientip#34 = 127.0.0.1))
+- FileScan json ds_tables.http_logs[@timestamp#33,clientip#34,request#35,status#36,size#37,..]
  Batched: false, DataFilters: [isnotnull(clientip#34), (clientip#34 = 127.0.0.1)], Format: JSON,
  Location: <b>CatalogFileIndex</b>(1 paths)[s3://httplogs/http_logs_partitioned_json_bz2],...
</pre>

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/272

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
