### PR TITLE
Add OpenSearchCatalog to enable direct access OpenSearch index in Spark SQL

### DIFF
--- a/docs/img/opensearch-table.md
+++ b/docs/img/opensearch-table.md
@@ -1,0 +1,66 @@
+# OpenSearch Table
+
+## Overview
+
+The `OpenSearchCatalog` class integrates Apache Spark with OpenSearch, allowing Spark to interact with OpenSearch indices as tables. This integration supports read and write operations, enabling seamless data processing and querying across Spark and OpenSearch.
+
+## Configuration Parameters
+
+To configure the `OpenSearchCatalog`, set the following parameters in your Spark session:
+
+- **`opensearch.port`**: The port to connect to OpenSearch. Default is `9200`.
+- **`opensearch.scheme`**: The scheme to use for the connection. Default is `http`. Valid values are `[http, https]`.
+- **`opensearch.auth`**: The authentication method to use. Default is `noauth`. Valid values are `[noauth, sigv4, basic]`.
+- **`opensearch.auth.username`**: The username for basic authentication.
+- **`opensearch.auth.password`**: The password for basic authentication.
+- **`opensearch.region`**: The AWS region to use for SigV4 authentication. Default is `us-west-2`. Used only when `auth` is `sigv4`.
+
+## Usage
+
+### Initializing the Catalog
+
+To configure and initialize the catalog in your Spark session, set the following configurations:
+
+```scala
+spark.conf.set("spark.sql.catalog.dev", "org.apache.spark.opensearch.catalog.OpenSearchCatalog")
+spark.conf.set("spark.sql.catalog.dev.opensearch.port", "9200")
+spark.conf.set("spark.sql.catalog.dev.opensearch.scheme", "http")
+spark.conf.set("spark.sql.catalog.dev.opensearch.auth", "noauth")
+```
+
+### Querying Data
+
+Once the catalog is configured, you can use Spark SQL to query OpenSearch indices as tables:
+
+- The namespace **MUST** be `default`.
+- When using a wildcard index name or a comma-separated index name as the table, it **MUST** be wrapped in backticks.
+
+Example:
+
+```scala
+val df = spark.sql("SELECT * FROM dev.default.my_index")
+df.show()
+```
+
+Using a wildcard index name:
+```scala
+val df = spark.sql("SELECT * FROM dev.default.`my_index*`")
+df.show()
+```
+
+Using a comma-separated index name:
+```scala
+val df = spark.sql("SELECT * FROM dev.default.`index1,index2`")
+df.show()
+```
+
+
+
+
+## Limitation
+### Unsupported catalog operation
+- List Tables: Not supported.
+- Create Table: Not supported.
+- Alter Table: Not supported.
+- Drop Table: Not supported.
+- Rename Table: Not supported.

--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -33,7 +33,7 @@ spark.conf.set("spark.sql.catalog.dev.opensearch.auth", "noauth")
 Once the catalog is configured, you can use Spark SQL to query OpenSearch indices as tables:
 
 - The namespace **MUST** be `default`.
-- When using a wildcard index name or a comma-separated index name as the table, it **MUST** be wrapped in backticks.
+- When using a wildcard index name, it **MUST** be wrapped in backticks.
 
 Example:
 
@@ -45,12 +45,6 @@ df.show()
 Using a wildcard index name:
 ```scala
 val df = spark.sql("SELECT * FROM dev.default.`my_index*`")
-df.show()
-```
-
-Using a comma-separated index name:
-```scala
-val df = spark.sql("SELECT * FROM dev.default.`index1,index2`")
 df.show()
 ```
 

--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -54,9 +54,6 @@ val df = spark.sql("SELECT * FROM dev.default.`index1,index2`")
 df.show()
 ```
 
-
-
-
 ## Limitation
 ### Unsupported catalog operation
 - List Tables: Not supported.

--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -49,9 +49,12 @@ df.show()
 ```
 
 ## Limitation
-### Unsupported catalog operation
+### catalog operation
 - List Tables: Not supported.
 - Create Table: Not supported.
 - Alter Table: Not supported.
 - Drop Table: Not supported.
 - Rename Table: Not supported.
