### PR TITLE
Unescape query from EMR spark submit parameter

### DIFF
--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
@@ -56,8 +56,7 @@ object FlintJob extends Logging with FlintJobExecutor {
     conf.set(FlintSparkConf.JOB_TYPE.key, jobType)
 
     val dataSource = conf.get("spark.flint.datasource.name", "")
-    val query = queryOption.getOrElse(
-      unescapeQuery(conf.get(FlintSparkConf.QUERY.key, "")))
+    val query = queryOption.getOrElse(unescapeQuery(conf.get(FlintSparkConf.QUERY.key, "")))
     if (query.isEmpty) {
       throw new IllegalArgumentException(s"Query undefined for the ${jobType} job.")
     }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
@@ -56,7 +56,8 @@ object FlintJob extends Logging with FlintJobExecutor {
     conf.set(FlintSparkConf.JOB_TYPE.key, jobType)
 
     val dataSource = conf.get("spark.flint.datasource.name", "")
-    val query = queryOption.getOrElse(conf.get(FlintSparkConf.QUERY.key, ""))
+    val query = queryOption.getOrElse(
+      unescapeQuery(conf.get(FlintSparkConf.QUERY.key, "")))
     if (query.isEmpty) {
       throw new IllegalArgumentException(s"Query undefined for the ${jobType} job.")
     }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -363,8 +363,8 @@ trait FlintJobExecutor {
   }
 
   /**
-   * Unescape the query string which is escaped for EMR spark submit parameter parsing.
-   * Ref: https://github.com/opensearch-project/sql/pull/2587
+   * Unescape the query string which is escaped for EMR spark submit parameter parsing. Ref:
+   * https://github.com/opensearch-project/sql/pull/2587
    */
   def unescapeQuery(query: String): String = {
     unescapeJava(query)

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -251,7 +251,7 @@ object FlintREPL extends Logging with FlintJobExecutor {
         if (defaultQuery.isEmpty) {
           throw new IllegalArgumentException("Query undefined for the streaming job.")
         }
-        defaultQuery
+        unescapeQuery(defaultQuery)
       } else ""
     }
   }

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -95,11 +95,13 @@ class FlintREPLTest
     query shouldBe "SELECT * FROM table"
   }
 
-  test("getQuery should return unescaped default query for streaming job if queryOption is None") {
+  test(
+    "getQuery should return unescaped default query for streaming job if queryOption is None") {
     val queryOption = None
     val jobType = "streaming"
     val conf = new SparkConf().set(
-      FlintSparkConf.QUERY.key, "SELECT \\\"1\\\" UNION SELECT '\\\"1\\\"' UNION SELECT \\\"\\\\\\\"1\\\\\\\"\\\"")
+      FlintSparkConf.QUERY.key,
+      "SELECT \\\"1\\\" UNION SELECT '\\\"1\\\"' UNION SELECT \\\"\\\\\\\"1\\\\\\\"\\\"")
 
     val query = FlintREPL.getQuery(queryOption, jobType, conf)
     query shouldBe "SELECT \"1\" UNION SELECT '\"1\"' UNION SELECT \"\\\"1\\\"\""

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -95,6 +95,16 @@ class FlintREPLTest
     query shouldBe "SELECT * FROM table"
   }
 
+  test("getQuery should return unescaped default query for streaming job if queryOption is None") {
+    val queryOption = None
+    val jobType = "streaming"
+    val conf = new SparkConf().set(
+      FlintSparkConf.QUERY.key, "SELECT \\\"1\\\" UNION SELECT '\\\"1\\\"' UNION SELECT \\\"\\\\\\\"1\\\\\\\"\\\"")
+
+    val query = FlintREPL.getQuery(queryOption, jobType, conf)
+    query shouldBe "SELECT \"1\" UNION SELECT '\"1\"' UNION SELECT \"\\\"1\\\"\""
+  }
+
   test(
     "getQuery should throw IllegalArgumentException if queryOption is None and default query is not defined for streaming job") {
     val queryOption = None


### PR DESCRIPTION
### Description
In [a previous PR in sql](https://github.com/opensearch-project/sql/pull/2587), query is escaped in spark submit parameter. This PR unescapes the query on the receiving end, retrieving the original query. This affects only the query in SparkConf.

End to end test is performed as follows:
Query:
```
CREATE INDEX cv
ON mys3.default.http_logs (`status`, `day`, `size`, `request`)
WITH (
  auto_refresh = true,
  refresh_interval="5 Minutes",
  checkpoint_location = 's3://test',
  index_settings = "{\"number_of_shards\":1,\"number_of_replicas\":1}"
)
```
Spark submit parameter for the EMR job (query escaped and wrapped with quotes):
```
--conf spark.flint.job.query="CREATE INDEX cv ON mys3.default.http_logs (`status`, `day`, `size`, `request`) WITH (auto_refresh = true, refresh_interval=\"5 Minutes\", checkpoint_location = 's3://test',index_settings = \"{\\\"number_of_shards\\\":1,\\\"number_of_replicas\\\":1}\")"
```
Query received on spark *before* this PR fix (query still escaped and result in syntax error):
```
CREATE INDEX cv ON mys3.default.http_logs (`status`, `day`, `size`, `request`) WITH (auto_refresh = true, refresh_interval=\"5 Minutes\", checkpoint_location = 's3://test',index_settings = \"{\\\"number_of_shards\\\":1,\\\"number_of_replicas\\\":1}\")
```
Query received on spark *after* this PR fix (query unescaped):
```
CREATE INDEX cv ON mys3.default.http_logs (`status`, `day`, `size`, `request`) WITH (auto_refresh = true, refresh_interval="5 Minutes", checkpoint_location = 's3://test',index_settings = "{\"number_of_shards\":1,\"number_of_replicas\":1}")
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
