### PR TITLE
Enhance Iceberg query performance with covering index support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,6 +130,7 @@ lazy val flintSparkIntegration = (project in file("flint-spark-integration"))
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-java-sdk" % "1.12.397" % "provided"
         exclude ("com.fasterxml.jackson.core", "jackson-databind"),
+      "org.apache.iceberg" %% s"iceberg-spark-runtime-$sparkMinorVersion" % icebergVersion % "provided",
       "org.scalactic" %% "scalactic" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest-flatspec" % "3.2.15" % "test",

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelation.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.source
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+
+/**
+ * This source relation abstraction allows Flint to interact uniformly with different kinds of
+ * source data formats (like Spark built-in File, Delta table, Iceberg, etc.), hiding the
+ * specifics of each data source implementation.
+ */
+trait FlintSparkSourceRelation {
+
+  /**
+   * @return
+   *   the concrete logical plan of the relation associated
+   */
+  def plan: LogicalPlan
+
+  /**
+   * @return
+   *   fully qualified table name represented by the relation
+   */
+  def tableName: String
+
+  /**
+   * @return
+   *   output column list of the relation
+   */
+  def output: Seq[AttributeReference]
+}
+
+/**
+ * Extractor that identifies source relation type and wrapping applicable logical plans into
+ * appropriate `FlintSparkSourceRelation` instance.
+ */
+object FlintSparkSourceRelation {
+  def unapply(plan: LogicalPlan): Option[FlintSparkSourceRelation] = plan match {
+    case relation @ LogicalRelation(_, _, Some(_), false) =>
+      Some(file.FlintSparkFileSourceRelation(relation))
+    case _ => None
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelation.scala
@@ -5,13 +5,8 @@
 
 package org.opensearch.flint.spark.source
 
-import org.opensearch.flint.spark.source.file.FileSourceRelation
-import org.opensearch.flint.spark.source.iceberg.IcebergSourceRelation
-
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.datasources.LogicalRelation
-import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
 /**
  * This source relation abstraction allows Flint to interact uniformly with different kinds of
@@ -37,11 +32,4 @@ trait FlintSparkSourceRelation {
    *   output column list of the relation
    */
   def output: Seq[AttributeReference]
-}
-
-trait FlintSparkSourceRelationProvider {
-
-  def isSupported(plan: LogicalPlan): Boolean
-
-  def getRelation(plan: LogicalPlan): FlintSparkSourceRelation
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelation.scala
@@ -5,9 +5,13 @@
 
 package org.opensearch.flint.spark.source
 
+import org.opensearch.flint.spark.source.file.FileSourceRelation
+import org.opensearch.flint.spark.source.iceberg.IcebergSourceRelation
+
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
 /**
  * This source relation abstraction allows Flint to interact uniformly with different kinds of
@@ -35,14 +39,9 @@ trait FlintSparkSourceRelation {
   def output: Seq[AttributeReference]
 }
 
-/**
- * Extractor that identifies source relation type and wrapping applicable logical plans into
- * appropriate `FlintSparkSourceRelation` instance.
- */
-object FlintSparkSourceRelation {
-  def unapply(plan: LogicalPlan): Option[FlintSparkSourceRelation] = plan match {
-    case relation @ LogicalRelation(_, _, Some(_), false) =>
-      Some(file.FlintSparkFileSourceRelation(relation))
-    case _ => None
-  }
+trait FlintSparkSourceRelationProvider {
+
+  def isSupported(plan: LogicalPlan): Boolean
+
+  def getRelation(plan: LogicalPlan): FlintSparkSourceRelation
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelationProvider.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelationProvider.scala
@@ -8,6 +8,7 @@ package org.opensearch.flint.spark.source
 import org.opensearch.flint.spark.source.file.FileSourceRelationProvider
 import org.opensearch.flint.spark.source.iceberg.IcebergSourceRelationProvider
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
@@ -50,7 +51,7 @@ trait FlintSparkSourceRelationProvider {
 /**
  * Companion object provides utility methods.
  */
-object FlintSparkSourceRelationProvider {
+object FlintSparkSourceRelationProvider extends Logging {
 
   /**
    * Retrieve all supported source relation provider for the given Spark session.
@@ -72,6 +73,9 @@ object FlintSparkSourceRelationProvider {
         .contains("org.apache.iceberg.spark.SparkSessionCatalog")) {
       relations = relations :+ new IcebergSourceRelationProvider
     }
+
+    val providerNames = relations.map(_.name()).mkString(",")
+    logInfo(s"Loaded source relation providers [$providerNames]")
     relations
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelationProvider.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelationProvider.scala
@@ -60,7 +60,7 @@ object FlintSparkSourceRelationProvider {
    * @return
    *   a sequence of source relation provider
    */
-  def getProviders(spark: SparkSession): Seq[FlintSparkSourceRelationProvider] = {
+  def getAllProviders(spark: SparkSession): Seq[FlintSparkSourceRelationProvider] = {
     var relations = Seq[FlintSparkSourceRelationProvider]()
 
     // File source is built-in supported

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelationProvider.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/FlintSparkSourceRelationProvider.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.source
+
+import org.opensearch.flint.spark.source.file.FileSourceRelationProvider
+import org.opensearch.flint.spark.source.iceberg.IcebergSourceRelationProvider
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+/**
+ * A provider defines what kind of logical plan can be supported by Flint Spark integration. It
+ * serves similar purpose to Scala extractor which has to be used in match case statement.
+ * However, the problem here is we want to avoid hard dependency on some data source code, such as
+ * Iceberg. In this case, we have to maintain a list of provider and run it only if the 3rd party
+ * library is available in current Spark session.
+ */
+trait FlintSparkSourceRelationProvider {
+
+  /**
+   * @return
+   *   the name of the source relation provider
+   */
+  def name(): String
+
+  /**
+   * Determines whether the given logical plan is supported by this provider.
+   *
+   * @param plan
+   *   the logical plan to evaluate
+   * @return
+   *   true if the plan is supported, false otherwise
+   */
+  def isSupported(plan: LogicalPlan): Boolean
+
+  /**
+   * Creates a source relation based on the provided logical plan.
+   *
+   * @param plan
+   *   the logical plan to wrap in source relation
+   * @return
+   *   an instance of source relation
+   */
+  def getRelation(plan: LogicalPlan): FlintSparkSourceRelation
+}
+
+/**
+ * Companion object provides utility methods.
+ */
+object FlintSparkSourceRelationProvider {
+
+  /**
+   * Retrieve all supported source relation provider for the given Spark session.
+   *
+   * @param spark
+   *   the Spark session
+   * @return
+   *   a sequence of source relation provider
+   */
+  def getProviders(spark: SparkSession): Seq[FlintSparkSourceRelationProvider] = {
+    var relations = Seq[FlintSparkSourceRelationProvider]()
+
+    // File source is built-in supported
+    relations = relations :+ new FileSourceRelationProvider
+
+    // Add Iceberg provider if it's enabled in Spark conf
+    if (spark.conf
+        .getOption("spark.sql.catalog.spark_catalog")
+        .contains("org.apache.iceberg.spark.SparkSessionCatalog")) {
+      relations = relations :+ new IcebergSourceRelationProvider
+    }
+    relations
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/file/FileSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/file/FileSourceRelation.scala
@@ -5,9 +5,10 @@
 
 package org.opensearch.flint.spark.source.file
 
-import org.opensearch.flint.spark.source.FlintSparkSourceRelation
+import org.opensearch.flint.spark.source.{FlintSparkSourceRelation, FlintSparkSourceRelationProvider}
 
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 
 /**
@@ -16,7 +17,7 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation
  * @param plan
  *   the relation plan associated with the file-based data source
  */
-case class FlintSparkFileSourceRelation(override val plan: LogicalRelation)
+case class FileSourceRelation(override val plan: LogicalRelation)
     extends FlintSparkSourceRelation {
 
   override def tableName: String =
@@ -25,4 +26,16 @@ case class FlintSparkFileSourceRelation(override val plan: LogicalRelation)
       .qualifiedName
 
   override def output: Seq[AttributeReference] = plan.output
+}
+
+class FileSourceRelationProvider extends FlintSparkSourceRelationProvider {
+
+  override def isSupported(plan: LogicalPlan): Boolean = plan match {
+    case LogicalRelation(_, _, Some(_), false) => true
+    case _ => false
+  }
+
+  override def getRelation(plan: LogicalPlan): FlintSparkSourceRelation = {
+    FileSourceRelation(plan.asInstanceOf[LogicalRelation])
+  }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/file/FileSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/file/FileSourceRelation.scala
@@ -5,17 +5,16 @@
 
 package org.opensearch.flint.spark.source.file
 
-import org.opensearch.flint.spark.source.{FlintSparkSourceRelation, FlintSparkSourceRelationProvider}
+import org.opensearch.flint.spark.source.FlintSparkSourceRelation
 
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 
 /**
  * Concrete source relation implementation for Spark built-in file-based data sources.
  *
  * @param plan
- *   the relation plan associated with the file-based data source
+ *   the `LogicalRelation` that represents the plan associated with the File-based table
  */
 case class FileSourceRelation(override val plan: LogicalRelation)
     extends FlintSparkSourceRelation {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/file/FileSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/file/FileSourceRelation.scala
@@ -21,21 +21,8 @@ case class FileSourceRelation(override val plan: LogicalRelation)
     extends FlintSparkSourceRelation {
 
   override def tableName: String =
-    plan.catalogTable
-      .getOrElse(throw new IllegalArgumentException("No table found in the source relation plan"))
+    plan.catalogTable.get // catalogTable must be present as pre-checked in source relation provider's
       .qualifiedName
 
   override def output: Seq[AttributeReference] = plan.output
-}
-
-class FileSourceRelationProvider extends FlintSparkSourceRelationProvider {
-
-  override def isSupported(plan: LogicalPlan): Boolean = plan match {
-    case LogicalRelation(_, _, Some(_), false) => true
-    case _ => false
-  }
-
-  override def getRelation(plan: LogicalPlan): FlintSparkSourceRelation = {
-    FileSourceRelation(plan.asInstanceOf[LogicalRelation])
-  }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/file/FileSourceRelationProvider.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/file/FileSourceRelationProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.source.file
+
+import org.opensearch.flint.spark.source.{FlintSparkSourceRelation, FlintSparkSourceRelationProvider}
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+
+/**
+ * Source relation provider for Spark built-in file-based source.
+ *
+ * @param name
+ *   the name of the file source provider
+ */
+class FileSourceRelationProvider(override val name: String = "file")
+    extends FlintSparkSourceRelationProvider {
+
+  override def isSupported(plan: LogicalPlan): Boolean = plan match {
+    case LogicalRelation(_, _, Some(_), false) => true
+    case _ => false
+  }
+
+  override def getRelation(plan: LogicalPlan): FlintSparkSourceRelation = {
+    FileSourceRelation(plan.asInstanceOf[LogicalRelation])
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/file/FlintSparkFileSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/file/FlintSparkFileSourceRelation.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.source.file
+
+import org.opensearch.flint.spark.source.FlintSparkSourceRelation
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+
+/**
+ * Concrete source relation implementation for Spark built-in file-based data sources.
+ *
+ * @param plan
+ *   the relation plan associated with the file-based data source
+ */
+case class FlintSparkFileSourceRelation(override val plan: LogicalRelation)
+    extends FlintSparkSourceRelation {
+
+  override def tableName: String =
+    plan.catalogTable
+      .getOrElse(throw new IllegalArgumentException("No table found in the source relation plan"))
+      .qualifiedName
+
+  override def output: Seq[AttributeReference] = plan.output
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/iceberg/IcebergSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/iceberg/IcebergSourceRelation.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.source.iceberg
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.opensearch.flint.spark.source.{FlintSparkSourceRelation, FlintSparkSourceRelationProvider}
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+
+/**
+ * Concrete implementation of `FlintSparkSourceRelation` for Iceberg-based data sources. This
+ * class encapsulates the handling of relations backed by Iceberg tables, which are built on top
+ * of Spark's DataSourceV2 and TableProvider interfaces.
+ *
+ * @param plan
+ *   the `DataSourceV2Relation` that represents the plan associated with the Iceberg table.
+ */
+case class IcebergSourceRelation(override val plan: DataSourceV2Relation)
+    extends FlintSparkSourceRelation {
+
+  /**
+   * Retrieves the fully qualified name of the table from the Iceberg table metadata. If the
+   * Iceberg table is not correctly referenced or the metadata is missing, an exception is thrown.
+   */
+  override def tableName: String =
+    plan.table.name() // TODO: confirm
+
+  /**
+   * Provides the output attributes of the logical plan. These attributes represent the schema of
+   * the Iceberg table as it appears in Spark's logical plan and are used to define the structure
+   * of the data returned by scans of the Iceberg table.
+   */
+  override def output: Seq[AttributeReference] = plan.output
+}
+
+class IcebergSourceRelationProvider extends FlintSparkSourceRelationProvider {
+
+  override def isSupported(plan: LogicalPlan): Boolean = plan match {
+    case DataSourceV2Relation(_: SparkTable, _, _, _, _) => true
+    case _ => false
+  }
+
+  override def getRelation(plan: LogicalPlan): FlintSparkSourceRelation = {
+    IcebergSourceRelation(plan.asInstanceOf[DataSourceV2Relation])
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/iceberg/IcebergSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/iceberg/IcebergSourceRelation.scala
@@ -5,11 +5,9 @@
 
 package org.opensearch.flint.spark.source.iceberg
 
-import org.apache.iceberg.spark.source.SparkTable
-import org.opensearch.flint.spark.source.{FlintSparkSourceRelation, FlintSparkSourceRelationProvider}
+import org.opensearch.flint.spark.source.FlintSparkSourceRelation
 
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
 /**
@@ -23,29 +21,8 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 case class IcebergSourceRelation(override val plan: DataSourceV2Relation)
     extends FlintSparkSourceRelation {
 
-  /**
-   * Retrieves the fully qualified name of the table from the Iceberg table metadata. If the
-   * Iceberg table is not correctly referenced or the metadata is missing, an exception is thrown.
-   */
   override def tableName: String =
     plan.table.name() // TODO: confirm
 
-  /**
-   * Provides the output attributes of the logical plan. These attributes represent the schema of
-   * the Iceberg table as it appears in Spark's logical plan and are used to define the structure
-   * of the data returned by scans of the Iceberg table.
-   */
   override def output: Seq[AttributeReference] = plan.output
-}
-
-class IcebergSourceRelationProvider extends FlintSparkSourceRelationProvider {
-
-  override def isSupported(plan: LogicalPlan): Boolean = plan match {
-    case DataSourceV2Relation(_: SparkTable, _, _, _, _) => true
-    case _ => false
-  }
-
-  override def getRelation(plan: LogicalPlan): FlintSparkSourceRelation = {
-    IcebergSourceRelation(plan.asInstanceOf[DataSourceV2Relation])
-  }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/iceberg/IcebergSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/iceberg/IcebergSourceRelation.scala
@@ -22,7 +22,7 @@ case class IcebergSourceRelation(override val plan: DataSourceV2Relation)
     extends FlintSparkSourceRelation {
 
   override def tableName: String =
-    plan.table.name() // TODO: confirm
+    plan.table.name()
 
   override def output: Seq[AttributeReference] = plan.output
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/iceberg/IcebergSourceRelation.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/iceberg/IcebergSourceRelation.scala
@@ -22,7 +22,7 @@ case class IcebergSourceRelation(override val plan: DataSourceV2Relation)
     extends FlintSparkSourceRelation {
 
   override def tableName: String =
-    plan.table.name()
+    plan.identifier.map(_.toString()).get
 
   override def output: Seq[AttributeReference] = plan.output
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/iceberg/IcebergSourceRelationProvider.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/source/iceberg/IcebergSourceRelationProvider.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.source.iceberg
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.opensearch.flint.spark.source.{FlintSparkSourceRelation, FlintSparkSourceRelationProvider}
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanRelation}
+
+/**
+ * Source relation provider for Apache Iceberg-based source.
+ *
+ * @param name
+ *   the name of the Iceberg source provider
+ */
+class IcebergSourceRelationProvider(override val name: String = "iceberg")
+    extends FlintSparkSourceRelationProvider {
+
+  override def isSupported(plan: LogicalPlan): Boolean = plan match {
+    case DataSourceV2Relation(_: SparkTable, _, _, _, _) => true
+    case DataSourceV2ScanRelation(DataSourceV2Relation(_: SparkTable, _, _, _, _), _, _, _) =>
+      true
+    case _ => false
+  }
+
+  override def getRelation(plan: LogicalPlan): FlintSparkSourceRelation = plan match {
+    case relation @ DataSourceV2Relation(_: SparkTable, _, _, _, _) =>
+      IcebergSourceRelation(relation)
+    case DataSourceV2ScanRelation(
+          relation @ DataSourceV2Relation(_: SparkTable, _, _, _, _),
+          _,
+          _,
+          _) =>
+      IcebergSourceRelation(relation)
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -27,11 +27,11 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
   private val testTable = "spark_catalog.default.apply_covering_index_test"
   private val testTable2 = "spark_catalog.default.apply_covering_index_test_2"
 
-  // Mock FlintClient to avoid looking for real OpenSearch cluster
+  /** Mock FlintClient to avoid looking for real OpenSearch cluster */
   private val clientBuilder = mockStatic(classOf[FlintClientBuilder])
   private val client = mock[FlintClient](RETURNS_DEEP_STUBS)
 
-  /** Mock FlintSpark which is required by the rule */
+  /** Mock FlintSpark which is required by the rule. Deep stub required to replace spark val. */
   private val flint = mock[FlintSpark](RETURNS_DEEP_STUBS)
 
   /** Instantiate the rule once for all tests */
@@ -47,7 +47,6 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
       .when(() => FlintClientBuilder.build(any(classOf[FlintOptions])))
       .thenReturn(client)
     when(flint.spark).thenReturn(spark)
-    // when(flint.spark.conf.getOption(any())).thenReturn(None)
   }
 
   override protected def afterAll(): Unit = {

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -32,7 +32,7 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
   private val client = mock[FlintClient](RETURNS_DEEP_STUBS)
 
   /** Mock FlintSpark which is required by the rule */
-  private val flint = mock[FlintSpark]
+  private val flint = mock[FlintSpark](RETURNS_DEEP_STUBS)
 
   /** Instantiate the rule once for all tests */
   private val rule = new ApplyFlintSparkCoveringIndex(flint)
@@ -47,6 +47,7 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
       .when(() => FlintClientBuilder.build(any(classOf[FlintOptions])))
       .thenReturn(client)
     when(flint.spark).thenReturn(spark)
+    // when(flint.spark.conf.getOption(any())).thenReturn(None)
   }
 
   override protected def afterAll(): Unit = {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergCoveringIndexITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergCoveringIndexITSuite.scala
@@ -5,9 +5,8 @@
 
 package org.opensearch.flint.spark.iceberg
 
-// FIXME: support Iceberg table in covering index rewrite rule
-/*
+import org.opensearch.flint.spark.FlintSparkCoveringIndexSqlITSuite
+
 class FlintSparkIcebergCoveringIndexITSuite
     extends FlintSparkCoveringIndexSqlITSuite
     with FlintSparkIcebergSuite {}
- */


### PR DESCRIPTION
### Description

PR #318 disabled covering index IT for Iceberg temporarily. This PR adds the missing support and re-enable the IT.

#### PR Planned

- [x] https://github.com/opensearch-project/opensearch-spark/pull/318
- [ ] https://github.com/opensearch-project/opensearch-spark/pull/325 *[Current]*
- [x] Add logging or whyNot API to explain why/whyNot index applied *[Logging added in this PR]*
- [ ] Support SQL hint for Spark conf, ex. CV rewrite, hybrid scan *[TBD]*
- [ ] Support partial covering index rewrite *[TBD]*

#### Changes

Added new `FlintSparkSourceRelation` and `FlintSparkSourceRelationProvider` abstraction. See Scala doc for its responsibility. Will refactor `ApplyFlintSparkSkippingIndex` and `FlintSparkValidationHelper.isTableProviderSupported` based on these later.

<img width="1354" alt="Screenshot 2024-04-30 at 11 55 56 AM" src="https://github.com/opensearch-project/opensearch-spark/assets/46505291/17b68c72-c768-43ee-8458-4f23e6ce1caa">

### Testing

#### Spark Table

<pre>
spark-sql> CREATE INDEX all ON myglue.ds_tables.http_logs
         > (
         >   `@timestamp`,
         >   clientip,
         >   request,
         >   status,
         >   size
         > );

scala> sc.setLogLevel("INFO")
scala> sql("EXPLAIN SELECT clientip FROM myglue.ds_tables.http_logs WHERE status != 200").show

# Logging explains whether and why the index is applied
24/05/03 17:51:17 INFO FlintSparkSourceRelationProvider: Loaded source relation providers [file]
24/05/03 17:51:17 INFO ApplyFlintSparkCoveringIndex: Provider [file] can match sub plan LogicalRelation
24/05/03 17:51:18 INFO ApplyFlintSparkCoveringIndex: Found covering index 
[flint_myglue_ds_tables_http_logs_all_index] on table myglue.ds_tables.http_logs
24/05/03 17:51:18 INFO ApplyFlintSparkCoveringIndex:
 Is covering index flint_myglue_ds_tables_http_logs_all_index applicable: true
   Index state: Some(active)
   Index filter condition: None
   Columns required: Set(clientip, status)
   Columns indexed: Set(@timestamp, request, size, clientip, status)
</pre>

#### Iceberg Table

With Iceberg runtime, create Iceberg table and covering index successfully:

<pre>
$ spark-sql --jars /home/hadoop/flint-spark-integration-assembly-0.4.0-SNAPSHOT.jar,/home/hadoop/sql-job-assembly-0.1.0-SNAPSHOT.jar,<b>/usr/share/aws/iceberg/lib/iceberg-spark3-runtime.jar</b> \
--conf spark.sql.extensions=<b>org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions</b>,org.opensearch.flint.spark.FlintSparkExtensions \
--conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
<b>--conf spark.sql.catalog.spark_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
--conf spark.sql.catalog.spark_catalog.warehouse=s3://.../iceberg-warehouse</b> \
...

CREATE DATABASE myglue.iceberg;

spark-sql> CREATE TABLE myglue.iceberg.http_logs_iceberg (
         >   `@timestamp` TIMESTAMP,
         >   clientip STRING,
         >   request STRING,
         >   status INT,
         >   size INT
         > )
         > USING iceberg
         > LOCATION 's3://daichen-benchmark/iceberg-warehouse/httplogs_iceberg';
Time taken: 1.688 seconds
</pre>

Test query acceleration with covering index:

<pre>
spark-sql> EXPLAIN SELECT clientip FROM myglue.iceberg.http_logs_iceberg WHERE status != 200;
== Physical Plan ==
*(1) Project [clientip#39]
+- BatchScan[@timestamp#38, request#40, size#42, clientip#39, status#41]
<b>class org.apache.spark.sql.flint.FlintScan, PushedPredicates: [status IS NOT NULL, NOT (status = 200)]</b>
RuntimeFilters: []
</pre>

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/298

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