+
+### table operation
+- Table only support read operation, for instance, SELECT, DESCRIBE.

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
@@ -40,7 +40,7 @@ public interface FlintClient {
    * @return map where the keys are the matched index names, and the values are
    *         corresponding index metadata
    */
-  Map<String, FlintMetadata> getAllIndexMetadata(String indexNamePattern);
+  Map<String, FlintMetadata> getAllIndexMetadata(String... indexNamePattern);
 
   /**
    * Retrieve metadata in a Flint index.

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
@@ -60,7 +60,7 @@ public class FlintOpenSearchClient implements FlintClient {
    * excluding '*' because it's reserved for pattern matching.
    */
   private final static Set<Character> INVALID_INDEX_NAME_CHARS =
-      Set.of(' ', ':', '"', '+', '/', '\\', '|', '?', '#', '>', '<');
+      Set.of(' ', ',', ':', '"', '+', '/', '\\', '|', '?', '#', '>', '<');
 
   private final FlintOptions options;
 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
@@ -60,7 +60,7 @@ public class FlintOpenSearchClient implements FlintClient {
    * excluding '*' because it's reserved for pattern matching.
    */
   private final static Set<Character> INVALID_INDEX_NAME_CHARS =
-      Set.of(' ', ',', ':', '"', '+', '/', '\\', '|', '?', '#', '>', '<');
+      Set.of(' ', ':', '"', '+', '/', '\\', '|', '?', '#', '>', '<');
 
   private final FlintOptions options;
 
@@ -101,11 +101,12 @@ public class FlintOpenSearchClient implements FlintClient {
   }
 
   @Override
-  public Map<String, FlintMetadata> getAllIndexMetadata(String indexNamePattern) {
-    LOG.info("Fetching all Flint index metadata for pattern " + indexNamePattern);
-    String osIndexNamePattern = sanitizeIndexName(indexNamePattern);
+  public Map<String, FlintMetadata> getAllIndexMetadata(String... indexNamePattern) {
+    LOG.info("Fetching all Flint index metadata for pattern " + String.join(",", indexNamePattern));
+    String[] indexNames =
+        Arrays.stream(indexNamePattern).map(this::sanitizeIndexName).toArray(String[]::new);
     try (IRestHighLevelClient client = createClient()) {
-      GetIndexRequest request = new GetIndexRequest(osIndexNamePattern);
+      GetIndexRequest request = new GetIndexRequest(indexNames);
       GetIndexResponse response = client.getIndex(request, RequestOptions.DEFAULT);
 
       return Arrays.stream(response.getIndices())
@@ -117,7 +118,8 @@ public class FlintOpenSearchClient implements FlintClient {
               )
           ));
     } catch (Exception e) {
-      throw new IllegalStateException("Failed to get Flint index metadata for " + osIndexNamePattern, e);
+      throw new IllegalStateException("Failed to get Flint index metadata for " +
+          String.join(",", indexNames), e);
     }
   }
 

--- a/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalog.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalog.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.opensearch.catalog
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.opensearch.catalog.OpenSearchCatalog.{OPENSEARCH_PREFIX}
+import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, NoSuchTableException}
+import org.apache.spark.sql.connector.catalog._
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.flint.FlintTable
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * A Spark TableCatalog implementation wrap OpenSearch domain as Catalog.
+ *
+ * <p> Configuration parameters for OpenSearchCatalog:
+ *
+ * <ul> <li><code>opensearch.port</code>: Default is 9200.</li>
+ * <li><code>opensearch.scheme</code>: Default is http. Valid values are [http, https].</li>
+ * <li><code>opensearch.auth</code>: Default is noauth. Valid values are [noauth, sigv4,
+ * basic].</li> <li><code>opensearch.auth.username</code>: Basic auth username.</li>
+ * <li><code>opensearch.auth.password</code>: Basic auth password.</li>
+ * <li><code>opensearch.region</code>: Default is us-west-2. Only used when auth is sigv4.</li>
+ * </ul>
+ */
+class OpenSearchCatalog extends CatalogPlugin with TableCatalog with Logging {
+
+  private var catalogName: String = _
+  private var options: CaseInsensitiveStringMap = _
+
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+    this.catalogName = name
+    this.options = options
+  }
+
+  override def name(): String = catalogName
+
+  @throws[NoSuchNamespaceException]
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    throw new UnsupportedOperationException("OpenSearchCatalog does not support listTables")
+  }
+
+  @throws[NoSuchTableException]
+  override def loadTable(ident: Identifier): Table = {
+    logInfo(s"Loading table ${ident.name()}")
+    if (!ident.namespace().exists(n => OpenSearchCatalog.isDefaultNamespace(n))) {
+      throw new NoSuchTableException(ident.namespace().mkString("."), ident.name())
+    }
+
+    val conf = new java.util.HashMap[String, String](
+      removePrefixFromMap(options.asCaseSensitiveMap(), OPENSEARCH_PREFIX))
+    conf.put("path", ident.name())
+
+    FlintTable(conf, Option.empty)
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: java.util.Map[String, String]): Table = {
+    throw new UnsupportedOperationException("OpenSearchCatalog does not support createTable")
+  }
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    throw new UnsupportedOperationException("OpenSearchCatalog does not support alterTable")
+  }
+
+  override def dropTable(ident: Identifier): Boolean = {
+    throw new UnsupportedOperationException("OpenSearchCatalog does not support dropTable")
+  }
+
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    throw new UnsupportedOperationException("OpenSearchCatalog does not support renameTable")
+  }
+
+  private def removePrefixFromMap(
+      map: java.util.Map[String, String],
+      prefix: String): java.util.Map[String, String] = {
+    val result = new java.util.HashMap[String, String]()
+    map.forEach { (key, value) =>
+      if (key.startsWith(prefix)) {
+        val newKey = key.substring(prefix.length)
+        result.put(newKey, value)
+      } else {
+        result.put(key, value)
+      }
+    }
+    result
+  }
+}
+
+object OpenSearchCatalog {
+
+  /**
+   * The reserved namespace.
+   */
+  val RESERVED_DEFAULT_NAMESPACE: String = "default"
+
+  /**
+   * The prefix for OpenSearch-related configuration keys.
+   */
+  val OPENSEARCH_PREFIX: String = "opensearch."
+
+  /**
+   * Checks if the given namespace is the reserved default namespace.
+   *
+   * @param namespace
+   *   The namespace to check.
+   * @return
+   *   True if the namespace is the reserved default namespace, false otherwise.
+   */
+  def isDefaultNamespace(namespace: String): Boolean = {
+    RESERVED_DEFAULT_NAMESPACE.equalsIgnoreCase(namespace)
+  }
+
+  /**
+   * Splits the table name into index names.
+   *
+   * @param tableName
+   *   The name of the table, potentially containing comma-separated index names.
+   * @return
+   *   An array of index names.
+   */
+  def indexNames(tableName: String): Array[String] = {
+    tableName.split(",")
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalog.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalog.scala
@@ -10,7 +10,7 @@ import org.apache.spark.opensearch.catalog.OpenSearchCatalog.OPENSEARCH_PREFIX
 import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, NoSuchTableException}
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.flint.FlintTable
+import org.apache.spark.sql.flint.FlintReadOnlyTable
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -55,7 +55,7 @@ class OpenSearchCatalog extends CatalogPlugin with TableCatalog with Logging {
       removePrefixFromMap(options.asCaseSensitiveMap(), OPENSEARCH_PREFIX))
     conf.put("path", ident.name())
 
-    FlintTable(conf, Option.empty)
+    new FlintReadOnlyTable(conf, Option.empty)
   }
 
   override def createTable(

--- a/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalog.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalog.scala
@@ -6,7 +6,7 @@
 package org.apache.spark.opensearch.catalog
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.opensearch.catalog.OpenSearchCatalog.{OPENSEARCH_PREFIX}
+import org.apache.spark.opensearch.catalog.OpenSearchCatalog.OPENSEARCH_PREFIX
 import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, NoSuchTableException}
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.expressions.Transform

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintReadOnlyTable.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintReadOnlyTable.scala
@@ -29,7 +29,9 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  * @param userSpecifiedSchema
  *   userSpecifiedSchema
  */
