### PR TITLE
Fix shutdown bug due to non-daemon thread in driver

### DIFF
--- a/integ-test/src/test/scala/org/apache/spark/sql/FlintJobITSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/sql/FlintJobITSuite.scala
@@ -76,7 +76,7 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
         JobOperator(spark, query, dataSourceName, resultIndex, true, streamingRunningCount)
       job.envinromentProvider = new MockEnvironment(
         Map("SERVERLESS_EMR_JOB_ID" -> jobRunId, "SERVERLESS_EMR_VIRTUAL_CLUSTER_ID" -> appId))
-
+      job.terminateJVM = false
       job.start()
     }
     futureResult.onComplete {

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -34,6 +34,8 @@ trait FlintJobExecutor {
   var threadPoolFactory: ThreadPoolFactory = new DefaultThreadPoolFactory()
   var envinromentProvider: EnvironmentProvider = new RealEnvironment()
   var enableHiveSupport: Boolean = true
+  // termiante JVM in the presence non-deamon thread before exiting
+  var terminateJVM = true
 
   // The enabled setting, which can be applied only to the top-level mapping definition and to object fields,
   val resultIndexMapping =

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -57,8 +57,6 @@ object FlintREPL extends Logging with FlintJobExecutor {
   val EARLY_TERMIANTION_CHECK_FREQUENCY = 60000L
 
   @volatile var earlyExitFlag: Boolean = false
-  // termiante JVM in the presence non-deamon thread before exiting
-  var terminateJVM = true
 
   def updateSessionIndex(flintCommand: FlintCommand, updater: OpenSearchUpdater): Unit = {
     updater.update(flintCommand.statementId, FlintCommand.serialize(flintCommand))


### PR DESCRIPTION
### Description
Similar to https://github.com/opensearch-project/opensearch-spark/pull/175, this PR adds shutdown logic in FlintJob.

Tests:
* Verified in IT if terminateJVM is enabled, JVM would shut down.

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/270

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
