### PR TITLE
support shard level split on read path

### DIFF
--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -58,3 +58,6 @@ df.show()
 
 ### table operation
 - Table only support read operation, for instance, SELECT, DESCRIBE.
+
+##  InputPartition
+Each InputPartition represents a data split that can be processed by a single Spark task. The number of input partitions returned corresponds to the number of RDD partitions produced by this scan. An OpenSearch table can contain multiple indices, each comprising multiple shards. The input partition count is determined by multiplying the number of indices by the number of shards. Read requests are divided and executed in parallel across multiple shards on multiple nodes.

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
@@ -75,6 +75,16 @@ public interface FlintClient {
   FlintReader createReader(String indexName, String query);
 
   /**
+   * Create {@link FlintReader}.
+   *
+   * @param indexName index name.
+   * @param shardId shard id.
+   * @param query DSL query. DSL query is null means match_all
+   * @return {@link FlintReader}.
+   */
+  FlintReader createReader(String indexName, String shardId, String query);
+
+  /**
    * Create {@link FlintWriter}.
    *
    * @param indexName - index name

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
@@ -64,7 +64,7 @@ public class FlintOpenSearchClient implements FlintClient {
       Set.of(' ', ',', ':', '"', '+', '/', '\\', '|', '?', '#', '>', '<');
 
   private final static Function<String, String> SHARD_ID_PREFERENCE =
-      shardId -> "_shards:"+shardId;
+      shardId -> shardId == null ? shardId : "_shards:"+shardId;
 
   private final FlintOptions options;
 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchScrollReader.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchScrollReader.java
@@ -69,9 +69,9 @@ public class OpenSearchScrollReader extends OpenSearchReader {
       return Optional.of(response);
     } else {
       try {
-        return Optional.of(client.scroll(new SearchScrollRequest().scroll(scrollDuration)
-                .scrollId(scrollId),
-            RequestOptions.DEFAULT));
+        return Optional
+            .of(client.scroll(new SearchScrollRequest().scroll(scrollDuration).scrollId(scrollId),
+                RequestOptions.DEFAULT));
       } catch (OpenSearchStatusException e) {
         LOG.log(Level.WARNING, "scroll context not exist", e);
         scrollId = null;
@@ -92,10 +92,8 @@ public class OpenSearchScrollReader extends OpenSearchReader {
       }
     } catch (OpenSearchStatusException e) {
       // OpenSearch throw exception if scroll already closed. https://github.com/opensearch-project/OpenSearch/issues/11121
-      LOG.log(
-          Level.WARNING,
-          "close scroll exception, it is a known bug https://github" + ".com/opensearch-project/OpenSearch/issues/11121.",
-          e);
+      LOG.log(Level.WARNING, "close scroll exception, it is a known bug https://github" +
+          ".com/opensearch-project/OpenSearch/issues/11121.", e);
     } finally {
       scrollId = null;
     }

--- a/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalog.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/catalog/OpenSearchCatalog.scala
@@ -39,12 +39,10 @@ class OpenSearchCatalog extends CatalogPlugin with TableCatalog with Logging {
 
   override def name(): String = catalogName
 
-  @throws[NoSuchNamespaceException]
   override def listTables(namespace: Array[String]): Array[Identifier] = {
     throw new UnsupportedOperationException("OpenSearchCatalog does not support listTables")
   }
 
-  @throws[NoSuchTableException]
   override def loadTable(ident: Identifier): Table = {
     logInfo(s"Loading table ${ident.name()}")
     if (!ident.namespace().exists(n => OpenSearchCatalog.isDefaultNamespace(n))) {

--- a/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/table/OpenSearchTable.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/table/OpenSearchTable.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.opensearch.table
+
+import scala.collection.JavaConverters._
+
+import org.opensearch.flint.core.{FlintClientBuilder, FlintOptions}
+import org.opensearch.flint.core.metadata.FlintMetadata
+
+import org.apache.spark.sql.flint.datatype.FlintDataType
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Represents an OpenSearch table.
+ *
+ * @param tableName
+ *   The name of the table.
+ * @param metadata
+ *   Metadata of the table.
+ */
+case class OpenSearchTable(tableName: String, metadata: Map[String, FlintMetadata]) {
+  /*
+   * FIXME. we use first index schema in multiple indices. we should merge StructType to widen type
+   */
+  lazy val schema: StructType = {
+    metadata.values.headOption
+      .map(m => FlintDataType.deserialize(m.getContent))
+      .getOrElse(StructType(Nil))
+  }
+
+  lazy val partitions: Array[PartitionInfo] = {
+    metadata.map { case (partitionName, metadata) =>
+      PartitionInfo.apply(partitionName, metadata.indexSettings.get)
+    }.toArray
+  }
+}
+
+object OpenSearchTable {
+
+  /**
+   * Creates an OpenSearchTable instance.
+   *
+   * @param tableName
+   *   tableName support (1) single index name. (2) wildcard index name. (3) comma sep index name.
+   * @param options
+   *   The options for Flint.
+   * @return
+   *   An instance of OpenSearchTable.
+   */
+  def apply(tableName: String, options: FlintOptions): OpenSearchTable = {
+    OpenSearchTable(
+      tableName,
+      FlintClientBuilder
+        .build(options)
+        .getAllIndexMetadata(tableName.split(","): _*)
+        .asScala
+        .toMap)
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/table/PartitionInfo.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/table/PartitionInfo.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.opensearch.table
+
+import org.json4s.{Formats, NoTypeHints}
+import org.json4s.jackson.JsonMethods
+import org.json4s.native.Serialization
+
+/**
+ * Represents information about a partition in OpenSearch. Partition is backed by OpenSearch
+ * Index. Each partition contain a list of Shards
+ *
+ * @param partitionName
+ *   partition name.
+ * @param shards
+ *   shards.
+ */
+case class PartitionInfo(partitionName: String, shards: Array[ShardInfo]) {}
+
+object PartitionInfo {
+  implicit val formats: Formats = Serialization.formats(NoTypeHints)
+
+  /**
+   * Creates a PartitionInfo instance.
+   *
+   * @param partitionName The name of the partition.
+   * @param settings The settings of the partition.
+   * @return An instance of PartitionInfo.
+   */
+  def apply(partitionName: String, settings: String): PartitionInfo = {
+    val shards =
+      Range.apply(0, numberOfShards(settings)).map(id => ShardInfo(partitionName, id)).toArray
+    PartitionInfo(partitionName, shards)
+  }
+
+  /**
+   * Extracts the number of shards from the settings string.
+   *
+   * @param settingStr The settings string.
+   * @return The number of shards.
+   */
+  def numberOfShards(settingStr: String): Int = {
+    val setting = JsonMethods.parse(settingStr)
+    (setting \ "index.number_of_shards").extract[String].toInt
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/table/PartitionInfo.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/table/PartitionInfo.scala
@@ -26,9 +26,12 @@ object PartitionInfo {
   /**
    * Creates a PartitionInfo instance.
    *
-   * @param partitionName The name of the partition.
-   * @param settings The settings of the partition.
-   * @return An instance of PartitionInfo.
+   * @param partitionName
+   *   The name of the partition.
+   * @param settings
+   *   The settings of the partition.
+   * @return
+   *   An instance of PartitionInfo.
    */
   def apply(partitionName: String, settings: String): PartitionInfo = {
     val shards =
@@ -39,8 +42,10 @@ object PartitionInfo {
   /**
    * Extracts the number of shards from the settings string.
    *
-   * @param settingStr The settings string.
-   * @return The number of shards.
+   * @param settingStr
+   *   The settings string.
+   * @return
+   *   The number of shards.
    */
   def numberOfShards(settingStr: String): Int = {
     val setting = JsonMethods.parse(settingStr)

--- a/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/table/ShardInfo.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/opensearch/table/ShardInfo.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.opensearch.table
+
+/**
+ * Represents information about a shard in OpenSearch.
+ *
+ * @param indexName
+ *   The name of the index.
+ * @param id
+ *   The ID of the shard.
+ */
+case class ShardInfo(indexName: String, id: Int)

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintScanBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintScanBuilder.scala
@@ -6,13 +6,14 @@
 package org.apache.spark.sql.flint
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.opensearch.table.OpenSearchTable
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownV2Filters}
 import org.apache.spark.sql.flint.config.FlintSparkConf
 import org.apache.spark.sql.flint.storage.FlintQueryCompiler
 import org.apache.spark.sql.types.StructType
 
-case class FlintScanBuilder(tableName: String, schema: StructType, options: FlintSparkConf)
+case class FlintScanBuilder(table: OpenSearchTable, schema: StructType, options: FlintSparkConf)
     extends ScanBuilder
     with SupportsPushDownV2Filters
     with Logging {
@@ -20,7 +21,7 @@ case class FlintScanBuilder(tableName: String, schema: StructType, options: Flin
   private var pushedPredicate = Array.empty[Predicate]
 
   override def build(): Scan = {
-    FlintScan(tableName, schema, options, pushedPredicate)
+    FlintScan(table, schema, options, pushedPredicate)
   }
 
   override def pushPredicates(predicates: Array[Predicate]): Array[Predicate] = {

--- a/integ-test/src/test/scala/org/apache/spark/opensearch/table/OpenSearchCatalogSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/opensearch/table/OpenSearchCatalogSuite.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.opensearch.table
+
+import org.opensearch.flint.spark.FlintSparkSuite
+
+trait OpenSearchCatalogSuite extends FlintSparkSuite {
+  val catalogName = "dev"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    spark.conf.set(
+      s"spark.sql.catalog.${catalogName}",
+      "org.apache.spark.opensearch.catalog.OpenSearchCatalog")
+    spark.conf.set(s"spark.sql.catalog.${catalogName}.opensearch.port", s"$openSearchPort")
+    spark.conf.set(s"spark.sql.catalog.${catalogName}.opensearch.host", openSearchHost)
+    spark.conf.set(
+      s"spark.sql.catalog.${catalogName}.opensearch.write.refresh_policy",
+      "wait_for")
+  }
+}

--- a/integ-test/src/test/scala/org/apache/spark/opensearch/table/OpenSearchTableITSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/opensearch/table/OpenSearchTableITSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.opensearch.table
+
+class OpenSearchTableITSuite extends OpenSearchCatalogSuite {
+
+  def multipleShardsIndex(indexName: String): Unit = {
+    val twoShards = """{
+                           |  "number_of_shards": "2",
+                           |  "number_of_replicas": "0"
+                           |}""".stripMargin
+
+    val mappings = """{
+                     |  "properties": {
+                     |    "accountId": {
+                     |      "type": "keyword"
+                     |    },
+                     |    "eventName": {
+                     |      "type": "keyword"
+                     |    },
+                     |    "eventSource": {
+                     |      "type": "keyword"
+                     |    }
+                     |  }
+                     |}""".stripMargin
+    val docs = Seq("""{
+                     |  "accountId": "123",
+                     |  "eventName": "event",
+                     |  "eventSource": "source"
+                     |}""".stripMargin)
+    index(indexName, twoShards, mappings, docs)
+  }
+
+  test("Partition works correctly when indices include multiple shards") {
+    val indexName1 = "t0001"
+    withIndexName(indexName1) {
+      multipleShardsIndex(indexName1)
+      val df = spark.sql(s"""
+        SELECT accountId, eventName, eventSource
+        FROM ${catalogName}.default.`t0001`""")
+
+      assert(df.rdd.getNumPartitions == 2)
+    }
+  }
+
+  test("Partition works correctly when query wildcard index") {
+    val indexName1 = "t0001"
+    val indexName2 = "t0002"
+    withIndexName(indexName1) {
+      withIndexName(indexName2) {
+        simpleIndex(indexName1)
+        simpleIndex(indexName2)
+        val df = spark.sql(s"""
+        SELECT accountId, eventName, eventSource
+        FROM ${catalogName}.default.`t0001,t0002`""")
+
+        assert(df.rdd.getNumPartitions == 2)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
* A partition of an OpenSearchTable is backed by an OpenSearch Index. Each partition is split into a configurable number of shards, which are then distributed across the cluster.
* Update doc, https://github.com/penghuo/penghuo-opensearch-spark/blob/issue396/docs/opensearch-table.md#inputpartition.
* Performance test track at https://github.com/opensearch-project/opensearch-spark/issues/403.

### Test
1. Test with EMR-S. The task is scheduled based on split count. For instance, index has 5 shards, then 5 tasks are scheduled.
```
24/06/29 00:24:43 INFO DAGScheduler: Got map stage job 0 (main at NativeMethodAccessorImpl.java:0) with 5 output partitions
24/06/29 00:24:43 INFO DAGScheduler: Submitting 5 missing tasks from ShuffleMapStage 0 (MapPartitionsRDD[5] at main at NativeMethodAccessorImpl.java:0) (first 15 tasks are for partitions Vector(0, 1, 2, 3, 4))
```

2. Test with AWS OpenSearch Multi-AZ with Standby domain.  it support `preference:_shard:` paramaters.

### Benchmark
#### Single Index with 5 shards
The table below presents the p90 query latency results for both the partitioned and non-partitioned test cases. Across all queries, the results with partitioning show significantly lower times compared to the non-partitioned results.

| Query                                                                                                     | p90 ms (without partition) | p90 ms (with partition) |
|-----------------------------------------------------------------------------------------------------------|------------------------------:|----------------------------:|
| SELECT COUNT(*) FROM dev.default.`logs-181998`                                                            |                         42296 |                       17031 |
| SELECT COUNT(*) FROM dev.default.`logs-181998` WHERE status <> 0;                                         |                         44142 |                       16667 |
| SELECT COUNT(*), AVG(size) FROM dev.default.`logs-181998`;                                                |                         44584 |                       18775 |
| SELECT AVG(CAST(size AS BIGINT)) FROM dev.default.`logs-181998`;                                          |                         43575 |                       19474 |
| SELECT MIN(`@timestamp`), MAX(`@timestamp`) FROM dev.default.`logs-181998`;                               |                         43533 |                       19130 |
| SELECT status, COUNT() FROM dev.default.logs-181998 WHERE status <> 0 GROUP BY status ORDER BY COUNT() DESC; |                      43952 |                       19661 |


![1](https://github.com/opensearch-project/opensearch-spark/assets/2969395/9d58b49f-7d1b-42e0-96e5-00038030316e)

#### Multiple Indices, each index has 5 shards
The table below presents the p90 query latency results for both the partitioned and non-partitioned test cases when query index wildcard. Across all queries, the results with partitioning show significantly lower times compared to the non-partitioned results.

| Query                                                                                                     | p90 ms (without partition) | p90 ms (with partition) |
|-----------------------------------------------------------------------------------------------------------|------------------------------:|----------------------------:|
| SELECT COUNT(*) FROM dev.default.\`logs-1*\`                                                            |                        228049 |                       52123 |
| SELECT COUNT(*) FROM dev.default.\`logs-1*\` WHERE status <> 0;                                         |                        215548 |                       43631 |
| SELECT COUNT(*), AVG(size) FROM dev.default.\`logs-1*\`;                                                |                        222332 |                       51583 |
| SELECT AVG(CAST(size AS BIGINT)) FROM dev.default.\`logs-1*\`;                                          |                        215273 |                       51805 |
| SELECT MIN(\`@timestamp\`), MAX(\`@timestamp\`) FROM dev.default.\`logs-1*\`;                               |                        224576 |                       45914 |
| SELECT status, COUNT(*) FROM dev.default.\`logs-1*\` WHERE status <> 0 GROUP BY status ORDER BY COUNT(*) DESC; |                        189594 |                       46758 |

![2](https://github.com/opensearch-project/opensearch-spark/assets/2969395/7a66f888-4e90-42b1-ae7e-0b7140fa7225)


### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/396

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