-class FlintReadOnlyTable(conf: util.Map[String, String], userSpecifiedSchema: Option[StructType])
+class FlintReadOnlyTable(
+    val conf: util.Map[String, String],
+    val userSpecifiedSchema: Option[StructType])
     extends Table
     with SupportsRead {
 

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintReadOnlyTable.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintReadOnlyTable.scala
@@ -57,7 +57,7 @@ class FlintReadOnlyTable(
   }
 
   override def capabilities(): util.Set[TableCapability] =
-    util.EnumSet.of(BATCH_READ, BATCH_WRITE, TRUNCATE, STREAMING_WRITE)
+    util.EnumSet.of(BATCH_READ)
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
     FlintScanBuilder(name, schema, flintSparkConf)

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintReadOnlyTable.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintReadOnlyTable.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql.flint
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+import org.opensearch.flint.core.FlintClientBuilder
+
+import org.apache.spark.opensearch.catalog.OpenSearchCatalog
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.{SupportsRead, Table, TableCapability}
+import org.apache.spark.sql.connector.catalog.TableCapability.{BATCH_READ, BATCH_WRITE, STREAMING_WRITE, TRUNCATE}
+import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.flint.config.FlintSparkConf
+import org.apache.spark.sql.flint.datatype.FlintDataType
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * FlintReadOnlyTable.
+ *
+ * @param conf
+ *   configuration
+ * @param userSpecifiedSchema
+ *   userSpecifiedSchema
+ */
+class FlintReadOnlyTable(conf: util.Map[String, String], userSpecifiedSchema: Option[StructType])
+    extends Table
+    with SupportsRead {
+
+  lazy val sparkSession = SparkSession.active
+
+  lazy val flintSparkConf: FlintSparkConf = FlintSparkConf(conf)
+
+  lazy val name: String = flintSparkConf.tableName()
+
+  // todo. currently, we use first index schema in multiple indices. we should merge StructType
+  //  to widen type
+  lazy val schema: StructType = {
+    userSpecifiedSchema.getOrElse {
+      FlintClientBuilder
+        .build(flintSparkConf.flintOptions())
+        .getAllIndexMetadata(OpenSearchCatalog.indexNames(name): _*)
+        .values()
+        .asScala
+        .headOption
+        .map(m => FlintDataType.deserialize(m.getContent))
+        .getOrElse(StructType(Nil))
+    }
+  }
+
+  override def capabilities(): util.Set[TableCapability] =
+    util.EnumSet.of(BATCH_READ, BATCH_WRITE, TRUNCATE, STREAMING_WRITE)
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    FlintScanBuilder(name, schema, flintSparkConf)
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintTable.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintTable.scala
@@ -18,7 +18,9 @@ import org.apache.spark.sql.types.StructType
  * @param userSpecifiedSchema
  *   userSpecifiedSchema
  */
-case class FlintTable(conf: util.Map[String, String], userSpecifiedSchema: Option[StructType])
+case class FlintTable(
+    override val conf: util.Map[String, String],
+    override val userSpecifiedSchema: Option[StructType])
     extends FlintReadOnlyTable(conf, userSpecifiedSchema)
     with SupportsWrite {
 

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintTable.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintTable.scala
@@ -7,7 +7,8 @@ package org.apache.spark.sql.flint
 
 import java.util
 
-import org.apache.spark.sql.connector.catalog.SupportsWrite
+import org.apache.spark.sql.connector.catalog.{SupportsWrite, TableCapability}
+import org.apache.spark.sql.connector.catalog.TableCapability.{BATCH_READ, BATCH_WRITE, STREAMING_WRITE, TRUNCATE}
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.apache.spark.sql.types.StructType
 
@@ -23,6 +24,9 @@ case class FlintTable(
     override val userSpecifiedSchema: Option[StructType])
     extends FlintReadOnlyTable(conf, userSpecifiedSchema)
     with SupportsWrite {
+
+  override def capabilities(): util.Set[TableCapability] =
+    util.EnumSet.of(BATCH_READ, BATCH_WRITE, TRUNCATE, STREAMING_WRITE)
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
     FlintWriteBuilder(name, info, flintSparkConf)

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintTable.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintTable.scala
@@ -7,20 +7,9 @@ package org.apache.spark.sql.flint
 
 import java.util
 
-import scala.collection.JavaConverters._
-
-import org.opensearch.flint.core.FlintClientBuilder
-
-import org.apache.spark.opensearch.catalog.OpenSearchCatalog
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
-import org.apache.spark.sql.connector.catalog.TableCapability.{BATCH_READ, BATCH_WRITE, STREAMING_WRITE, TRUNCATE}
-import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.connector.catalog.SupportsWrite
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
-import org.apache.spark.sql.flint.config.FlintSparkConf
-import org.apache.spark.sql.flint.datatype.FlintDataType
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
  * FlintTable.
@@ -30,37 +19,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  *   userSpecifiedSchema
  */
 case class FlintTable(conf: util.Map[String, String], userSpecifiedSchema: Option[StructType])
-    extends Table
-    with SupportsRead
+    extends FlintReadOnlyTable(conf, userSpecifiedSchema)
     with SupportsWrite {
-
-  lazy val sparkSession = SparkSession.active
-
-  lazy val flintSparkConf: FlintSparkConf = FlintSparkConf(conf)
-
-  lazy val name: String = flintSparkConf.tableName()
-
-  // todo. currently, we use first index schema in multiple indices. we should merge StructType
-  //  to widen type
-  lazy val schema: StructType = {
-    userSpecifiedSchema.getOrElse {
-      FlintClientBuilder
-        .build(flintSparkConf.flintOptions())
-        .getAllIndexMetadata(OpenSearchCatalog.indexNames(name): _*)
-        .values()
-        .asScala
-        .headOption
-        .map(m => FlintDataType.deserialize(m.getContent))
-        .getOrElse(StructType(Nil))
-    }
-  }
-
-  override def capabilities(): util.Set[TableCapability] =
-    util.EnumSet.of(BATCH_READ, BATCH_WRITE, TRUNCATE, STREAMING_WRITE)
-
-  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-    FlintScanBuilder(name, schema, flintSparkConf)
-  }
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
     FlintWriteBuilder(name, info, flintSparkConf)

--- a/flint-spark-integration/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogTest.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogTest.scala
@@ -16,7 +16,7 @@ import org.apache.spark.FlintSuite
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.connector.catalog.{Identifier, TableChange}
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.flint.FlintTable
+import org.apache.spark.sql.flint.FlintReadOnlyTable
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -71,7 +71,7 @@ class OpenSearchCatalogTest
     table should not be null
     table.name() should be("table1")
 
-    val flintTableConf = FlintTable.unapply(table.asInstanceOf[FlintTable]).get._1
+    val flintTableConf = table.asInstanceOf[FlintReadOnlyTable].conf
     flintTableConf.get("port") should be("9200")
     flintTableConf.get("scheme") should be("http")
     flintTableConf.get("auth") should be("noauth")

--- a/flint-spark-integration/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogTest.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogTest.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.opensearch.catalog
+
+import scala.collection.JavaConverters._
+
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.FlintSuite
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.connector.catalog.{Identifier, TableChange}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.flint.FlintTable
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class OpenSearchCatalogTest
+    extends FlintSuite
+    with Matchers
+    with BeforeAndAfterEach
+    with MockitoSugar {
+
+  private var catalog: OpenSearchCatalog = _
+  private val catalogName = "dev"
+  private val optionsMap = Map(
+    "opensearch.port" -> "9200",
+    "opensearch.scheme" -> "http",
+    "opensearch.auth" -> "noauth",
+    "some.other.config" -> "value")
+  private val options = new CaseInsensitiveStringMap(optionsMap.asJava)
+
+  override def beforeEach(): Unit = {
+    catalog = new OpenSearchCatalog()
+    catalog.initialize(catalogName, options)
+  }
+
+  test("Catalog should initialize with given name and options") {
+    catalog.name() should be(catalogName)
+  }
+
+  test("listTables should throw UnsupportedOperationException") {
+    val namespace = Array("default")
+
+    intercept[UnsupportedOperationException] {
+      catalog.listTables(namespace)
+    }
+  }
+
+  test("loadTable should throw NoSuchTableException if namespace is not default") {
+    val identifier = mock[Identifier]
+    when(identifier.namespace()).thenReturn(Array("non-default"))
+    when(identifier.name()).thenReturn("table1")
+
+    intercept[NoSuchTableException] {
+      catalog.loadTable(identifier)
+    }
+  }
+
+  test("loadTable should load table if namespace is default") {
+    val identifier = mock[Identifier]
+    when(identifier.namespace()).thenReturn(Array("default"))
+    when(identifier.name()).thenReturn("table1")
+
+    val table = catalog.loadTable(identifier)
+    table should not be null
+    table.name() should be("table1")
+
+    val flintTableConf = FlintTable.unapply(table.asInstanceOf[FlintTable]).get._1
+    flintTableConf.get("port") should be("9200")
+    flintTableConf.get("scheme") should be("http")
+    flintTableConf.get("auth") should be("noauth")
+    flintTableConf.get("some.other.config") should be("value")
+    flintTableConf.containsKey("opensearch.port") should be(false)
+    flintTableConf.containsKey("opensearch.scheme") should be(false)
+    flintTableConf.containsKey("opensearch.auth") should be(false)
+  }
+
+  test("createTable should throw UnsupportedOperationException") {
+    val identifier = mock[Identifier]
+    val schema = mock[StructType]
+    val partitions = Array.empty[Transform]
+    val properties = Map.empty[String, String].asJava
+
+    intercept[UnsupportedOperationException] {
+      catalog.createTable(identifier, schema, partitions, properties)
+    }
+  }
+
+  test("alterTable should throw UnsupportedOperationException") {
+    val identifier = mock[Identifier]
+    val changes = Array.empty[TableChange]
+
+    intercept[UnsupportedOperationException] {
+      catalog.alterTable(identifier, changes: _*)
+    }
+  }
+
+  test("dropTable should throw UnsupportedOperationException") {
+    val identifier = mock[Identifier]
+
+    intercept[UnsupportedOperationException] {
+      catalog.dropTable(identifier)
+    }
+  }
+
+  test("renameTable should throw UnsupportedOperationException") {
+    val oldIdentifier = mock[Identifier]
+    val newIdentifier = mock[Identifier]
+
+    intercept[UnsupportedOperationException] {
+      catalog.renameTable(oldIdentifier, newIdentifier)
+    }
+  }
+
+  test("isDefaultNamespace should return true for default namespace") {
+    OpenSearchCatalog.isDefaultNamespace("default") should be(true)
+  }
+
+  test("isDefaultNamespace should return false for non-default namespace") {
+    OpenSearchCatalog.isDefaultNamespace("non-default") should be(false)
+  }
+
+  test("indexNames should split table name by comma") {
+    val tableName = "index-1,index-2"
+    val result = OpenSearchCatalog.indexNames(tableName)
+    result should contain theSameElementsAs Array("index-1", "index-2")
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -5,6 +5,8 @@
 
 package org.opensearch.flint.spark.covering
 
+import scala.collection.JavaConverters._
+
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mockStatic, when, RETURNS_DEEP_STUBS}
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
@@ -198,7 +200,8 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
       })
 
       indexes.foreach { index =>
-        when(client.getIndexMetadata(index.name())).thenReturn(index.metadata())
+        when(client.getAllIndexMetadata(index.name()))
+          .thenReturn(Map.apply(index.name() -> index.metadata()).asJava)
       }
       rule.apply(plan)
     }

--- a/integ-test/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogITSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogITSuite.scala
@@ -55,7 +55,8 @@ class OpenSearchCatalogITSuite
     }
   }
 
