### PR TITLE
Allow non-existent checkpoint location path in index validation

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkValidationHelper.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkValidationHelper.scala
@@ -76,7 +76,11 @@ trait FlintSparkValidationHelper extends Logging {
           new Path(checkpointLocation),
           spark.sessionState.newHadoopConf())
 
+      // The primary intent here is to catch any exceptions during the accessibility check.
+      // The actual result is ignored, as Spark can create any necessary sub-folders
+      // when the streaming job starts.
       checkpointManager.exists(new Path(checkpointLocation))
+      true
     } catch {
       case e: IOException =>
         logWarning(s"Failed to check if checkpoint location $checkpointLocation exists", e)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/AutoIndexRefresh.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/AutoIndexRefresh.scala
@@ -56,7 +56,7 @@ class AutoIndexRefresh(indexName: String, index: FlintSparkIndex)
     if (checkpointLocation.isDefined) {
       require(
         isCheckpointLocationAccessible(spark, checkpointLocation.get),
-        s"Checkpoint location ${checkpointLocation.get} doesn't exist or no permission to access")
+        s"No permission to access the checkpoint location ${checkpointLocation.get}")
     }
   }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/IncrementalIndexRefresh.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/IncrementalIndexRefresh.scala
@@ -39,7 +39,7 @@ class IncrementalIndexRefresh(indexName: String, index: FlintSparkIndex)
       "Checkpoint location is required by incremental refresh")
     require(
       isCheckpointLocationAccessible(spark, checkpointLocation.get),
-      s"Checkpoint location ${checkpointLocation.get} doesn't exist or no permission to access")
+      s"No permission to access the checkpoint location ${checkpointLocation.get}")
   }
 
   override def start(spark: SparkSession, flintSparkConf: FlintSparkConf): Option[String] = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexValidationITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexValidationITSuite.scala
@@ -116,8 +116,8 @@ class FlintSparkIndexValidationITSuite extends FlintSparkSuite with SparkHiveSup
         withTable(testTable) {
           sql(s"CREATE TABLE $testTable (name STRING) USING JSON")
 
-          // Generate UUID as folder name to ensure the path not exist
-          val checkpointDir = s"/test/${UUID.randomUUID()}"
+          // Use unknown scheme URL to simulate location without access permission
+          val checkpointDir = "unknown://invalid_permission_path"
           the[IllegalArgumentException] thrownBy {
             sql(s"""
                  | $statement
@@ -127,7 +127,7 @@ class FlintSparkIndexValidationITSuite extends FlintSparkSuite with SparkHiveSup
                  | )
                  |""".stripMargin)
           } should have message
-            s"requirement failed: Checkpoint location $checkpointDir doesn't exist or no permission to access"
+            s"requirement failed: No permission to access the checkpoint location $checkpointDir"
         }
       }
     }


### PR DESCRIPTION
### Description

The pre-validation of checkpoint locations, introduced in [PR #297](https://github.com/opensearch-project/opensearch-spark/pull/297), requires the specified checkpoint path to exist. However, Spark is designed to automatically create necessary sub-folders when a streaming job begins. This PR is to relax this strict validation to enhance user convenience and ensure backward compatibility.

#### Testing

For checkpoint location without access permission, the behavior is the same as before:

<pre>
spark-sql> CREATE SKIPPING INDEX ON ds_tables.http_logs 
...                (clientip VALUE_SET) 
...                WITH (
...                  auto_refresh = true,
...                  <b>checkpoint_location = 's3://test/test'</b>
...                );

java.lang.IllegalArgumentException: requirement failed: 
  No permission to access the checkpoint location s3://test/test
</pre>

For checkpoint location with non-existent sub-folders, the validation can pass now and Spark streaming job creates it when start:

<pre>
# validation-test folder doesn't exist
spark-sql> CREATE SKIPPING INDEX ON ds_tables.http_logs 
...                (clientip VALUE_SET) 
...                WITH (
...                  auto_refresh = true,
...                  <b>checkpoint_location = 's3://daichen/validation-test'</b>
...                );
Time taken: 11.97 seconds

# both validation-test and validation-test/subtest1 folder doesn't exist
spark-sql> CREATE SKIPPING INDEX ON ds_tables.http_logs 
...                (clientip VALUE_SET) 
...                WITH (
...                  auto_refresh = true,
...                  <b>checkpoint_location = 's3://daichen/validation-test/subtest1'</b>
...                );
Time taken: 12.978 seconds
</pre>

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/65

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
