### PR TITLE
Support custom metadata log service implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ lazy val root = (project in file("."))
 
 lazy val flintCore = (project in file("flint-core"))
   .disablePlugins(AssemblyPlugin)
+  .dependsOn(flintCommons)
   .settings(
     commonSettings,
     name := "flint-core",

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLog.java
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLog.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.flint.core.metadata.log;
+package org.opensearch.flint.common.metadata.log;
 
 import java.util.Optional;
 

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
@@ -160,14 +160,4 @@ object FlintMetadataLogEntry {
       |    "number_of_replicas": "0"
       |  }
       |}""".stripMargin
-
-  def failLogEntry(dataSourceName: String, error: String): FlintMetadataLogEntry =
-    FlintMetadataLogEntry(
-      "",
-      UNASSIGNED_SEQ_NO,
-      UNASSIGNED_PRIMARY_TERM,
-      0L,
-      IndexState.FAILED,
-      dataSourceName,
-      error)
 }

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.flint.core.metadata.log
+package org.opensearch.flint.common.metadata.log
 
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState.IndexState
-import org.opensearch.index.seqno.SequenceNumbers.{UNASSIGNED_PRIMARY_TERM, UNASSIGNED_SEQ_NO}
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.IndexState
 
 /**
  * Flint metadata log entry. This is temporary and will merge field in FlintMetadata here and move

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogService.java
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogService.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.flint.core.metadata.log;
+package org.opensearch.flint.common.metadata.log;
 
 import java.util.Optional;
 

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogService.java
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogService.java
@@ -6,31 +6,12 @@
 package org.opensearch.flint.common.metadata.log;
 
 import java.util.Optional;
-import org.apache.spark.SparkConf;
 
 /**
  * Flint metadata log service provides API for metadata log related operations on a Flint index
  * regardless of underlying storage.
  */
-public abstract class FlintMetadataLogService {
-
-  protected final SparkConf sparkConf;
-
-  /**
-   * Constructor.
-   *
-   * @param sparkConf spark configuration
-   */
-  public FlintMetadataLogService(SparkConf sparkConf) {
-    this.sparkConf = sparkConf;
-  }
-
-  /**
-   * Default constructor.
-   */
-  public FlintMetadataLogService() {
-    this(null);
-  }
+public interface FlintMetadataLogService {
 
   /**
    * Start a new optimistic transaction.
@@ -39,7 +20,7 @@ public abstract class FlintMetadataLogService {
    * @param forceInit force init transaction and create empty metadata log if not exist
    * @return transaction handle
    */
-  public abstract <T> OptimisticTransaction<T> startTransaction(String indexName, boolean forceInit);
+  <T> OptimisticTransaction<T> startTransaction(String indexName, boolean forceInit);
 
   /**
    * Start a new optimistic transaction.
@@ -47,7 +28,7 @@ public abstract class FlintMetadataLogService {
    * @param indexName index name
    * @return transaction handle
    */
-  public <T> OptimisticTransaction<T> startTransaction(String indexName) {
+  default <T> OptimisticTransaction<T> startTransaction(String indexName) {
     return startTransaction(indexName, false);
   }
 
@@ -57,12 +38,12 @@ public abstract class FlintMetadataLogService {
    * @param indexName index name
    * @return optional metadata log
    */
-  public abstract Optional<FlintMetadataLog<FlintMetadataLogEntry>> getIndexMetadataLog(String indexName);
+  Optional<FlintMetadataLog<FlintMetadataLogEntry>> getIndexMetadataLog(String indexName);
 
   /**
    * Record heartbeat timestamp for index streaming job.
    *
    * @param indexName index name
    */
-  public abstract void recordHeartbeat(String indexName);
+  void recordHeartbeat(String indexName);
 }

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogService.java
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogService.java
@@ -10,6 +10,10 @@ import java.util.Optional;
 /**
  * Flint metadata log service provides API for metadata log related operations on a Flint index
  * regardless of underlying storage.
+ * <p>
+ * Custom implementations of this interface are expected to provide a public constructor with
+ * the signature {@code public MyCustomService(SparkConf sparkConf)} to be instantiated by
+ * the FlintMetadataLogServiceBuilder.
  */
 public interface FlintMetadataLogService {
 

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogService.java
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogService.java
@@ -6,12 +6,31 @@
 package org.opensearch.flint.common.metadata.log;
 
 import java.util.Optional;
+import org.apache.spark.SparkConf;
 
 /**
  * Flint metadata log service provides API for metadata log related operations on a Flint index
  * regardless of underlying storage.
  */
-public interface FlintMetadataLogService {
+public abstract class FlintMetadataLogService {
+
+  protected final SparkConf sparkConf;
+
+  /**
+   * Constructor.
+   *
+   * @param sparkConf spark configuration
+   */
+  public FlintMetadataLogService(SparkConf sparkConf) {
+    this.sparkConf = sparkConf;
+  }
+
+  /**
+   * Default constructor.
+   */
+  public FlintMetadataLogService() {
+    this(null);
+  }
 
   /**
    * Start a new optimistic transaction.
@@ -20,7 +39,7 @@ public interface FlintMetadataLogService {
    * @param forceInit force init transaction and create empty metadata log if not exist
    * @return transaction handle
    */
-  <T> OptimisticTransaction<T> startTransaction(String indexName, boolean forceInit);
+  public abstract <T> OptimisticTransaction<T> startTransaction(String indexName, boolean forceInit);
 
   /**
    * Start a new optimistic transaction.
@@ -28,7 +47,7 @@ public interface FlintMetadataLogService {
    * @param indexName index name
    * @return transaction handle
    */
-  default <T> OptimisticTransaction<T> startTransaction(String indexName) {
+  public <T> OptimisticTransaction<T> startTransaction(String indexName) {
     return startTransaction(indexName, false);
   }
 
@@ -38,12 +57,12 @@ public interface FlintMetadataLogService {
    * @param indexName index name
    * @return optional metadata log
    */
-  Optional<FlintMetadataLog<FlintMetadataLogEntry>> getIndexMetadataLog(String indexName);
+  public abstract Optional<FlintMetadataLog<FlintMetadataLogEntry>> getIndexMetadataLog(String indexName);
 
   /**
    * Record heartbeat timestamp for index streaming job.
    *
    * @param indexName index name
    */
-  void recordHeartbeat(String indexName);
+  public abstract void recordHeartbeat(String indexName);
 }

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/OptimisticTransaction.java
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/OptimisticTransaction.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.flint.core.metadata.log;
+package org.opensearch.flint.common.metadata.log;
 
 import java.util.function.Function;
 import java.util.function.Predicate;

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -90,6 +90,8 @@ public class FlintOptions implements Serializable {
 
   public static final String DEFAULT_BATCH_BYTES = "1mb";
 
+  public static final String CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS = "spark.datasource.flint.customFlintMetadataLogServiceClass";
+
   public FlintOptions(Map<String, String> options) {
     this.options = options;
     this.retryOptions = new FlintRetryOptions(options);
@@ -161,5 +163,9 @@ public class FlintOptions implements Serializable {
     // we did not expect this value could be large than 10mb = 10 * 1024 * 1024
     return (int) org.apache.spark.network.util.JavaUtils
         .byteStringAs(options.getOrDefault(BATCH_BYTES, DEFAULT_BATCH_BYTES), ByteUnit.BYTE);
+  }
+
+  public String getCustomFlintMetadataLogServiceClass() {
+    return options.getOrDefault(CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS, "");
   }
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/FlintMetadata.scala
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/FlintMetadata.scala
@@ -7,10 +7,10 @@ package org.opensearch.flint.core.metadata
 
 import java.util
 
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.core.FlintVersion
 import org.opensearch.flint.core.FlintVersion.current
 import org.opensearch.flint.core.metadata.FlintJsonHelper._
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
 
 /**
  * Flint metadata follows Flint index specification and defines metadata for a Flint index

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
@@ -7,7 +7,7 @@ package org.opensearch.flint.core.metadata.log;
 
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
-import static org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState$;
+import static org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState$;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
@@ -15,6 +15,10 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+
+import org.opensearch.flint.common.metadata.log.FlintMetadataLog;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry;
+import org.opensearch.flint.common.metadata.log.OptimisticTransaction;
 
 /**
  * Default optimistic transaction implementation that captures the basic workflow for

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/FlintMetadataLogServiceBuilder.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/FlintMetadataLogServiceBuilder.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.flint.core.metadata.log;
 
+import java.lang.reflect.Constructor;
+import org.apache.spark.SparkConf;
 import org.opensearch.flint.core.FlintOptions;
 import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService;
 
@@ -12,7 +14,19 @@ import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService;
  * {@link FlintMetadataLogService} builder.
  */
 public class FlintMetadataLogServiceBuilder {
-  public static FlintMetadataLogService build(FlintOptions options) {
-    return new FlintOpenSearchMetadataLogService(options);
+  public static FlintMetadataLogService build(FlintOptions options, SparkConf sparkConf) {
+    String className = options.getCustomFlintMetadataLogServiceClass();
+    if (className.isEmpty()) {
+      return new FlintOpenSearchMetadataLogService(options);
+    }
+
+    // Attempts to instantiate Flint metadata log service with sparkConf using reflection
+    try {
+      Class<?> flintMetadataLogServiceClass = Class.forName(className);
+      Constructor<?> constructor = flintMetadataLogServiceClass.getConstructor(SparkConf.class);
+      return (FlintMetadataLogService) constructor.newInstance(sparkConf);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to instantiate FlintMetadataLogService: " + className, e);
+    }
   }
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/FlintMetadataLogServiceBuilder.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/FlintMetadataLogServiceBuilder.java
@@ -13,6 +13,10 @@ import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService;
 
 /**
  * {@link FlintMetadataLogService} builder.
+ * <p>
+ * Custom implementations of {@link FlintMetadataLogService} are expected to provide a public
+ * constructor with the signature {@code public MyCustomService(SparkConf sparkConf)} to be
+ * instantiated by this builder.
  */
 public class FlintMetadataLogServiceBuilder {
   public static FlintMetadataLogService build(FlintOptions options, SparkConf sparkConf) {

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/FlintMetadataLogServiceBuilder.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/FlintMetadataLogServiceBuilder.java
@@ -7,6 +7,7 @@ package org.opensearch.flint.core.metadata.log;
 
 import java.lang.reflect.Constructor;
 import org.apache.spark.SparkConf;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogService;
 import org.opensearch.flint.core.FlintOptions;
 import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService;
 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -23,10 +23,10 @@ import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLog;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry;
 import org.opensearch.flint.core.FlintOptions;
 import org.opensearch.flint.core.IRestHighLevelClient;
-import org.opensearch.flint.core.metadata.log.FlintMetadataLog;
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry;
 
 /**
  * Flint metadata log in OpenSearch store. For now use single doc instead of maintaining history

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
@@ -24,7 +24,7 @@ import org.opensearch.flint.core.metadata.log.DefaultOptimisticTransaction;
 /**
  * Flint metadata log service implementation for OpenSearch storage.
  */
-public class FlintOpenSearchMetadataLogService extends FlintMetadataLogService {
+public class FlintOpenSearchMetadataLogService implements FlintMetadataLogService {
 
   private static final Logger LOG = Logger.getLogger(FlintOpenSearchMetadataLogService.class.getName());
 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
@@ -12,14 +12,14 @@ import org.opensearch.client.RequestOptions;
 import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLog;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState$;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogService;
+import org.opensearch.flint.common.metadata.log.OptimisticTransaction;
 import org.opensearch.flint.core.FlintOptions;
 import org.opensearch.flint.core.IRestHighLevelClient;
 import org.opensearch.flint.core.metadata.log.DefaultOptimisticTransaction;
-import org.opensearch.flint.core.metadata.log.FlintMetadataLog;
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry;
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState$;
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogService;
-import org.opensearch.flint.core.metadata.log.OptimisticTransaction;
 
 /**
  * Flint metadata log service implementation for OpenSearch storage.

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
@@ -24,7 +24,7 @@ import org.opensearch.flint.core.metadata.log.DefaultOptimisticTransaction;
 /**
  * Flint metadata log service implementation for OpenSearch storage.
  */
-public class FlintOpenSearchMetadataLogService implements FlintMetadataLogService {
+public class FlintOpenSearchMetadataLogService extends FlintMetadataLogService {
 
   private static final Logger LOG = Logger.getLogger(FlintOpenSearchMetadataLogService.class.getName());
 

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -175,6 +175,11 @@ object FlintSparkConf {
     FlintConfig(s"spark.flint.datasource.name")
       .doc("data source name")
       .createOptional()
+  val CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS =
+    FlintConfig(FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS)
+      .datasourceOption()
+      .doc("custom Flint metadata log service class")
+      .createOptional()
   val QUERY =
     FlintConfig("spark.flint.job.query")
       .doc("Flint query for batch and streaming job")
@@ -274,6 +279,7 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
     val optionsWithoutDefault = Seq(
       RETRYABLE_EXCEPTION_CLASS_NAMES,
       DATA_SOURCE_NAME,
+      CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS,
       SESSION_ID,
       REQUEST_INDEX,
       METADATA_ACCESS_AWS_CREDENTIALS_PROVIDER,

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -9,11 +9,12 @@ import scala.collection.JavaConverters._
 
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.native.Serialization
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState._
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogService
+import org.opensearch.flint.common.metadata.log.OptimisticTransaction.NO_LOG_ENTRY
 import org.opensearch.flint.core.{FlintClient, FlintClientBuilder}
 import org.opensearch.flint.core.metadata.FlintMetadata
-import org.opensearch.flint.core.metadata.log.{FlintMetadataLogService, FlintMetadataLogServiceBuilder}
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState._
-import org.opensearch.flint.core.metadata.log.OptimisticTransaction.NO_LOG_ENTRY
+import org.opensearch.flint.core.metadata.log.FlintMetadataLogServiceBuilder
 import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
 import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName._
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -45,8 +45,11 @@ class FlintSpark(val spark: SparkSession) extends Logging {
   /** Flint client for low-level index operation */
   private val flintClient: FlintClient = FlintClientBuilder.build(flintSparkConf.flintOptions())
 
-  private val flintMetadataLogService: FlintMetadataLogService =
-    FlintMetadataLogServiceBuilder.build(flintSparkConf.flintOptions())
+  private val flintMetadataLogService: FlintMetadataLogService = {
+    FlintMetadataLogServiceBuilder.build(
+      flintSparkConf.flintOptions(),
+      spark.sparkContext.getConf)
+  }
 
   /** Required by json4s parse function */
   implicit val formats: Formats = Serialization.formats(NoTypeHints) + SkippingKindSerializer

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -7,8 +7,8 @@ package org.opensearch.flint.spark
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.core.metadata.FlintMetadata
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.flint.datatype.FlintDataType

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
@@ -16,8 +16,8 @@ import scala.sys.addShutdownHook
 import dev.failsafe.{Failsafe, RetryPolicy}
 import dev.failsafe.event.ExecutionAttemptedEvent
 import dev.failsafe.function.CheckedRunnable
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState.{FAILED, REFRESHING}
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogService
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.{FAILED, REFRESHING}
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogService
 import org.opensearch.flint.core.metrics.{MetricConstants, MetricsUtil}
 
 import org.apache.spark.internal.Logging

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
@@ -7,7 +7,7 @@ package org.opensearch.flint.spark.covering
 
 import java.util
 
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState.DELETED
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.DELETED
 import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex}
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -7,8 +7,8 @@ package org.opensearch.flint.spark.covering
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.core.metadata.FlintMetadata
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.spark._
 import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, generateSchemaJSON, metadataBuilder, quotedTableName}
 import org.opensearch.flint.spark.FlintSparkIndexOptions.empty

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -10,8 +10,8 @@ import java.util.Locale
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.collection.convert.ImplicitConversions.`map AsScala`
 
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.core.metadata.FlintMetadata
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex, FlintSparkIndexBuilder, FlintSparkIndexOptions}
 import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, generateSchemaJSON, metadataBuilder, StreamingRefresh}
 import org.opensearch.flint.spark.FlintSparkIndexOptions.empty

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/ApplyFlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/ApplyFlintSparkSkippingIndex.scala
@@ -6,7 +6,7 @@
 package org.opensearch.flint.spark.skipping
 
 import com.amazon.awslogsdataaccesslayer.connectors.spark.LogsTable
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState.DELETED
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.DELETED
 import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex}
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.{getSkippingIndexName, FILE_PATH_COLUMN, SKIPPING_INDEX_TYPE}
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -7,8 +7,8 @@ package org.opensearch.flint.spark.skipping
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.core.metadata.FlintMetadata
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.spark._
 import org.opensearch.flint.spark.FlintSparkIndex._
 import org.opensearch.flint.spark.FlintSparkIndexOptions.empty

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -7,9 +7,9 @@ package org.opensearch.flint.spark.covering
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mockStatic, when, RETURNS_DEEP_STUBS}
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.{ACTIVE, DELETED, IndexState}
 import org.opensearch.flint.core.{FlintClient, FlintClientBuilder, FlintOptions}
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState.{ACTIVE, DELETED, IndexState}
 import org.opensearch.flint.spark.FlintSpark
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
 import org.scalatest.matchers.{Matcher, MatchResult}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/ApplyFlintSparkSkippingIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/ApplyFlintSparkSkippingIndexSuite.scala
@@ -8,8 +8,8 @@ package org.opensearch.flint.spark.skipping
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState.{DELETED, IndexState, REFRESHING}
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.{DELETED, IndexState, REFRESHING}
 import org.opensearch.flint.spark.FlintSpark
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.{getSkippingIndexName, SKIPPING_INDEX_TYPE}
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.SkippingKind

--- a/integ-test/src/test/scala/org/opensearch/flint/OpenSearchTransactionSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/OpenSearchTransactionSuite.scala
@@ -16,9 +16,9 @@ import org.opensearch.action.update.UpdateRequest
 import org.opensearch.client.RequestOptions
 import org.opensearch.client.indices.{CreateIndexRequest, GetIndexRequest}
 import org.opensearch.common.xcontent.XContentType
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.{QUERY_EXECUTION_REQUEST_MAPPING, QUERY_EXECUTION_REQUEST_SETTINGS}
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState.IndexState
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.{QUERY_EXECUTION_REQUEST_MAPPING, QUERY_EXECUTION_REQUEST_SETTINGS}
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.IndexState
 import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService.METADATA_LOG_INDEX_NAME_PREFIX
 import org.opensearch.flint.spark.FlintSparkSuite
 

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -46,11 +46,11 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
   }
 
   test("should build metadata log service") {
-    val options =
+    val customOptions =
       openSearchOptions + (CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS.key -> "org.opensearch.flint.core.TestMetadataLogService")
-    val flintOptions = new FlintOptions(options.asJava)
-    flintMetadataLogService = FlintMetadataLogServiceBuilder.build(flintOptions, sparkConf)
-    flintMetadataLogService shouldBe a[TestMetadataLogService]
+    val customFlintOptions = new FlintOptions(customOptions.asJava)
+    val customFlintMetadataLogService = FlintMetadataLogServiceBuilder.build(customFlintOptions, sparkConf)
+    customFlintMetadataLogService shouldBe a[TestMetadataLogService]
   }
 
   test("should fail to build metadata log service if class name doesn't exist") {
@@ -122,9 +122,9 @@ case class TestMetadataLogService(sparkConf: SparkConf) extends FlintMetadataLog
   override def startTransaction[T](
       indexName: String,
       forceInit: Boolean): OptimisticTransaction[T] = {
-    new DefaultOptimisticTransaction(
-      "",
-      new FlintOpenSearchMetadataLog(new FlintOptions(Map[String, String]().asJava), "", ""))
+    val flintOptions = new FlintOptions(Map[String, String]().asJava)
+    val metadataLog = new FlintOpenSearchMetadataLog(flintOptions, "", "")
+    new DefaultOptimisticTransaction("", metadataLog)
   }
 
   override def startTransaction[T](indexName: String): OptimisticTransaction[T] = {

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -119,8 +119,7 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
   }
 }
 
-case class TestMetadataLogService(sparkConfParam: SparkConf)
-    extends FlintMetadataLogService(sparkConfParam) {
+case class TestMetadataLogService(sparkConf: SparkConf) extends FlintMetadataLogService {
   override def startTransaction[T](
       indexName: String,
       forceInit: Boolean): OptimisticTransaction[T] = {

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -5,19 +5,25 @@
 
 package org.opensearch.flint.core
 
-import java.util.Base64
+import java.util.{Base64, Optional}
 
 import scala.collection.JavaConverters._
 
 import org.opensearch.flint.OpenSearchTransactionSuite
+import org.opensearch.flint.core.metadata.log.DefaultOptimisticTransaction
+import org.opensearch.flint.core.metadata.log.FlintMetadataLog
 import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState._
 import org.opensearch.flint.core.metadata.log.FlintMetadataLogService
+import org.opensearch.flint.core.metadata.log.FlintMetadataLogServiceBuilder
+import org.opensearch.flint.core.metadata.log.OptimisticTransaction
+import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLog
 import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService
 import org.opensearch.index.seqno.SequenceNumbers.{UNASSIGNED_PRIMARY_TERM, UNASSIGNED_SEQ_NO}
 import org.scalatest.matchers.should.Matchers
 
-import org.apache.spark.sql.flint.config.FlintSparkConf.DATA_SOURCE_NAME
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.flint.config.FlintSparkConf.{CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS, DATA_SOURCE_NAME}
 
 class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
 
@@ -42,7 +48,23 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
     flintMetadataLogService = new FlintOpenSearchMetadataLogService(flintOptions)
   }
 
-  test("should fail if metadata log index doesn't exists") {
+  test("should build metadata log service") {
+    val options =
+      openSearchOptions + (CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS.key -> "org.opensearch.flint.core.TestMetadataLogService")
+    val flintOptions = new FlintOptions(options.asJava)
+    flintMetadataLogService = FlintMetadataLogServiceBuilder.build(flintOptions, sparkConf)
+    flintMetadataLogService shouldBe a[TestMetadataLogService]
+  }
+
+  test("should fail to build metadata log service if class name doesn't exist") {
+    val options = openSearchOptions + (CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS.key -> "dummy")
+    val flintOptions = new FlintOptions(options.asJava)
+    the[RuntimeException] thrownBy {
+      FlintMetadataLogServiceBuilder.build(flintOptions, sparkConf)
+    }
+  }
+
+  test("should fail to start transaction if metadata log index doesn't exists") {
     val options = openSearchOptions + (DATA_SOURCE_NAME.key -> "non-exist-datasource")
     val flintMetadataLogService =
       new FlintOpenSearchMetadataLogService(new FlintOptions(options.asJava))
@@ -97,4 +119,25 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
       flintMetadataLogService.recordHeartbeat(testFlintIndex)
     }
   }
+}
+
+case class TestMetadataLogService(sparkConf: SparkConf) extends FlintMetadataLogService {
+  override def startTransaction[T](
+      indexName: String,
+      forceInit: Boolean): OptimisticTransaction[T] = {
+    new DefaultOptimisticTransaction(
+      "",
+      new FlintOpenSearchMetadataLog(new FlintOptions(Map[String, String]().asJava), "", ""))
+  }
+
+  override def startTransaction[T](indexName: String): OptimisticTransaction[T] = {
+    startTransaction(indexName, false)
+  }
+
+  override def getIndexMetadataLog(
+      indexName: String): Optional[FlintMetadataLog[FlintMetadataLogEntry]] = {
+    Optional.empty()
+  }
+
+  override def recordHeartbeat(indexName: String): Unit = {}
 }

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -119,7 +119,8 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
   }
 }
 
-case class TestMetadataLogService(sparkConf: SparkConf) extends FlintMetadataLogService {
+case class TestMetadataLogService(sparkConfParam: SparkConf)
+    extends FlintMetadataLogService(sparkConfParam) {
   override def startTransaction[T](
       indexName: String,
       forceInit: Boolean): OptimisticTransaction[T] = {

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -49,7 +49,8 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
     val customOptions =
       openSearchOptions + (CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS.key -> "org.opensearch.flint.core.TestMetadataLogService")
     val customFlintOptions = new FlintOptions(customOptions.asJava)
-    val customFlintMetadataLogService = FlintMetadataLogServiceBuilder.build(customFlintOptions, sparkConf)
+    val customFlintMetadataLogService =
+      FlintMetadataLogServiceBuilder.build(customFlintOptions, sparkConf)
     customFlintMetadataLogService shouldBe a[TestMetadataLogService]
   }
 

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -10,13 +10,10 @@ import java.util.{Base64, Optional}
 import scala.collection.JavaConverters._
 
 import org.opensearch.flint.OpenSearchTransactionSuite
+import org.opensearch.flint.common.metadata.log.{FlintMetadataLog, FlintMetadataLogEntry, FlintMetadataLogService, OptimisticTransaction}
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState._
 import org.opensearch.flint.core.metadata.log.DefaultOptimisticTransaction
-import org.opensearch.flint.core.metadata.log.FlintMetadataLog
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState._
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogService
 import org.opensearch.flint.core.metadata.log.FlintMetadataLogServiceBuilder
-import org.opensearch.flint.core.metadata.log.OptimisticTransaction
 import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLog
 import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService
 import org.opensearch.index.seqno.SequenceNumbers.{UNASSIGNED_PRIMARY_TERM, UNASSIGNED_SEQ_NO}

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
@@ -12,9 +12,8 @@ import scala.collection.JavaConverters.mapAsJavaMapConverter
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.native.{JsonMethods, Serialization}
 import org.opensearch.flint.OpenSearchTransactionSuite
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState._
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogService
+import org.opensearch.flint.common.metadata.log.{FlintMetadataLogEntry, FlintMetadataLogService}
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState._
 import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService
 import org.opensearch.index.seqno.SequenceNumbers.{UNASSIGNED_PRIMARY_TERM, UNASSIGNED_SEQ_NO}
 import org.scalatest.matchers.should.Matchers

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
@@ -10,8 +10,8 @@ import java.util.Base64
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 import org.opensearch.flint.OpenSearchTransactionSuite
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry
-import org.opensearch.flint.core.metadata.log.FlintMetadataLogEntry.IndexState._
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState._
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
 import org.opensearch.index.seqno.SequenceNumbers.{UNASSIGNED_PRIMARY_TERM, UNASSIGNED_SEQ_NO}
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
### Description
1. Use reflection for `FlintMetadataLogServiceBuilder` to support custom implementation of `FlintMetadataLogService`
2. Read `SparkConf` for such builder
3. Make `FlintMetadataLogService` an abstract class with a constructor using `SparkConf`
4. Move interfaces to flint-commons
    1. Moved files: `FlintMetadataLog`, `FlintMetadataLogEntry`, `FlintMetadataLogService`, `OptimisticTransaction`
    2. Remove unused `failLogEntry` from `FlintMetadataLogEntry` (no access to org.opensearch.index namespace). Can add back in next PR when storage is abstracted away from the common `FlintMetadataLogEntry`

### Issues Resolved
* #371 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
