### PR TITLE
Updating security reachout email

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This project has adopted an [Open Source Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Security
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
+If you discover a potential security issue in this project we ask that you notify OpenSearch Security directly via email to security@opensearch.org. Please do **not** create a public GitHub issue.
 
 ## License
 


### PR DESCRIPTION
### Description
Updating security reach out email address from [aws-security@amazon.com](mailto:aws-security@amazon.com) to [security@opensearch.org](mailto:security@opensearch.org).

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
