### PR TITLE
Fix incorrect result in show index statement

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
@@ -76,8 +76,9 @@ trait FlintSparkCoveringIndexAstBuilder extends FlintSparkSqlExtensionsVisitor[A
       val indexNamePattern = FlintSparkCoveringIndex.getFlintIndexName("*", fullTableName)
       flint
         .describeIndexes(indexNamePattern)
-        .collect { case index: FlintSparkCoveringIndex =>
-          Row(index.indexName)
+        .collect {
+          case index: FlintSparkCoveringIndex if index.tableName == fullTableName =>
+            Row(index.indexName)
         }
     }
   }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/index/FlintSparkIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/index/FlintSparkIndexAstBuilder.scala
@@ -11,6 +11,7 @@ import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
 import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsVisitor, SparkSqlAstBuilder}
+import org.opensearch.flint.spark.sql.FlintSparkSqlAstBuilder.IndexBelongsTo
 import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser.ShowFlintIndexStatementContext
 
 import org.apache.spark.sql.Row
@@ -42,6 +43,7 @@ trait FlintSparkIndexAstBuilder extends FlintSparkSqlExtensionsVisitor[AnyRef] {
       val indexNamePattern = s"flint_${catalogDbName}_*"
       flint
         .describeIndexes(indexNamePattern)
+        .filter(index => index belongsTo ctx.catalogDb)
         .map { index =>
           val (databaseName, tableName, indexName) = index match {
             case skipping: FlintSparkSkippingIndex =>

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -339,6 +339,33 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
     deleteTestIndex(getFlintIndexName("idx_address", testTable), getSkippingIndexName(testTable))
   }
 
+  test("show covering index on source table with same prefix") {
+    flint
+      .coveringIndex()
+      .name(testIndex)
+      .onTable(testTable)
+      .addIndexColumns("name", "age")
+      .create()
+
+    val testTable2 = s"${testTable}_2"
+    withTable(testTable2) {
+      // Create another table with same prefix
+      createPartitionedAddressTable(testTable2)
+      flint
+        .coveringIndex()
+        .name(testIndex)
+        .onTable(testTable2)
+        .addIndexColumns("address")
+        .create()
+
+      // Expect no testTable2 present
+      val result = sql(s"SHOW INDEX ON $testTable")
+      checkAnswer(result, Seq(Row(testIndex)))
+
+      deleteTestIndex(getFlintIndexName(testIndex, testTable2))
+    }
+  }
+
   test("describe covering index") {
     flint
       .coveringIndex()

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -339,7 +339,7 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
     deleteTestIndex(getFlintIndexName("idx_address", testTable), getSkippingIndexName(testTable))
   }
 
-  test("show covering index on source table with same prefix") {
+  test("show covering index on source table with the same prefix") {
     flint
       .coveringIndex()
       .name(testIndex)

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
@@ -127,6 +127,18 @@ class FlintSparkIndexSqlITSuite extends FlintSparkSuite {
     deleteTestIndex(testCoveringFlintIndex)
   }
 
+  test("show flint index in database with the same prefix") {
+    flint.materializedView().name("spark_catalog.default.mv1").query(testMvQuery).create()
+    flint.materializedView().name("spark_catalog.default_test.mv2").query(testMvQuery).create()
+    checkAnswer(
+      sql(s"SHOW FLINT INDEX IN spark_catalog.default").select("index_name"),
+      Seq(Row("mv1")))
+
+    deleteTestIndex(
+      FlintSparkMaterializedView.getFlintIndexName("spark_catalog.default.mv1"),
+      FlintSparkMaterializedView.getFlintIndexName("spark_catalog.default_test.mv2"))
+  }
+
   test("should ignore non-Flint index") {
     try {
       sql(s"CREATE SKIPPING INDEX ON $testTableQualifiedName (name VALUE_SET)")

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -263,12 +263,20 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
       Seq(Row("mv1"), Row("mv2")))
 
     checkAnswer(sql(s"SHOW MATERIALIZED VIEW IN spark_catalog.other"), Seq.empty)
+
+    deleteTestIndex(
+      getFlintIndexName("spark_catalog.default.mv1"),
+      getFlintIndexName("spark_catalog.default.mv2"))
   }
 
   test("show materialized view in database with the same prefix") {
     flint.materializedView().name("spark_catalog.default.mv1").query(testQuery).create()
     flint.materializedView().name("spark_catalog.default_test.mv2").query(testQuery).create()
     checkAnswer(sql(s"SHOW MATERIALIZED VIEW IN spark_catalog.default"), Seq(Row("mv1")))
+
+    deleteTestIndex(
+      getFlintIndexName("spark_catalog.default.mv1"),
+      getFlintIndexName("spark_catalog.default_test.mv2"))
   }
 
   test("should return emtpy when show materialized views in empty database") {

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -265,6 +265,12 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
     checkAnswer(sql(s"SHOW MATERIALIZED VIEW IN spark_catalog.other"), Seq.empty)
   }
 
+  test("show materialized view in database with the same prefix") {
+    flint.materializedView().name("spark_catalog.default.mv1").query(testQuery).create()
+    flint.materializedView().name("spark_catalog.default_test.mv2").query(testQuery).create()
+    checkAnswer(sql(s"SHOW MATERIALIZED VIEW IN spark_catalog.default"), Seq(Row("mv1")))
+  }
+
   test("should return emtpy when show materialized views in empty database") {
     checkAnswer(sql(s"SHOW MATERIALIZED VIEW IN spark_catalog.other"), Seq.empty)
   }


### PR DESCRIPTION
### Description

This PR addresses the issue reported in #330, where `SHOW INDEX` and similar SQL statements returned index names associated with unintended tables due to same prefix in Flint index names. The underlying bug has been resolved by adding an additional validation step to verify catalog/database or the source table name after `describeIndex()`. This is fixed in Flint SQL layer, because the `describeIndex()` API is generic and accepts Flint index name.

Examples:

```
spark-sql> SHOW FLINT INDEX IN myglue.ds_tables;
flint_myglue_ds_tables_http_logs_all_index	covering	ds_tables	http_logs	all	false	active
flint_myglue_ds_tables_http_logs_lf_clientip_and_request_index	covering	ds_tables	http_logs_lf	clientip_and_request	false	active
flint_myglue_ds_tables_http_logs_lf_hive_all_index	covering	ds_tables	http_logs_lf_hive	all	false	active
flint_myglue_ds_tables_http_logs_perf_tiny_all_index	covering	ds_tables	http_logs_perf_tiny	all	false	active

# Before the fix
spark-sql> SHOW INDEX ON myglue.ds_tables.http_logs;
all
clientip_and_request
all
all

# After the fix
spark-sql> SHOW INDEX ON myglue.ds_tables.http_logs;
all
```

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/330

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
