### PR TITLE
Bump Flint version to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Version compatibility:
 | 0.2.0         | 11+         | 3.3.1         | 2.12.14       | 2.6+       |
 | 0.3.0         | 11+         | 3.3.2         | 2.12.14       | 2.13+      |
 | 0.4.0         | 11+         | 3.3.2         | 2.12.14       | 2.13+      |
+| 0.4.1         | 11+         | 3.3.2         | 2.12.14       | 2.13+      |
 
 ## Flint Extension Usage 
 
@@ -52,7 +53,7 @@ sbt clean standaloneCosmetic/publishM2
 ```
 then add org.opensearch:opensearch-spark_2.12 when run spark application, for example,
 ```
-bin/spark-shell --packages "org.opensearch:opensearch-spark_2.12:0.4.0-SNAPSHOT"
+bin/spark-shell --packages "org.opensearch:opensearch-spark_2.12:0.4.1-SNAPSHOT"
 ```
 
 ### PPL Build & Run 
@@ -64,7 +65,7 @@ sbt clean sparkPPLCosmetic/publishM2
 ```
 then add org.opensearch:opensearch-spark_2.12 when run spark application, for example,
 ```
-bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.4.0-SNAPSHOT"
+bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.4.1-SNAPSHOT"
 ```
 
 ## Code of Conduct

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val sparkMinorVersion = sparkVersion.split("\\.").take(2).mkString(".")
 
 ThisBuild / organization := "org.opensearch"
 
-ThisBuild / version := "0.4.0-SNAPSHOT"
+ThisBuild / version := "0.4.1-SNAPSHOT"
 
 ThisBuild / scalaVersion := scala212
 

--- a/docs/PPL-on-Spark.md
+++ b/docs/PPL-on-Spark.md
@@ -34,7 +34,7 @@ sbt clean sparkPPLCosmetic/publishM2
 ```
 then add org.opensearch:opensearch-spark_2.12 when run spark application, for example,
 ```
-bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.4.0-SNAPSHOT"
+bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.4.1-SNAPSHOT"
 ```
 
 ### PPL Extension Usage
@@ -46,7 +46,7 @@ spark-sql --conf "spark.sql.extensions=org.opensearch.flint.spark.FlintPPLSparkE
 ```
 
 ### Running With both Flint & PPL Extensions
-In order to make use of both flint and ppl extension, one can simply add both jars (`org.opensearch:opensearch-spark-ppl_2.12:0.4.0-SNAPSHOT`,`org.opensearch:opensearch-spark_2.12:0.4.0-SNAPSHOT`) to the cluster's
+In order to make use of both flint and ppl extension, one can simply add both jars (`org.opensearch:opensearch-spark-ppl_2.12:0.4.1-SNAPSHOT`,`org.opensearch:opensearch-spark_2.12:0.4.1-SNAPSHOT`) to the cluster's
 classpath.
 
 Next need to configure both extensions :

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ Currently, Flint metadata is only static configuration without version control a
 
 ```json
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "name": "...",
   "kind": "skipping",
   "source": "...",
@@ -670,7 +670,7 @@ For now, only single or conjunct conditions (conditions connected by AND) in WHE
 ### AWS EMR Spark Integration - Using execution role
 Flint use [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html). When running in EMR Spark, Flint use executionRole credentials
 ```
---conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.4.0-SNAPSHOT \
+--conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.4.1-SNAPSHOT \
 --conf spark.jars.repositories=https://aws.oss.sonatype.org/content/repositories/snapshots \
 --conf spark.emr-serverless.driverEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
@@ -712,7 +712,7 @@ Flint use [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJa
 ```
 3. Set the spark.datasource.flint.customAWSCredentialsProvider property with value as com.amazonaws.emr.AssumeRoleAWSCredentialsProvider. Set the environment variable ASSUME_ROLE_CREDENTIALS_ROLE_ARN with the ARN value of CrossAccountRoleB.
 ```
---conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.4.0-SNAPSHOT \
+--conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.4.1-SNAPSHOT \
 --conf spark.jars.repositories=https://aws.oss.sonatype.org/content/repositories/snapshots \
 --conf spark.emr-serverless.driverEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintVersion.scala
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintVersion.scala
@@ -18,6 +18,7 @@ object FlintVersion {
   val V_0_2_0: FlintVersion = FlintVersion("0.2.0")
   val V_0_3_0: FlintVersion = FlintVersion("0.3.0")
   val V_0_4_0: FlintVersion = FlintVersion("0.4.0")
+  val V_0_4_1: FlintVersion = FlintVersion("0.4.1")
 
-  def current(): FlintVersion = V_0_4_0
+  def current(): FlintVersion = V_0_4_1
 }


### PR DESCRIPTION
### Description

Bumped Flint version to 0.4.1. Ref: https://github.com/opensearch-project/opensearch-spark/pull/343

Testing:

```
$ sbt clean assembly
$ find . -name "*-0.4.0-SNAPSHOT.jar"

$ find . -name "*-0.4.1-SNAPSHOT.jar"
./integ-test/target/scala-2.12/integ-test-assembly-0.4.1-SNAPSHOT.jar
./spark-sql-application/target/scala-2.12/sql-job-assembly-0.4.1-SNAPSHOT.jar
./flint-spark-integration/target/scala-2.12/flint-spark-integration-assembly-0.4.1-SNAPSHOT.jar
./ppl-spark-integration/target/scala-2.12/ppl-spark-integration-assembly-0.4.1-SNAPSHOT.jar
```

### Issues Resolved

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
