### PR TITLE
Transition Flint index state to Failed upon refresh job termination

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -54,7 +54,7 @@ class FlintSpark(val spark: SparkSession) extends Logging {
     spark.conf.getOption("spark.flint.datasource.name").getOrElse("")
 
   /** Flint Spark index monitor */
-  private val flintIndexMonitor: FlintSparkIndexMonitor =
+  val flintIndexMonitor: FlintSparkIndexMonitor =
     new FlintSparkIndexMonitor(spark, flintClient, dataSourceName)
 
   /**

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -250,7 +250,8 @@ class FlintSpark(val spark: SparkSession) extends Logging {
       try {
         flintClient
           .startTransaction(indexName, dataSourceName)
-          .initialLog(latest => latest.state == ACTIVE || latest.state == REFRESHING)
+          .initialLog(latest =>
+            latest.state == ACTIVE || latest.state == REFRESHING || latest.state == FAILED)
           .transientLog(latest => latest.copy(state = DELETING))
           .finalLog(latest => latest.copy(state = DELETED))
           .commit(_ => {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
@@ -103,7 +103,7 @@ class FlintSparkIndexMonitor(
       .flatMap(name => spark.streams.active.find(_.name == name))
       .orElse(spark.streams.active.headOption)
 
-    if (job.isDefined) {
+    if (job.isDefined) { // must be present after DataFrameWriter.start() called in refreshIndex API
       val name = job.get.name // use streaming job name because indexName maybe None
       logInfo(s"Awaiting streaming job $name until terminated")
       try {

--- a/integ-test/src/test/scala/org/apache/spark/sql/FlintJobITSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/sql/FlintJobITSuite.scala
@@ -20,6 +20,7 @@ import org.scalatest.matchers.must.Matchers.{defined, have}
 import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, the}
 
 import org.apache.spark.sql.flint.FlintDataSourceV2.FLINT_DATASOURCE
+import org.apache.spark.sql.flint.config.FlintSparkConf
 import org.apache.spark.sql.util.MockEnvironment
 import org.apache.spark.util.ThreadUtils
 
@@ -72,6 +73,7 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
     val streamingRunningCount = new AtomicInteger(0)
 
     val futureResult = Future {
+      spark.conf.set(FlintSparkConf.JOB_TYPE.key, "streaming")
       val job =
         JobOperator(spark, query, dataSourceName, resultIndex, true, streamingRunningCount)
       job.envinromentProvider = new MockEnvironment(

--- a/integ-test/src/test/scala/org/apache/spark/sql/FlintJobITSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/sql/FlintJobITSuite.scala
@@ -84,7 +84,7 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
        * all Spark conf required by Flint code underlying manually.
        */
       spark.conf.set(DATA_SOURCE_NAME.key, dataSourceName)
-      spark.conf.set(JOB_TYPE.key, "batch")
+      spark.conf.set(JOB_TYPE.key, "streaming")
 
       /**
        * FlintJob.main() is not called because we need to manually set these variables within a

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
@@ -164,14 +164,15 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
   }
 
   test("await monitor terminated with exception should update index state to failed") {
-    // Simulate an exception in the streaming job
     new Thread(() => {
       Thread.sleep(3000L)
 
+      // Set Flint index readonly to simulate streaming job exception
       val settings = Map("index.blocks.write" -> true)
       val request = new UpdateSettingsRequest(testFlintIndex).settings(settings.asJava)
       openSearchClient.indices().putSettings(request, RequestOptions.DEFAULT)
 
+      // Trigger a new micro batch execution
       sql(s"""
            | INSERT INTO $testTable
            | PARTITION (year=2023, month=6)


### PR DESCRIPTION
### Description

This PR addresses the issue where the index state incorrectly remains in "refreshing" after a streaming job has failed. The fix  transitions the index state before Spark application exits on its best efforts. Ref: [Flint index state transition diagram](https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md#index-state-transition-1)

#### Before the Changes

1. `FlintJob` waits for a **global lock** in `StreamingQueryManager` using the `awaitAnyTermination` API. The Spark `StreamExecution` notifies all threads suspending on it first, and then triggers the listener and cleanup logic.
2. Consequently, it's possible that main thread (`FlintJob`) completes first and does not wait for the index monitor or the listener and cleanup logic in the `StreamExecution`, as both are daemon threads.

<img width="608" alt="Screenshot 2024-05-30 at 11 51 47 AM" src="https://github.com/opensearch-project/opensearch-spark/assets/46505291/fce3e8e1-6716-4761-98b9-d7e8a862a16c">

#### After the Changes

1. A new `awaitMonitor` API in `FlintSparkIndexMonitor` has been introduced to suspend the caller thread (main thread in `FlintJob`) and update the index state immediately upon resumption.
3. As a result, `FlintJob` now wait for a **specific stream execution** and will be notified only after `StreamExecution` completes all listener and cleanup logic.

<img width="595" alt="Screenshot 2024-05-30 at 11 49 46 AM" src="https://github.com/opensearch-project/opensearch-spark/assets/46505291/55c9008c-b19d-4eeb-a439-eb1fdc53f90a">

#### Sources that May Trigger the Termination of Stream Execution

- **Normal Termination**: `awaitMonitor` does nothing upon termination to avoid conflicts. It's API responsibility to transition the index state in these cases.
    - a) `DROP` index API
    - b) `ALTER` index API (from auto to manual)
- **Exception Termination**: there is possibility that both index monitor scheduled task and awaitMonitor tries to update index state in case b) below. Added retry to ensure the transition.
    - a) Index monitor scheduled task (terminates streaming execution when the OpenSearch cluster unreachable)
    - b) Spark terminates streaming execution upon encountering an exception

#### TODO

1. Support DROP index with FAILED state in SQL plugin. [Will create issue in sql repo later]
2. Persist error message of root cause in metadata log. Tracked in https://github.com/opensearch-project/opensearch-spark/issues/281
3. Differentiate exception retryable or not and persist state code. Tracked in https://github.com/opensearch-project/opensearch-spark/issues/149

### Testing

<pre>
<b># EMR-S log:</b>
24/05/31 22:14:10 INFO AppendDataExec: Data source write support FlintWrite(query_execution_result_glue...) committed.
<b>24/05/31 22:14:10 INFO FlintSparkIndexMonitor: Awaiting index monitor for None
24/05/31 22:14:10 INFO FlintSparkIndexMonitor: Awaiting streaming job flint_glue_default_http_logs_await_test_3_index until terminated</b>

<b># Simulate streaming job exception</b>
PUT flint_glue_default_http_logs_await_test_3_index/_block/write

<b># EMR-S log:</b>
24/06/01 22:24:31 ERROR FlintSparkIndexMonitor: Streaming job flint_glue_default_http_logs_await_test_3_index terminated with exception
24/06/01 22:25:03 INFO FlintOpenSearchMetadataLog: Log entry written as
FlintMetadataLogEntry(ZmxpbnRfZ2x1ZV9kZWZhdWx0X2h0dHBfbG9nc19hd2FpdF90ZXN0XzNfaW5kZXg=,
71,1,1717203462456,<b>failed</b>,glue,)

<b># Verify index state transitioned to FAILED as expected</b>
GET .query_execution_request_glue/_doc/ZmxpbnRfZ2x1ZV9kZWZhdWx0X2h0dHBfbG9nc19hd2FpdF90ZXN0XzNfaW5kZXg=
{
  "_index": ".query_execution_request_glue",
  "_id": "ZmxpbnRfZ2x1ZV9kZWZhdWx0X2h0dHBfbG9nc19hd2FpdF90ZXN0XzNfaW5kZXg=",
  "_version": 11,
  "_seq_no": 35,
  "_primary_term": 1,
  "found": true,
  "_source": {
    "version": "1.0",
    "latestId": "ZmxpbnRfZ2x1ZV9kZWZhdWx0X2h0dHBfbG9nc19hd2FpdF90ZXN0XzNfaW5kZXg=",
    "type": "flintindexstate",
    <b>"state": "failed",</b>
    "applicationId": "00fj56e4cs0ghe0l",
    "jobId": "00fjojhr9r8dho0n",
    "dataSourceName": "glue",
    "jobStartTime": 1717193633832,
    "lastUpdateTime": 1717193954278,
    "error": ""
  }
}
</pre>



### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/361

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
