### PR TITLE
Adding support to run integ tests on iceberg tables

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,10 @@ import Dependencies._
 lazy val scala212 = "2.12.14"
 lazy val sparkVersion = "3.3.2"
 lazy val opensearchVersion = "2.6.0"
+lazy val icebergVersion = "1.5.0"
+
+val scalaMinorVersion = scala212.split("\\.").take(2).mkString(".")
+val sparkMinorVersion = sparkVersion.split("\\.").take(2).mkString(".")
 
 ThisBuild / organization := "org.opensearch"
 
@@ -172,6 +176,8 @@ lazy val integtest = (project in file("integ-test"))
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "com.stephenn" %% "scalatest-json-jsonassert" % "0.2.5" % "test",
       "org.testcontainers" % "testcontainers" % "1.18.0" % "test",
+      "org.apache.iceberg" %% s"iceberg-spark-runtime-$sparkMinorVersion" % icebergVersion % "test",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0" % "test",
       // add opensearch-java client to get node stats
       "org.opensearch.client" % "opensearch-java" % "2.6.0" % "test"
         exclude ("com.fasterxml.jackson.core", "jackson-databind")),

--- a/integ-test/src/test/scala/org/apache/spark/sql/FlintJobITSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/sql/FlintJobITSuite.scala
@@ -38,7 +38,7 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
     super.beforeAll()
     // initialized after the container is started
     osClient = new OSClient(new FlintOptions(openSearchOptions.asJava))
-    createPartitionedMultiRowTable(testTable)
+    createPartitionedMultiRowAddressTable(testTable)
   }
 
   protected override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -26,7 +26,7 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    createPartitionedTable(testTable)
+    createPartitionedAddressTable(testTable)
   }
 
   override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -31,7 +31,7 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
   override def beforeEach(): Unit = {
     super.beforeEach()
 
-    createPartitionedTable(testTable)
+    createPartitionedAddressTable(testTable)
   }
 
   override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
@@ -25,7 +25,7 @@ class FlintSparkIndexJobITSuite extends OpenSearchTransactionSuite with Matchers
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    createPartitionedTable(testTable)
+    createPartitionedAddressTable(testTable)
   }
 
   override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
@@ -30,7 +30,7 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    createPartitionedTable(testTable)
+    createPartitionedAddressTable(testTable)
 
     // Replace mock executor with real one and change its delay
     val realExecutor = newDaemonThreadPoolScheduledExecutor("flint-index-heartbeat", 1)

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -38,7 +38,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    createPartitionedMultiRowTable(testTable)
+    createPartitionedMultiRowAddressTable(testTable)
   }
 
   override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.internal.SQLConf
 class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
 
   /** Test table and index name */
-  private val testTable = "spark_catalog.default.test"
+  private val testTable = "spark_catalog.default.skipping_test"
   private val testIndex = getSkippingIndexName(testTable)
   private val testLatestId = Base64.getEncoder.encodeToString(testIndex.getBytes)
 
