### PR TITLE
Enhance index monitor to terminate streaming job on consecutive errors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -519,6 +519,9 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.flint.index.hybridscan.enabled`: default is false.
 - `spark.flint.index.checkpoint.mandatory`: default is true.
 - `spark.datasource.flint.socket_timeout_millis`: default value is 60000.
+- `spark.flint.monitor.initialDelaySeconds`: Initial delay in seconds before starting the monitoring task. Default value is 15.
+- `spark.flint.monitor.intervalSeconds`: Interval in seconds for scheduling the monitoring task. Default value is 60.
+- `spark.flint.monitor.maxErrorCount`: Maximum number of consecutive errors allowed before stopping the monitoring task. Default value is 5.
 
 #### Data Type Mapping
 

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -154,13 +154,17 @@ object FlintSparkConf {
     .doc("Checkpoint location for incremental refresh index will be mandatory if enabled")
     .createWithDefault("true")
 
+  val MONITOR_INITIAL_DELAY_SECONDS = FlintConfig("spark.flint.monitor.initialDelaySeconds")
+    .doc("Initial delay in seconds before starting the monitoring task")
+    .createWithDefault("15")
+
+  val MONITOR_INTERVAL_SECONDS = FlintConfig("spark.flint.monitor.intervalSeconds")
+    .doc("Interval in seconds for scheduling the monitoring task")
+    .createWithDefault("60")
+
   val MONITOR_MAX_ERROR_COUNT = FlintConfig("spark.flint.monitor.maxErrorCount")
     .doc("Maximum number of consecutive errors allowed in index monitor")
     .createWithDefault("5")
-
-  val MONITOR_INTERVAL_SECONDS = FlintConfig("spark.flint.monitor.interval")
-    .doc("Interval in seconds for scheduling the monitoring task")
-    .createWithDefault("60")
 
   val SOCKET_TIMEOUT_MILLIS =
     FlintConfig(s"spark.datasource.flint.${FlintOptions.SOCKET_TIMEOUT_MILLIS}")
@@ -231,9 +235,11 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
 
   def isCheckpointMandatory: Boolean = CHECKPOINT_MANDATORY.readFrom(reader).toBoolean
 
-  def monitorMaxErrorCount(): Int = MONITOR_MAX_ERROR_COUNT.readFrom(reader).toInt
+  def monitorInitialDelaySeconds(): Int = MONITOR_INITIAL_DELAY_SECONDS.readFrom(reader).toInt
 
   def monitorIntervalSeconds(): Int = MONITOR_INTERVAL_SECONDS.readFrom(reader).toInt
+
+  def monitorMaxErrorCount(): Int = MONITOR_MAX_ERROR_COUNT.readFrom(reader).toInt
 
   /**
    * spark.sql.session.timeZone

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -154,6 +154,14 @@ object FlintSparkConf {
     .doc("Checkpoint location for incremental refresh index will be mandatory if enabled")
     .createWithDefault("true")
 
+  val MONITOR_MAX_ERROR_COUNT = FlintConfig("spark.flint.monitor.maxErrorCount")
+    .doc("Maximum number of consecutive errors allowed in index monitor")
+    .createWithDefault("5")
+
+  val MONITOR_INTERVAL_SECONDS = FlintConfig("spark.flint.monitor.interval")
+    .doc("Interval in seconds for scheduling the monitoring task")
+    .createWithDefault("60")
+
   val SOCKET_TIMEOUT_MILLIS =
     FlintConfig(s"spark.datasource.flint.${FlintOptions.SOCKET_TIMEOUT_MILLIS}")
       .datasourceOption()
@@ -222,6 +230,10 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
   def isHybridScanEnabled: Boolean = HYBRID_SCAN_ENABLED.readFrom(reader).toBoolean
 
   def isCheckpointMandatory: Boolean = CHECKPOINT_MANDATORY.readFrom(reader).toBoolean
+
+  def monitorMaxErrorCount(): Int = MONITOR_MAX_ERROR_COUNT.readFrom(reader).toInt
+
+  def monitorIntervalSeconds(): Int = MONITOR_INTERVAL_SECONDS.readFrom(reader).toInt
 
   /**
    * spark.sql.session.timeZone

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -13,6 +13,7 @@ import org.opensearch.flint.core.http.FlintRetryOptions._
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.FlintSuite
+import org.apache.spark.sql.flint.config.FlintSparkConf.{MONITOR_INTERVAL_SECONDS, MONITOR_MAX_ERROR_COUNT}
 
 class FlintSparkConfSuite extends FlintSuite {
   test("test spark conf") {
@@ -82,6 +83,21 @@ class FlintSparkConfSuite extends FlintSuite {
     val overrideConf = FlintSparkConf(Map("write.batch_bytes" -> "4mb").asJava)
     overrideConf.batchBytes() shouldBe 4 * 1024 * 1024
     overrideConf.flintOptions().getBatchBytes shouldBe 4 * 1024 * 1024
+  }
+
+  test("test index monitor options") {
+    val defaultConf = FlintSparkConf()
+    defaultConf.monitorMaxErrorCount() shouldBe 5
+    defaultConf.monitorIntervalSeconds() shouldBe 60
+
+    withSparkConf(MONITOR_MAX_ERROR_COUNT.key, MONITOR_INTERVAL_SECONDS.key) {
+      setFlintSparkConf(MONITOR_MAX_ERROR_COUNT, 10)
+      setFlintSparkConf(MONITOR_INTERVAL_SECONDS, 30)
+
+      val overrideConf = FlintSparkConf()
+      overrideConf.monitorMaxErrorCount() shouldBe 10
+      overrideConf.monitorIntervalSeconds() shouldBe 30
+    }
   }
 
   /**

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -13,7 +13,7 @@ import org.opensearch.flint.core.http.FlintRetryOptions._
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.FlintSuite
-import org.apache.spark.sql.flint.config.FlintSparkConf.{MONITOR_INTERVAL_SECONDS, MONITOR_MAX_ERROR_COUNT}
+import org.apache.spark.sql.flint.config.FlintSparkConf.{MONITOR_INITIAL_DELAY_SECONDS, MONITOR_INTERVAL_SECONDS, MONITOR_MAX_ERROR_COUNT}
 
 class FlintSparkConfSuite extends FlintSuite {
   test("test spark conf") {
@@ -87,16 +87,19 @@ class FlintSparkConfSuite extends FlintSuite {
 
   test("test index monitor options") {
     val defaultConf = FlintSparkConf()
-    defaultConf.monitorMaxErrorCount() shouldBe 5
+    defaultConf.monitorInitialDelaySeconds() shouldBe 15
     defaultConf.monitorIntervalSeconds() shouldBe 60
+    defaultConf.monitorMaxErrorCount() shouldBe 5
 
     withSparkConf(MONITOR_MAX_ERROR_COUNT.key, MONITOR_INTERVAL_SECONDS.key) {
-      setFlintSparkConf(MONITOR_MAX_ERROR_COUNT, 10)
+      setFlintSparkConf(MONITOR_INITIAL_DELAY_SECONDS, 5)
       setFlintSparkConf(MONITOR_INTERVAL_SECONDS, 30)
+      setFlintSparkConf(MONITOR_MAX_ERROR_COUNT, 10)
 
       val overrideConf = FlintSparkConf()
-      overrideConf.monitorMaxErrorCount() shouldBe 10
+      defaultConf.monitorInitialDelaySeconds() shouldBe 5
       overrideConf.monitorIntervalSeconds() shouldBe 30
+      overrideConf.monitorMaxErrorCount() shouldBe 10
     }
   }
 

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
@@ -140,7 +140,11 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
     waitForMonitorTaskRun()
 
     // Both monitor task and streaming job should stop after 10 times
-    10 times { (_, _) => {} }
+    10 times { (_, _) =>
+      {
+        // assert nothing. just wait enough times of task execution
+      }
+    }
 
     task.isCancelled shouldBe true
     spark.streams.active.exists(_.name == testFlintIndex) shouldBe false


### PR DESCRIPTION
### Description

This PR introduces enhancements to the `FlintSparkIndexMonitor` to improve the robustness and observability of index monitoring tasks. By tracking consecutive errors, this update helps in better managing the streaming tasks and resource utilization.

1. Add new Spark conf for monitor initial delay, interval and max error count
2. Add `FlintSparkIndexMonitorTask` with counter tracking number of consecutive errors
3. Add streaming job and monitor task terminating logic once max error count reached

Testing with EMR and AOS:

<pre>
scala> sc.setLogLevel("INFO")

<b># Start index refresh streaming job</b>
sql("CREATE SKIPPING INDEX ON myglue.ds_tables.http_logs_perf_tiny (status VALUE_SET) WITH (auto_refresh = true)")

24/05/17 21:28:13 INFO FlintSparkIndexMonitor: Starting index monitor for flint_myglue_ds_tables_http_logs_perf_tiny_skipping_index with configuration:
 - Initial delay: 15 seconds
 - Interval: 60 seconds
 - Max error count: 5

<b># Set read only on AOS</b>
PUT _cluster/settings
{
   "persistent":{
      "cluster.blocks.read_only": true
   }
}

<b># Monitor start failing</b>
24/05/17 21:28:24 ERROR FlintSparkIndexMonitor: Failed to update index log entry, consecutive errors: 1

24/05/17 21:29:24 ERROR FlintSparkIndexMonitor: Failed to update index log entry, consecutive errors: 2
...

<b># Remove read only on AOS</b>
PUT _cluster/settings
{
   "persistent":{
      "cluster.blocks.read_only": false
   }
}

<b># Monitor can update successfully</b>
24/05/17 21:30:24 INFO FlintSparkIndexMonitor: Scheduler trigger index monitor task for flint_myglue_ds_tables_http_logs_perf_tiny_skipping_index
24/05/17 21:30:24 INFO FlintSparkIndexMonitor: Streaming job is still active

<b># Set read only on AOS again</b>
PUT _cluster/settings
{
   "persistent":{
      "cluster.blocks.read_only": true
   }
}

<b># Counter is reset and restarts from 1</b>
24/05/17 21:31:25 ERROR FlintSparkIndexMonitor: Failed to update index log entry, consecutive errors: 1

24/05/17 21:32:25 ERROR FlintSparkIndexMonitor: Failed to update index log entry, consecutive errors: 2

...

<b># Monitor stops streaming job and itself once max error count reached</b>
24/05/17 21:35:26 ERROR FlintSparkIndexMonitor: Failed to update index log entry, consecutive errors: 5
java.lang.IllegalStateException: Failed to commit transaction operation
	at org.opensearch.flint.core.metadata.log.DefaultOptimisticTransaction.commit(DefaultOptimisticTransaction.java:125) ~[flint-spark-integration-assembly-0.5.0-SNAPSHOT.jar:0.5.0-SNAPSHOT]
	at org.opensearch.flint.spark.FlintSparkIndexMonitor$FlintSparkIndexMonitorTask.run(FlintSparkIndexMonitor.scala:106) ~[flint-spark-integration-assembly-0.5.0-SNAPSHOT.jar:0.5.0-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
24/05/17 21:35:26 INFO FlintSparkIndexMonitor: Terminating streaming job and index monitor for flint_myglue_ds_tables_http_logs_perf_tiny_skipping_index
24/05/17 21:35:26 INFO DAGScheduler: Asked to cancel job group 02c0af66-b3a9-4611-8fc2-9259206f83a4
24/05/17 21:35:26 ERROR MicroBatchExecution: Query flint_myglue_ds_tables_http_logs_perf_tiny_skipping_index [id = ba336769-f33d-4da8-8ba2-46630cbdcd92, runId = 02c0af66-b3a9-4611-8fc2-9259206f83a4] terminated with error ...
24/05/17 21:35:26 INFO DAGScheduler: Asked to cancel job group 02c0af66-b3a9-4611-8fc2-9259206f83a4
24/05/17 21:35:26 INFO MicroBatchExecution: Query flint_myglue_ds_tables_http_logs_perf_tiny_skipping_index [id = ba336769-f33d-4da8-8ba2-46630cbdcd92, runId = 02c0af66-b3a9-4611-8fc2-9259206f83a4] was stopped
24/05/17 21:35:26 INFO FlintSparkIndexMonitor: Cancelling scheduled task for index flint_myglue_ds_tables_http_logs_perf_tiny_skipping_index
24/05/17 21:35:26 INFO FlintSparkIndexMonitor: Streaming job and index monitor terminated
</pre>

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/344

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
