### PR TITLE
Fix build index with special full table name

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -102,7 +102,7 @@ object FlintSparkIndex {
   }
 
   /**
-   * Add backticks to table name to escape special character
+   * Add backticks to all parts of full table name to escape special character
    *
    * @param fullTableName
    *   source full table name
@@ -113,7 +113,7 @@ object FlintSparkIndex {
     require(fullTableName.split('.').length >= 3, s"Table name $fullTableName is not qualified")
 
     val parts = fullTableName.split('.')
-    s"${parts(0)}.${parts(1)}.`${parts.drop(2).mkString(".")}`"
+    s"`${parts(0)}`.`${parts(1)}`.`${parts.drop(2).mkString(".")}`"
   }
 
   /**

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndexSuite.scala
@@ -20,6 +20,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.spark.FlintSuite
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.aggregate.CollectSet
 import org.apache.spark.sql.functions.col
 
@@ -71,17 +72,19 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
     indexDf.schema.fieldNames should contain only ("name", FILE_PATH_COLUMN, ID_COLUMN)
   }
 
-  test("can build index on table name with special characters") {
-    val testTableSpecial = "spark_catalog.default.test/2023/10"
+  test("can parse identifier name with special characters during index build") {
+    val testTableSpecial = "spark_catalog.de-fault.test/2023/10"
     val indexCol = mock[FlintSparkSkippingStrategy]
     when(indexCol.outputSchema()).thenReturn(Map("name" -> "string"))
     when(indexCol.getAggregators).thenReturn(
       Seq(CollectSet(col("name").expr).toAggregateExpression()))
     val index = new FlintSparkSkippingIndex(testTableSpecial, Seq(indexCol))
 
-    val df = spark.createDataFrame(Seq(("hello", 20))).toDF("name", "age")
-    val indexDf = index.build(spark, Some(df))
-    indexDf.schema.fieldNames should contain only ("name", FILE_PATH_COLUMN, ID_COLUMN)
+    val error = intercept[AnalysisException] {
+      index.build(spark, None)
+    }
+    // Getting this error means that parsing doesn't fail with unquoted identifier
+    assert(error.getMessage().contains("UnresolvedRelation"))
   }
 
   // Test index build for different column type


### PR DESCRIPTION
### Description
Fix build index with special full table name, including special characters in catalog name and database name.
Also fix test suite for it.

Note: removed a test case that was added unintentionally

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
