### PR TITLE
Ignore non-Flint index in show and describe index statement

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -178,7 +178,7 @@ class FlintSpark(val spark: SparkSession) extends Logging {
       flintClient
         .getAllIndexMetadata(indexNamePattern)
         .asScala
-        .map(FlintSparkIndexFactory.create)
+        .flatMap(FlintSparkIndexFactory.create)
     } else {
       Seq.empty
     }
@@ -196,8 +196,7 @@ class FlintSpark(val spark: SparkSession) extends Logging {
     logInfo(s"Describing index name $indexName")
     if (flintClient.exists(indexName)) {
       val metadata = flintClient.getIndexMetadata(indexName)
-      val index = FlintSparkIndexFactory.create(metadata)
-      Some(index)
+      FlintSparkIndexFactory.create(metadata)
     } else {
       Option.empty
     }

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
@@ -133,7 +133,9 @@ class FlintSparkIndexSqlITSuite extends FlintSparkSuite {
       // Create a non-Flint index which has flint_ prefix in coincidence
       openSearchClient
         .indices()
-        .create(new CreateIndexRequest("flint_spark_catalog_invalid_index"), RequestOptions.DEFAULT)
+        .create(
+          new CreateIndexRequest("flint_spark_catalog_invalid_index"),
+          RequestOptions.DEFAULT)
 
       // Show statement should ignore such index without problem
       checkAnswer(

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
@@ -5,6 +5,8 @@
 
 package org.opensearch.flint.spark
 
+import org.opensearch.client.RequestOptions
+import org.opensearch.client.indices.CreateIndexRequest
 import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.AUTO_REFRESH
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView
@@ -122,5 +124,23 @@ class FlintSparkIndexSqlITSuite extends FlintSparkSuite {
           true,
           "refreshing")))
     deleteTestIndex(testCoveringFlintIndex)
+  }
+
+  test("should ignore non-Flint index") {
+    try {
+      sql(s"CREATE SKIPPING INDEX ON $testTableQualifiedName (name VALUE_SET)")
+
+      // Create a non-Flint index which has flint_ prefix in coincidence
+      openSearchClient
+        .indices()
+        .create(new CreateIndexRequest("flint_spark_catalog_invalid_index"), RequestOptions.DEFAULT)
+
+      // Show statement should ignore such index without problem
+      checkAnswer(
+        sql(s"SHOW FLINT INDEX IN spark_catalog"),
+        Row(testSkippingFlintIndex, "skipping", "default", testTableName, null, false, "active"))
+    } finally {
+      deleteTestIndex(testSkippingFlintIndex)
+    }
   }
 }

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
@@ -7,6 +7,7 @@ package org.opensearch.flint.spark
 
 import org.opensearch.client.RequestOptions
 import org.opensearch.client.indices.CreateIndexRequest
+import org.opensearch.common.xcontent.XContentType
 import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.AUTO_REFRESH
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView
@@ -130,11 +131,26 @@ class FlintSparkIndexSqlITSuite extends FlintSparkSuite {
     try {
       sql(s"CREATE SKIPPING INDEX ON $testTableQualifiedName (name VALUE_SET)")
 
-      // Create a non-Flint index which has flint_ prefix in coincidence
+      // Create a non-Flint index which has "flint_" prefix in coincidence
       openSearchClient
         .indices()
         .create(
-          new CreateIndexRequest("flint_spark_catalog_invalid_index"),
+          new CreateIndexRequest("flint_spark_catalog_invalid_index1"),
+          RequestOptions.DEFAULT)
+
+      // Create a non-Flint index which has "flint_" prefix and _meta mapping in coincidence
+      openSearchClient
+        .indices()
+        .create(
+          new CreateIndexRequest("flint_spark_catalog_invalid_index2")
+            .mapping(
+              """{
+                |  "_meta": {
+                |    "custom": "test"
+                |  }
+                |}
+                |""".stripMargin,
+              XContentType.JSON),
           RequestOptions.DEFAULT)
 
       // Show statement should ignore such index without problem


### PR DESCRIPTION
### Description

This PR introduced changes in Flint index factory which captured any exception occurred during Flint index creation. The invalid index will be ignored and log a warning message as below. Because all `SHOW` and `DESC` statement make use of this factory, this should fix the issue for all show and describe statements.

```
4/03/26 09:58:40 WARN FlintSparkIndexFactory: Failed to create Flint index from metadata
FlintMetadata(0.3.0,,,,[Ljava.util.Map;@4f60ac31,{},{},{},None,None,
Some({"index.creation_date":"1711472320637","index.number_of_replicas":"1","index.number_of_shards":"1",
"index.provided_name":"flint_spark_catalog_invalid_index","index.uuid":"NUWGIPFjQqO_2hn6pF94_w",
"index.version.created":"136277827"}))
scala.MatchError:  (of class java.lang.String)
	at org.opensearch.flint.spark.FlintSparkIndexFactory$.doCreate(FlintSparkIndexFactory.scala:58)
	at org.opensearch.flint.spark.FlintSparkIndexFactory$.create(FlintSparkIndexFactory.scala:44)
	at org.opensearch.flint.spark.FlintSpark.$anonfun$describeIndexes$2(FlintSpark.scala:181)
	at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:293)
```

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/295

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
