### PR TITLE
Prevent integration tests from running during unit test task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val commonSettings = Seq(
 
 // running `scalafmtAll` includes all subprojects under root
 lazy val root = (project in file("."))
-  .aggregate(flintCore, flintSparkIntegration, pplSparkIntegration, sparkSqlApplication, integtest)
+  .aggregate(flintCore, flintSparkIntegration, pplSparkIntegration, sparkSqlApplication)
   .disablePlugins(AssemblyPlugin)
   .settings(name := "flint", publish / skip := true)
 


### PR DESCRIPTION
### Description

This PR addresses [Issue #350](https://github.com/opensearch-project/opensearch-spark/issues/350) where integration tests are unexpectedly triggered during the test task, causing delays in the CI process.

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/350

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