@@ -42,11 +42,10 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   override def afterEach(): Unit = {
-    super.afterEach()
-
     // Delete all test indices
     deleteTestIndex(testIndex)
     sql(s"DROP TABLE $testTable")
+    super.afterEach()
   }
 
   test("create skipping index with metadata successfully") {
@@ -63,7 +62,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
     index shouldBe defined
     index.get.metadata().getContent should matchJson(s"""{
         |   "_meta": {
-        |     "name": "flint_spark_catalog_default_test_skipping_index",
+        |     "name": "flint_spark_catalog_default_skipping_test_skipping_index",
         |     "version": "${current()}",
         |     "kind": "skipping",
         |     "indexedColumns": [
@@ -101,7 +100,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
         |        "columnName": "name",
         |        "columnType": "string"
         |     }],
-        |     "source": "spark_catalog.default.test",
+        |     "source": "spark_catalog.default.skipping_test",
         |     "options": {
         |       "auto_refresh": "false",
         |       "incremental_refresh": "false"
@@ -323,6 +322,10 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("should not rewrite original query if no skipping index") {
+    assume(
+      System.getProperty("TABLE_TYPE") != "iceberg",
+      """Test disabled for iceberg because Iceberg tables have a built-in
+        skipping index which rewrites queries""")
     val query =
       s"""
          | SELECT name
@@ -338,6 +341,10 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("should not rewrite original query if skipping index is logically deleted") {
+    assume(
+      System.getProperty("TABLE_TYPE") != "iceberg",
+      """Test disabled for Iceberg because Iceberg tables have a built-in
+        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -360,6 +367,10 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("can build partition skipping index and rewrite applicable query") {
+    assume(
+      System.getProperty("TABLE_TYPE") != "iceberg",
+      """Test disabled for Iceberg because Iceberg tables have a built-in
+        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -385,6 +396,10 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("can build value set skipping index and rewrite applicable query") {
+    assume(
+      System.getProperty("TABLE_TYPE") != "iceberg",
+      """Test disabled for Iceberg because Iceberg tables have a built-in
+        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -414,6 +429,10 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("can build min max skipping index and rewrite applicable query") {
+    assume(
+      System.getProperty("TABLE_TYPE") != "iceberg",
+      """Test disabled for Iceberg because Iceberg tables have a built-in
+        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -440,6 +459,10 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("can build bloom filter skipping index and rewrite applicable query") {
+    assume(
+      System.getProperty("TABLE_TYPE") != "iceberg",
+      """Test disabled for Iceberg because Iceberg tables have a built-in
+        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -471,6 +494,10 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("should rewrite applicable query with table name without database specified") {
+    assume(
+      System.getProperty("TABLE_TYPE") != "iceberg",
+      """Test disabled for Iceberg because Iceberg tables have a built-in
+        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -480,7 +507,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
     // Table name without database name "default"
     val query = sql(s"""
                        | SELECT name
-                       | FROM test
+                       | FROM skipping_test
                        | WHERE year = 2023
                        |""".stripMargin)
 
@@ -489,6 +516,10 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("should not rewrite original query if filtering condition has disjunction") {
+    assume(
+      System.getProperty("TABLE_TYPE") != "iceberg",
+      """Test disabled for Iceberg because Iceberg tables have a built-in
+        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -322,10 +322,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("should not rewrite original query if no skipping index") {
-    assume(
-      System.getProperty("TABLE_TYPE") != "iceberg",
-      """Test disabled for iceberg because Iceberg tables have a built-in
-        skipping index which rewrites queries""")
     val query =
       s"""
          | SELECT name
@@ -341,10 +337,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("should not rewrite original query if skipping index is logically deleted") {
-    assume(
-      System.getProperty("TABLE_TYPE") != "iceberg",
-      """Test disabled for Iceberg because Iceberg tables have a built-in
-        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -367,10 +359,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("can build partition skipping index and rewrite applicable query") {
-    assume(
-      System.getProperty("TABLE_TYPE") != "iceberg",
-      """Test disabled for Iceberg because Iceberg tables have a built-in
-        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -396,10 +384,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("can build value set skipping index and rewrite applicable query") {
-    assume(
-      System.getProperty("TABLE_TYPE") != "iceberg",
-      """Test disabled for Iceberg because Iceberg tables have a built-in
-        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -429,10 +413,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("can build min max skipping index and rewrite applicable query") {
-    assume(
-      System.getProperty("TABLE_TYPE") != "iceberg",
-      """Test disabled for Iceberg because Iceberg tables have a built-in
-        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -459,10 +439,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("can build bloom filter skipping index and rewrite applicable query") {
-    assume(
-      System.getProperty("TABLE_TYPE") != "iceberg",
-      """Test disabled for Iceberg because Iceberg tables have a built-in
-        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -494,10 +470,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("should rewrite applicable query with table name without database specified") {
-    assume(
-      System.getProperty("TABLE_TYPE") != "iceberg",
-      """Test disabled for Iceberg because Iceberg tables have a built-in
-        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)
@@ -516,10 +488,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   test("should not rewrite original query if filtering condition has disjunction") {
-    assume(
-      System.getProperty("TABLE_TYPE") != "iceberg",
-      """Test disabled for Iceberg because Iceberg tables have a built-in
-        skipping index which rewrites queries""")
     flint
       .skippingIndex()
       .onTable(testTable)

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
@@ -31,7 +31,7 @@ class FlintSparkSkippingIndexSqlITSuite extends FlintSparkSuite {
   override def beforeEach(): Unit = {
     super.beforeAll()
 
-    createPartitionedMultiRowTable(testTable)
+    createPartitionedMultiRowAddressTable(testTable)
   }
 
   protected override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkTransactionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkTransactionITSuite.scala
@@ -26,7 +26,7 @@ class FlintSparkTransactionITSuite extends OpenSearchTransactionSuite with Match
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    createPartitionedTable(testTable)
+    createPartitionedAddressTable(testTable)
   }
 
   override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkUpdateIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkUpdateIndexITSuite.scala
@@ -22,7 +22,7 @@ class FlintSparkUpdateIndexITSuite extends FlintSparkSuite {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    createPartitionedMultiRowTable(testTable)
+    createPartitionedMultiRowAddressTable(testTable)
   }
 
   override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergCoveringIndexITSuite.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.iceberg
+
+import org.opensearch.flint.spark.FlintSparkCoveringIndexSqlITSuite
+
+class FlintSparkIcebergCoveringIndexITSuite
+    extends FlintSparkCoveringIndexSqlITSuite
+    with FlintSparkIcebergSuite {}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.iceberg
+
+import org.opensearch.flint.spark.FlintSparkMaterializedViewSqlITSuite
+
+class FlintSparkIcebergMaterializedViewITSuite
+    extends FlintSparkMaterializedViewSqlITSuite
+    with FlintSparkIcebergSuite {}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergSkippingIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergSkippingIndexITSuite.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.iceberg
+
+import org.opensearch.flint.spark.FlintSparkSkippingIndexSqlITSuite
+
+class FlintSparkIcebergSkippingIndexITSuite
+    extends FlintSparkSkippingIndexSqlITSuite
+    with FlintSparkIcebergSuite {}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergSuite.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.iceberg
+
+import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
+import org.opensearch.flint.spark.FlintSparkExtensions
+import org.opensearch.flint.spark.FlintSparkSuite
+
+import org.apache.spark.SparkConf
+
+/**
+ * Flint Spark suite tailored for Iceberg.
+ */
+trait FlintSparkIcebergSuite extends FlintSparkSuite {
+
+  // Override table type to Iceberg for this suite
+  override lazy protected val tableType: String = "iceberg"
+
+  // You can also override tableOptions if Iceberg requires different options
+  override lazy protected val tableOptions: String = ""
+
+  // Override the sparkConf method to include Iceberg-specific configurations
+  override protected def sparkConf: SparkConf = {
+    val conf = super.sparkConf
+      // Set Iceberg-specific Spark configurations
+      .set("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
+      .set("spark.sql.catalog.spark_catalog.type", "hadoop")
+      .set("spark.sql.catalog.spark_catalog.warehouse", s"spark-warehouse/${suiteName}")
+      .set(
+        "spark.sql.extensions",
+        List(
+          classOf[IcebergSparkSessionExtensions].getName,
+          classOf[FlintSparkExtensions].getName).mkString(", "))
+    conf
+  }
+
+  override def afterAll(): Unit = {
+    deleteDirectory(s"spark-warehouse/${suiteName}")
+    super.afterAll()
+  }
+
+}

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintPPLSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintPPLSuite.scala
@@ -5,7 +5,7 @@
 
 package org.opensearch.flint.spark.ppl
 
-import org.opensearch.flint.spark.{FlintPPLSparkExtensions, FlintSparkExtensions}
+import org.opensearch.flint.spark.{FlintPPLSparkExtensions, FlintSparkExtensions, FlintSparkSuite}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
@@ -14,7 +14,7 @@ import org.apache.spark.sql.flint.config.FlintSparkConf.OPTIMIZER_RULE_ENABLED
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-trait FlintPPLSuite extends SharedSparkSession {
+trait FlintPPLSuite extends FlintSparkSuite {
   override protected def sparkConf: SparkConf = {
     val conf = new SparkConf()
       .set("spark.ui.enabled", "false")

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintPPLSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintPPLSuite.scala
@@ -5,6 +5,7 @@
 
 package org.opensearch.flint.spark.ppl
 
+import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
 import org.opensearch.flint.spark.{FlintPPLSparkExtensions, FlintSparkExtensions, FlintSparkSuite}
 
 import org.apache.spark.SparkConf
@@ -16,18 +17,13 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 trait FlintPPLSuite extends FlintSparkSuite {
   override protected def sparkConf: SparkConf = {
-    val conf = new SparkConf()
-      .set("spark.ui.enabled", "false")
-      .set(SQLConf.CODEGEN_FALLBACK.key, "false")
-      .set(SQLConf.CODEGEN_FACTORY_MODE.key, CodegenObjectFactoryMode.CODEGEN_ONLY.toString)
-      // Disable ConvertToLocalRelation for better test coverage. Test cases built on
-      // LocalRelation will exercise the optimization rules better by disabling it as
-      // this rule may potentially block testing of other optimization rules such as
-      // ConstantPropagation etc.
-      .set(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, ConvertToLocalRelation.ruleName)
+    val conf = super.sparkConf
       .set(
         "spark.sql.extensions",
-        List(classOf[FlintPPLSparkExtensions].getName, classOf[FlintSparkExtensions].getName)
+        List(
+          classOf[IcebergSparkSessionExtensions].getName,
+          classOf[FlintPPLSparkExtensions].getName,
+          classOf[FlintSparkExtensions].getName)
           .mkString(", "))
       .set(OPTIMIZER_RULE_ENABLED.key, "false")
     conf

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintPPLSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintPPLSuite.scala
@@ -5,7 +5,6 @@
 
 package org.opensearch.flint.spark.ppl
 
-import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
 import org.opensearch.flint.spark.{FlintPPLSparkExtensions, FlintSparkExtensions, FlintSparkSuite}
 
 import org.apache.spark.SparkConf
@@ -20,10 +19,7 @@ trait FlintPPLSuite extends FlintSparkSuite {
     val conf = super.sparkConf
       .set(
         "spark.sql.extensions",
-        List(
-          classOf[IcebergSparkSessionExtensions].getName,
-          classOf[FlintPPLSparkExtensions].getName,
-          classOf[FlintSparkExtensions].getName)
+        List(classOf[FlintPPLSparkExtensions].getName, classOf[FlintSparkExtensions].getName)
           .mkString(", "))
       .set(OPTIMIZER_RULE_ENABLED.key, "false")
     conf

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLAggregationWithSpanITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLAggregationWithSpanITSuite.scala
@@ -24,35 +24,7 @@ class FlintSparkPPLAggregationWithSpanITSuite
     super.beforeAll()
 
     // Create test table
-    // Update table creation
-    sql(s"""
-         | CREATE TABLE $testTable
-         | (
-         |   name STRING,
-         |   age INT,
-         |   state STRING,
-         |   country STRING
-         | )
-         | USING CSV
-         | OPTIONS (
-         |  header 'false',
-         |  delimiter '\t'
-         | )
-         | PARTITIONED BY (
-         |    year INT,
-         |    month INT
-         | )
-         |""".stripMargin)
-
-    // Update data insertion
-    sql(s"""
-         | INSERT INTO $testTable
-         | PARTITION (year=2023, month=4)
-         | VALUES ('Jake', 70, 'California', 'USA'),
-         |        ('Hello', 30, 'New York', 'USA'),
-         |        ('John', 25, 'Ontario', 'Canada'),
-         |        ('Jane', 20, 'Quebec', 'Canada')
-         | """.stripMargin)
+    createPartitionedStateCountryTable(testTable)
   }
 
   protected override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLAggregationsITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLAggregationsITSuite.scala
@@ -24,35 +24,7 @@ class FlintSparkPPLAggregationsITSuite
     super.beforeAll()
 
     // Create test table
-    // Update table creation
-    sql(s"""
-         | CREATE TABLE $testTable
-         | (
-         |   name STRING,
-         |   age INT,
-         |   state STRING,
-         |   country STRING
-         | )
-         | USING CSV
-         | OPTIONS (
-         |  header 'false',
-         |  delimiter '\t'
-         | )
-         | PARTITIONED BY (
-         |    year INT,
-         |    month INT
-         | )
-         |""".stripMargin)
-
-    // Update data insertion
-    sql(s"""
-         | INSERT INTO $testTable
-         | PARTITION (year=2023, month=4)
-         | VALUES ('Jake', 70, 'California', 'USA'),
-         |        ('Hello', 30, 'New York', 'USA'),
-         |        ('John', 25, 'Ontario', 'Canada'),
-         |        ('Jane', 20, 'Quebec', 'Canada')
-         | """.stripMargin)
+    createPartitionedStateCountryTable(testTable)
   }
 
   protected override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBasicITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBasicITSuite.scala
@@ -22,36 +22,9 @@ class FlintSparkPPLBasicITSuite
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    // Create test table
-    // Update table creation
-    sql(s"""
-         | CREATE TABLE $testTable
-         | (
-         |   name STRING,
-         |   age INT,
-         |   state STRING,
-         |   country STRING
-         | )
-         | USING CSV
-         | OPTIONS (
-         |  header 'false',
-         |  delimiter '\t'
-         | )
-         | PARTITIONED BY (
-         |    year INT,
-         |    month INT
-         | )
-         |""".stripMargin)
 
-    // Update data insertion
-    sql(s"""
-         | INSERT INTO $testTable
-         | PARTITION (year=2023, month=4)
-         | VALUES ('Jake', 70, 'California', 'USA'),
-         |        ('Hello', 30, 'New York', 'USA'),
-         |        ('John', 25, 'Ontario', 'Canada'),
-         |        ('Jane', 20, 'Quebec', 'Canada')
-         | """.stripMargin)
+    // Create test table
+    createPartitionedStateCountryTable(testTable)
   }
 
   protected override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLCorrelationITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLCorrelationITSuite.scala
@@ -28,100 +28,19 @@ class FlintSparkPPLCorrelationITSuite
   override def beforeAll(): Unit = {
     super.beforeAll()
     // Create test tables
-    sql(s"""
-         | CREATE TABLE $testTable1
-         | (
-         |   name STRING,
-         |   age INT,
-         |   state STRING,
-         |   country STRING
-         | )
-         | USING CSV
-         | OPTIONS (
-         |  header 'false',
-         |  delimiter '\t'
-         | )
-         | PARTITIONED BY (
-         |    year INT,
-         |    month INT
-         | )
-         |""".stripMargin)
-
-    sql(s"""
-         | CREATE TABLE $testTable2
-         | (
-         |   name STRING,
-         |   occupation STRING,
-         |   country STRING,
-         |   salary INT
-         | )
-         | USING CSV
-         | OPTIONS (
-         |  header 'false',
-         |  delimiter '\t'
-         | )
-         | PARTITIONED BY (
-         |    year INT,
-         |    month INT
-         | )
-         |""".stripMargin)
-
+    createPartitionedStateCountryTable(testTable1)
     // Update data insertion
     sql(s"""
          | INSERT INTO $testTable1
          | PARTITION (year=2023, month=4)
-         | VALUES ('Jake', 70, 'California', 'USA'),
-         |        ('Hello', 30, 'New York', 'USA'),
-         |        ('John', 25, 'Ontario', 'Canada'),
-         |        ('Jim', 27,  'B.C', 'Canada'),
+         | VALUES ('Jim', 27,  'B.C', 'Canada'),
          |        ('Peter', 57,  'B.C', 'Canada'),
          |        ('Rick', 70,  'B.C', 'Canada'),
-         |        ('David', 40,  'Washington', 'USA'),
-         |        ('Jane', 20, 'Quebec', 'Canada')
+         |        ('David', 40,  'Washington', 'USA')
          | """.stripMargin)
-    // Insert data into the new table
-    sql(s"""
-         | INSERT INTO $testTable2
-         | PARTITION (year=2023, month=4)
-         | VALUES ('Jake', 'Engineer', 'England' , 100000),
-         |        ('Hello', 'Artist', 'USA', 70000),
-         |        ('John', 'Doctor', 'Canada', 120000),
-         |        ('David', 'Doctor', 'USA', 120000),
-         |        ('David', 'Unemployed', 'Canada', 0),
-         |        ('Jane', 'Scientist', 'Canada', 90000)
-         | """.stripMargin)
-    sql(s"""
-           | CREATE TABLE $testTable3
-           | (
-           |   name STRING,
-           |   country STRING,
-           |   hobby STRING,
-           |   language STRING
-           | )
-           | USING CSV
-           | OPTIONS (
-           |  header 'false',
-           |  delimiter '\t'
-           | )
-           | PARTITIONED BY (
-           |    year INT,
-           |    month INT
-           | )
-           |""".stripMargin)
 
-    // Insert data into the new table
-    sql(s"""
-           | INSERT INTO $testTable3
-           | PARTITION (year=2023, month=4)
-           | VALUES ('Jake', 'USA', 'Fishing', 'English'),
-           |        ('Hello', 'USA', 'Painting', 'English'),
-           |        ('John', 'Canada', 'Reading', 'French'),
-           |        ('Jim', 'Canada', 'Hiking', 'English'),
-           |        ('Peter', 'Canada', 'Gaming', 'English'),
-           |        ('Rick', 'USA', 'Swimming', 'English'),
-           |        ('David', 'USA', 'Gardening', 'English'),
-           |        ('Jane', 'Canada', 'Singing', 'French')
-           | """.stripMargin)
+    createOccupationTable(testTable2)
+    createHobbiesTable(testTable3)
   }
 
   protected override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLCorrelationITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLCorrelationITSuite.scala
@@ -620,7 +620,15 @@ class FlintSparkPPLCorrelationITSuite
       Row(70000.0, "Canada", 50L),
       Row(95000.0, "USA", 40L))
 
-    implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, Long](_.getAs[Long](2))
+    // Define ordering for rows that first compares by age then by name
+    implicit val rowOrdering: Ordering[Row] = new Ordering[Row] {
+      def compare(x: Row, y: Row): Int = {
+        val ageCompare = x.getAs[Long](2).compareTo(y.getAs[Long](2))
+        if (ageCompare != 0) ageCompare
+        else x.getAs[String](1).compareTo(y.getAs[String](1))
+      }
+    }
+
     // Compare the results
     assert(results.sorted.sameElements(expectedResults.sorted))
 

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLFiltersITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLFiltersITSuite.scala
@@ -23,35 +23,7 @@ class FlintSparkPPLFiltersITSuite
   override def beforeAll(): Unit = {
     super.beforeAll()
     // Create test table
-    // Update table creation
-    sql(s"""
-         | CREATE TABLE $testTable
-         | (
-         |   name STRING,
-         |   age INT,
-         |   state STRING,
-         |   country STRING
-         | )
-         | USING CSV
-         | OPTIONS (
-         |  header 'false',
-         |  delimiter '\t'
-         | )
-         | PARTITIONED BY (
-         |    year INT,
-         |    month INT
-         | )
-         |""".stripMargin)
-
-    // Update data insertion
-    sql(s"""
-         | INSERT INTO $testTable
-         | PARTITION (year=2023, month=4)
-         | VALUES ('Jake', 70, 'California', 'USA'),
-         |        ('Hello', 30, 'New York', 'USA'),
-         |        ('John', 25, 'Ontario', 'Canada'),
-         |        ('Jane', 20, 'Quebec', 'Canada')
-         | """.stripMargin)
+    createPartitionedStateCountryTable(testTable)
   }
 
   protected override def afterEach(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLTimeWindowITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLTimeWindowITSuite.scala
@@ -232,12 +232,16 @@ class FlintSparkPPLTimeWindowITSuite
         "prod3",
         Timestamp.valueOf("2023-05-03 17:00:00"),
         Timestamp.valueOf("2023-05-04 17:00:00")))
-    // Compare the results
-    implicit val timestampOrdering: Ordering[Timestamp] = new Ordering[Timestamp] {
-      def compare(x: Timestamp, y: Timestamp): Int = x.compareTo(y)
+
+    // Define ordering for rows that first compares by the timestamp and then by the productId
+    implicit val rowOrdering: Ordering[Row] = new Ordering[Row] {
+      def compare(x: Row, y: Row): Int = {
+        val dateCompare = x.getAs[Timestamp](2).compareTo(y.getAs[Timestamp](2))
+        if (dateCompare != 0) dateCompare
+        else x.getAs[String](1).compareTo(y.getAs[String](1))
+      }
     }
 
-    implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, Timestamp](_.getAs[Timestamp](2))
     assert(results.sorted.sameElements(expectedResults.sorted))
 
     // Retrieve the logical plan

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLTimeWindowITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLTimeWindowITSuite.scala
@@ -26,49 +26,7 @@ class FlintSparkPPLTimeWindowITSuite
     super.beforeAll()
     // Create test table
     // Update table creation
-    sql(s"""
-         | CREATE TABLE $testTable
-         | (
-         |   transactionId STRING,
-         |   transactionDate TIMESTAMP,
-         |   productId STRING,
-         |   productsAmount INT,
-         |   customerId STRING
-         | )
-         | USING CSV
-         | OPTIONS (
-         |  header 'false',
-         |  delimiter '\t'
-         | )
-         | PARTITIONED BY (
-         |    year INT,
-         |    month INT
-         | )
-         |""".stripMargin)
-
-    // Update data insertion
-    // -- Inserting records into the testTable for April 2023
-    sql(s"""
-         |INSERT INTO $testTable PARTITION (year=2023, month=4)
-         |VALUES
-         |('txn001', CAST('2023-04-01 10:30:00' AS TIMESTAMP), 'prod1', 2, 'cust1'),
-         |('txn001', CAST('2023-04-01 14:30:00' AS TIMESTAMP), 'prod1', 4, 'cust1'),
-         |('txn002', CAST('2023-04-02 11:45:00' AS TIMESTAMP), 'prod2', 1, 'cust2'),
-         |('txn003', CAST('2023-04-03 12:15:00' AS TIMESTAMP), 'prod3', 3, 'cust1'),
-         |('txn004', CAST('2023-04-04 09:50:00' AS TIMESTAMP), 'prod1', 1, 'cust3')
-         |  """.stripMargin)
-
-    // Update data insertion
-    // -- Inserting records into the testTable for May 2023
-    sql(s"""
-         |INSERT INTO $testTable PARTITION (year=2023, month=5)
-         |VALUES
-         |('txn005', CAST('2023-05-01 08:30:00' AS TIMESTAMP), 'prod2', 1, 'cust4'),
-         |('txn006', CAST('2023-05-02 07:25:00' AS TIMESTAMP), 'prod4', 5, 'cust2'),
-         |('txn007', CAST('2023-05-03 15:40:00' AS TIMESTAMP), 'prod3', 1, 'cust3'),
-         |('txn007', CAST('2023-05-03 19:30:00' AS TIMESTAMP), 'prod3', 2, 'cust3'),
-         |('txn008', CAST('2023-05-04 14:15:00' AS TIMESTAMP), 'prod1', 4, 'cust1')
-         |  """.stripMargin)
+    createTimeSeriesTransactionTable(testTable)
   }
 
   protected override def afterEach(): Unit = {


### PR DESCRIPTION
### Description
This change adds the capability to run integration tests on iceberg tables. 

### Testing
```
sbt "integtest/test" 

[info] Run completed in 34 minutes, 32 seconds.
[info] Total number of tests run: 302
[info] Suites: completed 29, aborted 0
[info] Tests: succeeded 302, failed 0, canceled 0, ignored 1, pending 0
[info] All tests passed.
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