-  test("Load comma seperated index expression as table") {
+  // FIXME, enable it when add partition info into OpenSearchTable.
+  ignore("Load comma seperated index expression as table") {
     val indexName1 = "t0001"
     val indexName2 = "t0002"
     withIndexName(indexName1) {

--- a/integ-test/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogITSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogITSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.opensearch.catalog
+
+import org.opensearch.flint.OpenSearchSuite
+
+import org.apache.spark.FlintSuite
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.streaming.StreamTest
+
+class OpenSearchCatalogITSuite
+    extends QueryTest
+    with StreamTest
+    with FlintSuite
+    with OpenSearchSuite {
+
+  private val catalogName = "dev"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    spark.conf.set(
+      s"spark.sql.catalog.${catalogName}",
+      "org.apache.spark.opensearch.catalog.OpenSearchCatalog")
+    spark.conf.set(s"spark.sql.catalog.${catalogName}.opensearch.port", s"$openSearchPort")
+    spark.conf.set(s"spark.sql.catalog.${catalogName}.opensearch.host", openSearchHost)
+  }
+
+  test("Load single index as table") {
+    val indexName = "t0001"
+    withIndexName(indexName) {
+      simpleIndex(indexName)
+      val df = spark.sql(s"""
+        SELECT accountId, eventName, eventSource
+        FROM ${catalogName}.default.${indexName}""")
+
+      assert(df.count() == 1)
+      checkAnswer(df, Row("123", "event", "source"))
+    }
+  }
+
+  test("Load index wildcard expression as table") {
+    val indexName = "t0001"
+    withIndexName(indexName) {
+      simpleIndex(indexName)
+      val df = spark.sql(s"""
+        SELECT accountId, eventName, eventSource
+        FROM ${catalogName}.default.`t*`""")
+
+      assert(df.count() == 1)
+      checkAnswer(df, Row("123", "event", "source"))
+    }
+  }
+
+  test("Load comma seperated index expression as table") {
+    val indexName1 = "t0001"
+    val indexName2 = "t0002"
+    withIndexName(indexName1) {
+      withIndexName(indexName2) {
+        simpleIndex(indexName1)
+        simpleIndex(indexName2)
+        val df = spark.sql(s"""
+        SELECT accountId, eventName, eventSource
+        FROM ${catalogName}.default.`t0001,t0002`""")
+
+        assert(df.count() == 2)
+        checkAnswer(df, Seq(Row("123", "event", "source"), Row("123", "event", "source")))
+      }
+    }
+  }
+}

--- a/integ-test/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogITSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogITSuite.scala
@@ -6,16 +6,13 @@
 package org.apache.spark.opensearch.catalog
 
 import org.opensearch.flint.OpenSearchSuite
+import org.opensearch.flint.spark.FlintSparkSuite
 
 import org.apache.spark.FlintSuite
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.streaming.StreamTest
 
-class OpenSearchCatalogITSuite
-    extends QueryTest
-    with StreamTest
-    with FlintSuite
-    with OpenSearchSuite {
+class OpenSearchCatalogITSuite extends FlintSparkSuite {
 
   private val catalogName = "dev"
 

--- a/integ-test/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogITSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalogITSuite.scala
@@ -70,7 +70,8 @@ class OpenSearchCatalogITSuite extends FlintSparkSuite {
         spark.sql(s"""
           INSERT INTO ${catalogName}.default.$indexName VALUES ('234', 'event-1', 'source-1')""")
       }
-      assert(exception.getMessage.contains(s"Table does not support writes: $indexName"))
+      assert(
+        exception.getMessage.contains(s"Table $indexName does not support append in batch mode."))
     }
   }
 
@@ -85,7 +86,7 @@ class OpenSearchCatalogITSuite extends FlintSparkSuite {
     }
   }
 
-  test("Failed to override value of readonly table") {
+  test("Failed to overwrite value of readonly table") {
     val indexName = "t0001"
     withIndexName(indexName) {
       simpleIndex(indexName)
@@ -93,7 +94,9 @@ class OpenSearchCatalogITSuite extends FlintSparkSuite {
         spark.sql(s"""
           INSERT OVERWRITE TABLE ${catalogName}.default.$indexName VALUES ('234', 'event-1', 'source-1')""")
       }
-      assert(exception.getMessage.contains(s"Table does not support writes: $indexName"))
+      assert(
+        exception.getMessage.contains(
+          s"Table $indexName does not support truncate in batch mode."))
     }
   }
 


### PR DESCRIPTION
### Description
This PR introduces the `OpenSearchCatalog` class, enabling Apache Spark to integrate with OpenSearch as a data catalog and direct access OpenSearch Index in Spark SQL. Key features and changes include:

### Configuration Parameters
- **`opensearch.port`**: Default is `9200`.
- **`opensearch.scheme`**: Default is `http`. Valid values are `[http, https]`.
- **`opensearch.auth`**: Default is `noauth`. Valid values are `[noauth, sigv4, basic]`.
- **`opensearch.auth.username`**: Basic auth username.
- **`opensearch.auth.password`**: Basic auth password.
- **`opensearch.region`**: Default is `us-west-2`. Used only when `auth` is `sigv4`.

### Implemented Methods
- **`loadTable`**: Loads a read only table from the OpenSearch index.
- **Unsupported Operations**: The following methods throw `UnsupportedOperationException`:
  - `listTables`
  - `createTable`
  - `alterTable`
  - `dropTable`
  - `renameTable`

### Follow up
* Support comma separated index name as table identifier.

### Doc
https://github.com/penghuo/penghuo-opensearch-spark/blob/issue395/docs/opensearch-table.md

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/395

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
