### PR TITLE
Apply new logging format to record exceptions

### DIFF
--- a/flint-core/src/main/java/org/opensearch/flint/core/logging/CustomLogging.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/logging/CustomLogging.java
@@ -44,9 +44,9 @@ public class CustomLogging {
     private static final Map<String, BiConsumer<String, Throwable>> logLevelActions = new HashMap<>();
 
     static {
-        String[] parts = System.getenv().getOrDefault("FLINT_CLUSTER_NAME", UNKNOWN + ":" + UNKNOWN).split(":");
+        DOMAIN_NAME = System.getenv().getOrDefault("FLINT_CLUSTER_NAME", UNKNOWN + ":" + UNKNOWN);
+        String[] parts = DOMAIN_NAME.split(":");
         CLIENT_ID = parts.length == 2 ? parts[0] : UNKNOWN;
-        DOMAIN_NAME = parts.length == 2 ? parts[1] : UNKNOWN;
 
         logLevelActions.put("DEBUG", logger::debug);
         logLevelActions.put("INFO", logger::info);
@@ -78,10 +78,6 @@ public class CustomLogging {
      * @return A map representation of the log event.
      */
     protected static Map<String, Object> constructLogEventMap(String level, Object content, Throwable throwable) {
-        if (content == null) {
-            throw new IllegalArgumentException("Log message must not be null");
-        }
-
         Map<String, Object> logEventMap = new LinkedHashMap<>();
         Map<String, Object> body = new LinkedHashMap<>();
         constructMessageBody(content, body);
@@ -105,6 +101,11 @@ public class CustomLogging {
     }
 
     private static void constructMessageBody(Object content, Map<String, Object> body) {
+        if (content == null) {
+            body.put("message", "");
+            return;
+        }
+
         if (content instanceof Message) {
             Message message = (Message) content;
             body.put("message", message.getFormattedMessage());
@@ -149,6 +150,10 @@ public class CustomLogging {
 
     public static void logError(Object message) {
         log("ERROR", message, null);
+    }
+
+    public static void logError(Throwable throwable) {
+        log("ERROR", "", throwable);
     }
 
     public static void logError(Object message, Throwable throwable) {


### PR DESCRIPTION
### Description
Apply new logging format to record actions
1. LogInfo on JobType

```
24/05/13 20:46:11 INFO CustomLogging: {"timestamp":1715633171427,"severityText":"INFO","severityNumber":9,"body":{"message":"Job type is: interactive"},"attributes":{"domainName":"xxxxxx","clientId":"xxxxxx"}}
```
2. LogError on exist errors in FlintREPL and FlintJob interface

```
24/05/13 20:46:39 ERROR CustomLogging: {"timestamp":1715633199579,"severityText":"ERROR","severityNumber":17,"body":{"message":"OpenSearch Operation failed with an exception:"},"attributes":{"domainName":"xxxxxx","clientId":"xxxxxx","exception.type":"java.net.ConnectException","exception.message":"Timeout connecting to xxxxxx"}}
```
3. Glue info redaction
```
{"Message":"Fail to read data from Glue. Cause: Access denied in AWS Glue service. Please check permissions. (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: null; Proxy: null)","ErrorSource":"AWSGlue","StatusCode":"400"}
```

```
24/05/13 22:47:51 ERROR CustomLogging: {"timestamp":1715640471319,"severityText":"ERROR","severityNumber":17,"body":{"message":"","statusCode":400},"attributes":{"domainName":"xxxxxx","clientId":"xxxxxx","exception.type":"com.amazonaws.services.glue.model.AccessDeniedException","exception.message":"Access denied in AWS Glue service. Please check permissions. (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: null; Proxy: null)"}}
```

```
      {
        "_index": "query_execution_result_myglue",
        "_id": "xxxxxx",
        "_score": null,
        "_source": {
          "error": """{"Message":"Fail to read data from Glue. Cause: Access denied in AWS Glue service. Please check permissions. (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: null; Proxy: null)","ErrorSource":"AWSGlue","StatusCode":"400"}""",
          "jobType": "interactive",
          "dataSourceName": "myglue"
        },
        "sort": [
          1715640471326
        ]
      },
```
### Issues Resolved
Follow up of https://github.com/opensearch-project/opensearch-spark/issues/235

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
