### PR TITLE
Add covering index based query rewriter rule

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,6 +133,7 @@ lazy val flintSparkIntegration = (project in file("flint-spark-integration"))
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest-flatspec" % "3.2.15" % "test",
       "org.scalatestplus" %% "mockito-4-6" % "3.2.15.0" % "test",
+      "org.mockito" % "mockito-inline" % "4.6.0" % "test",
       "com.stephenn" %% "scalatest-json-jsonassert" % "0.2.5" % "test",
       "com.github.sbt" % "junit-interface" % "0.13.3" % "test"),
     libraryDependencies ++= deps(sparkVersion),

--- a/docs/index.md
+++ b/docs/index.md
@@ -514,7 +514,8 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.datasource.flint.retry.max_retries`: max retries on failed HTTP request. default value is 3. Use 0 to disable retry.
 - `spark.datasource.flint.retry.http_status_codes`: retryable HTTP response status code list. default value is "429,502" (429 Too Many Request and 502 Bad Gateway).
 - `spark.datasource.flint.retry.exception_class_names`: retryable exception class name list. by default no retry on any exception thrown.
-- `spark.flint.optimizer.enabled`: default is true.
+- `spark.flint.optimizer.enabled`: default is true. enable the Flint optimizer for improving query performance.
+- `spark.flint.optimizer.covering.enabled`: default is true. enable the Flint covering index optimizer for improving query performance.
 - `spark.flint.index.hybridscan.enabled`: default is false.
 - `spark.flint.index.checkpoint.mandatory`: default is true.
 - `spark.datasource.flint.socket_timeout_millis`: default value is 60000.

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -205,7 +205,7 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
 
   def isOptimizerEnabled: Boolean = OPTIMIZER_RULE_ENABLED.readFrom(reader).toBoolean
 
-  def isCoveringIndexRewriteEnabled: Boolean =
+  def isCoveringIndexOptimizerEnabled: Boolean =
     OPTIMIZER_RULE_COVERING_INDEX_ENABLED.readFrom(reader).toBoolean
 
   def isHybridScanEnabled: Boolean = HYBRID_SCAN_ENABLED.readFrom(reader).toBoolean

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -133,6 +133,11 @@ object FlintSparkConf {
     .doc("Enable Flint optimizer rule for query rewrite with Flint index")
     .createWithDefault("true")
 
+  val OPTIMIZER_RULE_COVERING_INDEX_ENABLED =
+    FlintConfig("spark.flint.optimizer.covering.enabled")
+      .doc("Enable Flint optimizer rule for query rewrite with Flint covering index")
+      .createWithDefault("true")
+
   val HYBRID_SCAN_ENABLED = FlintConfig("spark.flint.index.hybridscan.enabled")
     .doc("Enable hybrid scan to include latest source data not refreshed to index yet")
     .createWithDefault("false")
@@ -199,6 +204,9 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
   }
 
   def isOptimizerEnabled: Boolean = OPTIMIZER_RULE_ENABLED.readFrom(reader).toBoolean
+
+  def isCoveringIndexRewriteEnabled: Boolean =
+    OPTIMIZER_RULE_COVERING_INDEX_ENABLED.readFrom(reader).toBoolean
 
   def isHybridScanEnabled: Boolean = HYBRID_SCAN_ENABLED.readFrom(reader).toBoolean
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkOptimizer.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkOptimizer.scala
@@ -28,7 +28,7 @@ class FlintSparkOptimizer(spark: SparkSession) extends Rule[LogicalPlan] {
     Seq(new ApplyFlintSparkCoveringIndex(flint), new ApplyFlintSparkSkippingIndex(flint))
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
-    if (isOptimizerEnabled) {
+    if (FlintSparkConf().isCoveringIndexRewriteEnabled) {
       rules.head.apply(plan) // TODO: apply one by one
     } else {
       plan

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkOptimizer.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkOptimizer.scala
@@ -5,6 +5,7 @@
 
 package org.opensearch.flint.spark
 
+import org.opensearch.flint.spark.covering.ApplyFlintSparkCoveringIndex
 import org.opensearch.flint.spark.skipping.ApplyFlintSparkSkippingIndex
 
 import org.apache.spark.sql.SparkSession
@@ -23,11 +24,12 @@ class FlintSparkOptimizer(spark: SparkSession) extends Rule[LogicalPlan] {
   private val flint: FlintSpark = new FlintSpark(spark)
 
   /** Only one Flint optimizer rule for now. Need to estimate cost if more than one in future. */
-  private val rule = new ApplyFlintSparkSkippingIndex(flint)
+  private val rules =
+    Seq(new ApplyFlintSparkCoveringIndex(flint), new ApplyFlintSparkSkippingIndex(flint))
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
     if (isOptimizerEnabled) {
-      rule.apply(plan)
+      rules.head.apply(plan) // TODO: apply one by one
     } else {
       plan
     }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.covering
+
+import java.util
+
+import org.opensearch.flint.spark.FlintSpark
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, V2WriteCommand}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.flint.{qualifyTableName, FlintDataSourceV2}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * Flint Spark covering index apply rule that rewrites applicable query's table scan operator to
+ * accelerate query by reducing data scanned significantly.
+ *
+ * @param flint
+ *   Flint Spark API
+ */
+class ApplyFlintSparkCoveringIndex(flint: FlintSpark) extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+
+    /**
+     * Prerequisite:
+     * ```
+     *   1) Not an insert statement
+     *   2) Relation is supported, ex. Iceberg, Delta, File. (is this check required?)
+     *   3) Any covering index on the table:
+     *     3.1) doesn't have filtering condition
+     *     3.2) cover all columns present in the query
+     * ```
+     */
+    case relation @ LogicalRelation(_, _, Some(table), false)
+        if !plan.isInstanceOf[V2WriteCommand] =>
+      val qualifiedTableName = qualifyTableName(flint.spark, table.qualifiedName)
+      val indexPattern = getFlintIndexName("*", qualifiedTableName)
+      val indexes = flint.describeIndexes(indexPattern)
+
+      // Choose the first covering index that meets all criteria
+      indexes
+        .collectFirst {
+          case index: FlintSparkCoveringIndex if index.filterCondition.isEmpty =>
+            val ds = new FlintDataSourceV2
+            val options = new CaseInsensitiveStringMap(util.Map.of("path", index.name()))
+            val inferredSchema = ds.inferSchema(options)
+            val flintTable = ds.getTable(inferredSchema, Array.empty, options)
+
+            // Adjust attributes to match the original plan's output
+            val outputAttributes = relation.output.map { attr =>
+              AttributeReference(attr.name, attr.dataType, attr.nullable, attr.metadata)(
+                attr.exprId,
+                attr.qualifier)
+            }
+
+            // Create the DataSourceV2 scan with corrected attributes
+            DataSourceV2Relation(flintTable, outputAttributes, None, None, options)
+        }
+        .getOrElse(relation) // If no index found, return the original relation
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
@@ -6,10 +6,10 @@
 package org.opensearch.flint.spark.covering
 
 import java.util
+
 import org.opensearch.flint.spark.FlintSpark
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
 
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, V2WriteCommand}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.LogicalRelation
@@ -67,11 +67,11 @@ class ApplyFlintSparkCoveringIndex(flint: FlintSpark) extends Rule[LogicalPlan] 
             val flintTable = ds.getTable(inferredSchema, Array.empty, options)
 
             // Adjust attributes to match the original plan's output
-            val outputAttributes = relation.output.map { attr =>
-              AttributeReference(attr.name, attr.dataType, attr.nullable, attr.metadata)(
-                attr.exprId,
-                attr.qualifier)
-            }
+            // TODO: replace original source column type with filed type in index metadata?
+            val outputAttributes =
+              index.indexedColumns.keys
+                .map(colName => relation.output.find(_.name == colName).get)
+                .toSeq
 
             // Create the DataSourceV2 scan with corrected attributes
             DataSourceV2Relation(flintTable, outputAttributes, None, None, options)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
@@ -7,7 +7,7 @@ package org.opensearch.flint.spark.covering
 
 import java.util
 
-import org.opensearch.flint.spark.FlintSpark
+import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex}
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
 
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, V2WriteCommand}
@@ -40,42 +40,54 @@ class ApplyFlintSparkCoveringIndex(flint: FlintSpark) extends Rule[LogicalPlan] 
      */
     case relation @ LogicalRelation(_, _, Some(table), false)
         if !plan.isInstanceOf[V2WriteCommand] =>
-      val qualifiedTableName = qualifyTableName(flint.spark, table.qualifiedName)
-      val indexPattern = getFlintIndexName("*", qualifiedTableName)
-      val indexes = flint.describeIndexes(indexPattern)
+      val tableName = table.qualifiedName
+      val requiredCols = allRequiredColumnsInQueryPlan(plan)
 
-      // Collect all columns needed by the query except those in relation. This is because this rule
-      // executes before push down optimization, relation includes all columns in the table.
-      val requiredCols =
-        plan
-          .collect {
-            case _: LogicalRelation => Set.empty[String]
-            case other => other.expressions.flatMap(_.references).map(_.name).toSet
-          }
-          .flatten
-          .toSet
-
-      // Choose the first covering index that meets all criteria
-      indexes
+      // Choose the first covering index that meets all criteria above
+      allCoveringIndexesOnTable(tableName)
         .collectFirst {
           case index: FlintSparkCoveringIndex
               if index.filterCondition.isEmpty &&
                 requiredCols.subsetOf(index.indexedColumns.keySet) =>
-            val ds = new FlintDataSourceV2
-            val options = new CaseInsensitiveStringMap(util.Map.of("path", index.name()))
-            val inferredSchema = ds.inferSchema(options)
-            val flintTable = ds.getTable(inferredSchema, Array.empty, options)
-
-            // Adjust attributes to match the original plan's output
-            // TODO: replace original source column type with filed type in index metadata?
-            val outputAttributes =
-              index.indexedColumns.keys
-                .map(colName => relation.output.find(_.name == colName).get)
-                .toSeq
-
-            // Create the DataSourceV2 scan with corrected attributes
-            DataSourceV2Relation(flintTable, outputAttributes, None, None, options)
+            replaceTableRelationWithIndexRelation(relation, index)
         }
         .getOrElse(relation) // If no index found, return the original relation
+  }
+
+  private def allRequiredColumnsInQueryPlan(plan: LogicalPlan): Set[String] = {
+    // Collect all columns needed by the query, except those in relation. This is because this rule
+    // executes before push down optimization and thus relation includes all columns in the table.
+    plan
+      .collect {
+        case _: LogicalRelation => Set.empty[String]
+        case other => other.expressions.flatMap(_.references).map(_.name).toSet
+      }
+      .flatten
+      .toSet
+  }
+
+  private def allCoveringIndexesOnTable(tableName: String): Seq[FlintSparkIndex] = {
+    val qualifiedTableName = qualifyTableName(flint.spark, tableName)
+    val indexPattern = getFlintIndexName("*", qualifiedTableName)
+    flint.describeIndexes(indexPattern)
+  }
+
+  private def replaceTableRelationWithIndexRelation(
+      relation: LogicalRelation,
+      index: FlintSparkCoveringIndex): LogicalPlan = {
+    val ds = new FlintDataSourceV2
+    val options = new CaseInsensitiveStringMap(util.Map.of("path", index.name()))
+    val inferredSchema = ds.inferSchema(options)
+    val flintTable = ds.getTable(inferredSchema, Array.empty, options)
+
+    // Adjust attributes to match the original plan's output
+    // TODO: replace original source column type with filed type in index metadata?
+    val outputAttributes =
+      index.indexedColumns.keys
+        .map(colName => relation.output.find(_.name == colName).get)
+        .toSeq
+
+    // Create the DataSourceV2 scan with corrected attributes
+    DataSourceV2Relation(flintTable, outputAttributes, None, None, options)
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
@@ -30,11 +30,12 @@ class ApplyFlintSparkCoveringIndex(flint: FlintSpark) extends Rule[LogicalPlan] 
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case relation @ LogicalRelation(_, _, Some(table), false)
-        if !plan.isInstanceOf[V2WriteCommand] => // Not an insert statement
+        if !plan.isInstanceOf[V2WriteCommand] => // TODO: make sure only intercept SELECT query
       val relationCols = collectRelationColumnsInQueryPlan(relation, plan)
 
       // Choose the first covering index that meets all criteria above
       findAllCoveringIndexesOnTable(table.qualifiedName)
+        .sortBy(_.name())
         .collectFirst {
           case index: FlintSparkCoveringIndex if isCoveringIndexApplicable(index, relationCols) =>
             replaceTableRelationWithIndexRelation(index, relation)

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.covering
+
+import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.Mockito.{mockStatic, when, RETURNS_DEEP_STUBS}
+import org.opensearch.flint.core.{FlintClient, FlintClientBuilder, FlintOptions}
+import org.opensearch.flint.spark.FlintSpark
+import org.scalatest.matchers.{Matcher, MatchResult}
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+import org.apache.spark.FlintSuite
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.sources.BaseRelation
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
+
+  private val testTable = "spark_catalog.default.apply_covering_index_test"
+
+  private val clientBuilder = mockStatic(classOf[FlintClientBuilder])
+  private val client = mock[FlintClient](RETURNS_DEEP_STUBS)
+
+  /** Mock the FlintSpark dependency */
+  private val flint = mock[FlintSpark]
+
+  /** Instantiate the rule once for all tests */
+  private val rule = new ApplyFlintSparkCoveringIndex(flint)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    clientBuilder
+      .when(() => FlintClientBuilder.build(any(classOf[FlintOptions])))
+      .thenReturn(client)
+    when(flint.spark).thenReturn(spark)
+  }
+
+  override protected def afterAll(): Unit = {
+    clientBuilder.close()
+    super.afterAll()
+  }
+
+  test("Covering index should be applied when all columns are covered") {
+    val schema = StructType(Seq(StructField("name", StringType), StructField("age", IntegerType)))
+    val baseRelation = mock[BaseRelation]
+    when(baseRelation.schema).thenReturn(schema)
+
+    val table = mock[CatalogTable]
+    // when(table.identifier).thenReturn(TableIdentifier("test_table", Some("default")))
+    when(table.qualifiedName).thenReturn("default.test_table")
+
+    val logicalRelation = LogicalRelation(baseRelation, table)
+    when(flint.describeIndexes(anyString())).thenReturn(
+      Seq(
+        new FlintSparkCoveringIndex(
+          indexName = "test_index",
+          tableName = "spark_catalog.default.test_table",
+          indexedColumns = Map("name" -> "string", "age" -> "int"),
+          filterCondition = None)))
+
+    when(client.getIndexMetadata(anyString()).getContent).thenReturn(s"""
+         | {
+         |   "properties": {
+         |     "name": {
+         |       "type": "keyword"
+         |     },
+         |     "age": {
+         |       "type": "integer"
+         |     }
+         |   }
+         | }
+         |""".stripMargin)
+
+    val transformedPlan = rule.apply(logicalRelation)
+    assert(transformedPlan.isInstanceOf[DataSourceV2Relation])
+  }
+
+  test("Covering index should be applied when all columns are covered 2") {
+    assertFlintQueryRewriter
+      .withTable(StructType.fromDDL("name STRING, age INT"))
+      .withProject("name", "age")
+      .withIndex(
+        new FlintSparkCoveringIndex(
+          indexName = "test_index",
+          tableName = testTable,
+          indexedColumns = Map("name" -> "string", "age" -> "int")))
+      .assertIndexUsed()
+  }
+
+  private def assertFlintQueryRewriter: AssertionHelper = new AssertionHelper
+
+  class AssertionHelper {
+    private var schema: StructType = _
+    private var plan: LogicalPlan = _
+    private var index: FlintSparkCoveringIndex = _
+
+    def withTable(schema: StructType): AssertionHelper = {
+      this.schema = schema
+      val baseRelation = mock[BaseRelation]
+      when(baseRelation.schema).thenReturn(schema)
+
+      val table = mock[CatalogTable]
+      when(table.qualifiedName).thenReturn(testTable)
+
+      this.plan = LogicalRelation(baseRelation, table)
+      this
+    }
+
+    def withProject(colNames: String*): AssertionHelper = {
+      val output = colNames.map(name => AttributeReference(name, schema(name).dataType)())
+      this.plan = Project(output, plan)
+      this
+    }
+
+    def withIndex(index: FlintSparkCoveringIndex): AssertionHelper = {
+      this.index = index
+      when(flint.describeIndexes(anyString())).thenReturn(Seq(index))
+      this
+    }
+
+    def assertIndexUsed(): AssertionHelper = {
+      when(client.getIndexMetadata(anyString())).thenReturn(index.metadata())
+
+      rule.apply(plan) should scanIndexOnly
+      this
+    }
+
+    private def scanIndexOnly(): Matcher[LogicalPlan] = {
+      Matcher { (plan: LogicalPlan) =>
+        val result = plan.exists {
+          case relation: DataSourceV2Relation =>
+            relation.table.name() == index.name()
+          case _ => false
+        }
+
+        MatchResult(
+          result,
+          "Plan does not scan index only as expected",
+          "Plan scan index only as expected")
+      }
+    }
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -61,6 +61,18 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
       .assertIndexNotUsed(testTable)
   }
 
+  test("should not apply if covering index is partial") {
+    assertFlintQueryRewriter
+      .withQuery(s"SELECT name FROM $testTable")
+      .withIndex(
+        new FlintSparkCoveringIndex(
+          indexName = "name",
+          tableName = testTable,
+          indexedColumns = Map("name" -> "string"),
+          filterCondition = Some("age > 30")))
+      .assertIndexNotUsed(testTable)
+  }
+
   test("should not apply if covering index is logically deleted") {
     assertFlintQueryRewriter
       .withQuery(s"SELECT name FROM $testTable")

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -71,7 +71,7 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
       .assertIndexNotUsed()
   }
 
-  // Covering index doesn't column age
+  // Covering index doesn't cover column age
   Seq(
     s"SELECT * FROM $testTable",
     s"SELECT name, age FROM $testTable",

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -163,4 +163,17 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
       .create()
     deleteTestIndex(getFlintIndexName(newIndex, testTable))
   }
+
+  test("rewrite applicable query with covering index") {
+    flint
+      .coveringIndex()
+      .name(testIndex)
+      .onTable(testTable)
+      .addIndexColumns("name", "age")
+      .create()
+
+    flint.refreshIndex(testFlintIndex)
+
+    sql(s"SELECT name, age FROM $testTable").show
+  }
 }

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -14,7 +14,6 @@ import org.scalatest.matchers.must.Matchers.defined
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.flint.config.FlintSparkConf.OPTIMIZER_RULE_COVERING_INDEX_ENABLED
 
 class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
 
@@ -163,49 +162,5 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
       .addIndexColumns("address")
       .create()
     deleteTestIndex(getFlintIndexName(newIndex, testTable))
-  }
-
-  test("rewrite applicable query with covering index") {
-    flint
-      .coveringIndex()
-      .name(testIndex)
-      .onTable(testTable)
-      .addIndexColumns("name", "age")
-      .create()
-
-    checkKeywordsExist(sql(s"EXPLAIN SELECT name, age FROM $testTable"), "FlintScan")
-  }
-
-  test("should not rewrite with covering index if disabled") {
-    flint
-      .coveringIndex()
-      .name(testIndex)
-      .onTable(testTable)
-      .addIndexColumns("name", "age")
-      .create()
-
-    spark.conf.set(OPTIMIZER_RULE_COVERING_INDEX_ENABLED.key, "false")
-    try {
-      checkKeywordsNotExist(sql(s"EXPLAIN SELECT name, age FROM $testTable"), "FlintScan")
-    } finally {
-      spark.conf.set(OPTIMIZER_RULE_COVERING_INDEX_ENABLED.key, "true")
-    }
-  }
-
-  test("rewrite applicable query with covering index before skipping index") {
-    flint
-      .skippingIndex()
-      .onTable(testTable)
-      .addValueSet("name")
-      .addMinMax("age")
-      .create()
-    flint
-      .coveringIndex()
-      .name(testIndex)
-      .onTable(testTable)
-      .addIndexColumns("name", "age")
-      .create()
-
-    checkKeywordsExist(sql(s"EXPLAIN SELECT name, age FROM $testTable"), "FlintScan")
   }
 }

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -19,7 +19,7 @@ import org.scalatest.matchers.must.Matchers.defined
 import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, the}
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.flint.config.FlintSparkConf.CHECKPOINT_MANDATORY
+import org.apache.spark.sql.flint.config.FlintSparkConf.{CHECKPOINT_MANDATORY, OPTIMIZER_RULE_COVERING_INDEX_ENABLED}
 
 class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
 
@@ -43,34 +43,23 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
   }
 
   test("create covering index with auto refresh") {
-    sql(s"""
-         | CREATE INDEX $testIndex ON $testTable
-         | (name, age)
-         | WITH (auto_refresh = true)
-         |""".stripMargin)
-
-    // Wait for streaming job complete current micro batch
-    val job = spark.streams.active.find(_.name == testFlintIndex)
-    job shouldBe defined
-    failAfter(streamingTimeout) {
-      job.get.processAllAvailable()
-    }
+    awaitRefreshComplete(s"""
+           | CREATE INDEX $testIndex ON $testTable
+           | (name, age)
+           | WITH (auto_refresh = true)
+           | """.stripMargin)
 
     val indexData = flint.queryIndex(testFlintIndex)
     indexData.count() shouldBe 2
   }
 
   test("create covering index with filtering condition") {
-    sql(s"""
+    awaitRefreshComplete(s"""
            | CREATE INDEX $testIndex ON $testTable
            | (name, age)
            | WHERE address = 'Portland'
            | WITH (auto_refresh = true)
            |""".stripMargin)
-
-    // Wait for streaming job complete current micro batch
-    val job = spark.streams.active.find(_.name == testFlintIndex)
-    awaitStreamingComplete(job.get.id.toString)
 
     val indexData = flint.queryIndex(testFlintIndex)
     indexData.count() shouldBe 1
@@ -256,6 +245,53 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
     metadata.indexedColumns.map(_.asScala("columnName")) shouldBe Seq("name", "age")
   }
 
+  test("rewrite applicable query with covering index") {
+    awaitRefreshComplete(s"""
+           | CREATE INDEX $testIndex ON $testTable
+           | (name, age)
+           | WITH (auto_refresh = true)
+           | """.stripMargin)
+
+    val query = s"SELECT name, age FROM $testTable"
+    checkKeywordsExist(sql(s"EXPLAIN $query"), "FlintScan")
+    checkAnswer(sql(query), Seq(Row("Hello", 30), Row("World", 25)))
+  }
+
+  test("should not rewrite with covering index if disabled") {
+    awaitRefreshComplete(s"""
+           | CREATE INDEX $testIndex ON $testTable
+           | (name, age)
+           | WITH (auto_refresh = true)
+           |""".stripMargin)
+
+    spark.conf.set(OPTIMIZER_RULE_COVERING_INDEX_ENABLED.key, "false")
+    try {
+      checkKeywordsNotExist(sql(s"EXPLAIN SELECT name, age FROM $testTable"), "FlintScan")
+    } finally {
+      spark.conf.set(OPTIMIZER_RULE_COVERING_INDEX_ENABLED.key, "true")
+    }
+  }
+
+  test("rewrite applicable query with covering index before skipping index") {
+    try {
+      sql(s"""
+           | CREATE SKIPPING INDEX ON $testTable
+           | (age MIN_MAX)
+           | """.stripMargin)
+      awaitRefreshComplete(s"""
+           | CREATE INDEX $testIndex ON $testTable
+           | (name, age)
+           | WITH (auto_refresh = true)
+           | """.stripMargin)
+
+      val query = s"SELECT name FROM $testTable WHERE age = 30"
+      checkKeywordsExist(sql(s"EXPLAIN $query"), "FlintScan")
+      checkAnswer(sql(query), Row("Hello"))
+    } finally {
+      deleteTestIndex(getSkippingIndexName(testTable))
+    }
+  }
+
   test("show all covering index on the source table") {
     flint
       .coveringIndex()
@@ -308,14 +344,11 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
     flint.describeIndex(testFlintIndex) shouldBe defined
     flint.queryIndex(testFlintIndex).count() shouldBe 0
 
-    sql(s"""
+    awaitRefreshComplete(s"""
          | ALTER INDEX $testIndex ON $testTable
          | WITH (auto_refresh = true)
          | """.stripMargin)
 
-    // Wait for streaming job complete current micro batch
-    val job = spark.streams.active.find(_.name == testFlintIndex)
-    awaitStreamingComplete(job.get.id.toString)
     flint.queryIndex(testFlintIndex).count() shouldBe 2
   }
 
@@ -330,5 +363,13 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
     sql(s"DROP INDEX $testIndex ON $testTable")
     sql(s"VACUUM INDEX $testIndex ON $testTable")
     flint.describeIndex(testFlintIndex) shouldBe empty
+  }
+
+  private def awaitRefreshComplete(query: String): Unit = {
+    sql(query)
+
+    // Wait for streaming job complete current micro batch
+    val job = spark.streams.active.find(_.name == testFlintIndex)
+    awaitStreamingComplete(job.get.id.toString)
   }
 }

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergCoveringIndexITSuite.scala
@@ -5,8 +5,9 @@
 
 package org.opensearch.flint.spark.iceberg
 
-import org.opensearch.flint.spark.FlintSparkCoveringIndexSqlITSuite
-
+// FIXME: support Iceberg table in covering index rewrite rule
+/*
 class FlintSparkIcebergCoveringIndexITSuite
     extends FlintSparkCoveringIndexSqlITSuite
     with FlintSparkIcebergSuite {}
+ */


### PR DESCRIPTION
### Description

This PR introduces the feature to rewrite applicable queries using covering indexes, enhancing the performance of SELECT queries by allowing faster data retrieval using these indexes.

#### PR Planned

- [ ] https://github.com/opensearch-project/opensearch-spark/pull/318
- [ ] Support query rewrite for Iceberg table (IT disabled temporarily)
- [ ] Add logging or whyNot API to explain why/whyNot index applied
- [ ] Support SQL hint for Spark conf, ex. CV rewrite, hybrid scan *[TBD]*
- [ ] Support partial covering index rewrite *[TBD]*

#### Changes

- Implemented query rewrite logic that detects when a covering index can be utilized for a query.
- Added new SQL test cases to ensure proper functionality and to validate that queries are only rewritten when appropriate indexes are available and enabled.
- Provided a new option to enable or disable query rewrites using covering indexes.

#### Testing

Added several unit and integration tests to cover:

- UT: The basic functionality of query rewrite when a suitable covering index exists.
- IT: Ensuring no rewrite occurs when covering indexes are disabled via Spark configuration.
- IT: Correct interaction of query rewrites in presence of both covering and skipping indexes.

Examples:

<pre>
<b># Create covering index as before</b>
spark-sql> CREATE INDEX all ON ds_tables.http_logs
         > (`@timestamp`, clientip, request, status, size);
spark-sql> REFRESH INDEX all ON ds_tables.http_logs;
Time taken: 9593.567 seconds

<b># Disable covering index acceleration</b>
spark-sql> set spark.flint.optimizer.covering.enabled=false;

spark-sql> EXPLAIN SELECT clientip, request AS cnt FROM ds_tables.http_logs WHERE status = 400;
== Physical Plan ==
*(1) Project [clientip#17, request#18 AS cnt#10]
+- *(1) Filter (isnotnull(status#19) AND (status#19 = 400))
   +- <b>FileScan</b> json ds_tables.http_logs[clientip#17,request#18,status#19,year#21,month#22,day#23]
Batched: false, DataFilters: [isnotnull(status#19), (status#19 = 400)], Format: JSON,
Location: FlintSparkSkippingFileIndex(1 paths)[s3://.../httplogs/http_logs_partitioned_json_bz2],
PartitionFilters: [], PushedFilters: [IsNotNull(status), EqualTo(status,400)],
ReadSchema: struct<clientip:string,request:string,status:int>

<b># Enable covering index acceleration</b>
spark-sql> set spark.flint.optimizer.covering.enabled=true;

spark-sql> EXPLAIN SELECT clientip, request AS cnt FROM ds_tables.http_logs WHERE status = 400;
== Physical Plan ==
*(1) Project [clientip#17, request#18 AS cnt#39]
+- BatchScan[@timestamp#16, request#18, size#20, clientip#17, status#19]
class <b>org.apache.spark.sql.flint.FlintScan,
PushedPredicates: [status IS NOT NULL, status = 400]</b>
 RuntimeFilters: []

<b># Join query</b>
spark-sql> EXPLAIN
         > SELECT l.clientip, l.status, s.description
         > FROM ds_tables.http_logs l
         > JOIN ds_tables.http_status s ON l.status = s.status
         > WHERE clientip = '157.12.11.0';
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Project [clientip#17, status#19, description#51]
   +- BroadcastHashJoin [status#19], [status#50], Inner, BuildRight, false
      :- Project [clientip#17, status#19]
      :  +- BatchScan[@timestamp#16, request#18, size#20, clientip#17, status#19]
class <b>org.apache.spark.sql.flint.FlintScan,
PushedPredicates: [clientip IS NOT NULL, clientip = '157.12.11.0', status IS NOT NULL]</b>
RuntimeFilters: []
      +- BroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=71]
         +- Filter isnotnull(status#50)
            +- <b>FileScan parquet ds_tables.http_status[status#50,description#51]</b> Batched: true,
DataFilters: [isnotnull(status#50)], Format: Parquet,
Location: InMemoryFileIndex(1 paths)[s3://.../httpstatus], PartitionFilters: [],
PushedFilters: [IsNotNull(status)], ReadSchema: struct<status:int,description:string>
</pre>

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/298

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
