### PR TITLE
Separate metadata log entry data model and persistence

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ lazy val flintCore = (project in file("flint-core"))
       "org.mockito" % "mockito-junit-jupiter" % "3.12.4" % "test",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.9.0" % "test",
       "org.junit.jupiter" % "junit-jupiter-engine" % "5.9.0" % "test",
+      "com.typesafe.play" %% "play-json" % "2.9.2" % "test",
       "com.google.truth" % "truth" % "1.1.5" % "test",
       "net.aichler" % "jupiter-interface" % "0.11.1" % Test
     ),

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLog.java
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLog.java
@@ -31,4 +31,6 @@ public interface FlintMetadataLog<T> {
    * Remove all log entries.
    */
   void purge();
+
+  T emptyLogEntry();
 }

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
@@ -22,6 +22,8 @@ import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState
  *   entry version fields for consistency control
  * @param error
  *   error details if in error state
+ * @param storageContext
+ *   extra context fields required for storage
  */
 case class FlintMetadataLogEntry(
     id: String,
@@ -31,16 +33,28 @@ case class FlintMetadataLogEntry(
      */
     createTime: Long,
     state: IndexState,
-    entryVersion: Map[String, _],
-    error: String) {
+    entryVersion: Map[String, Any],
+    error: String,
+    storageContext: Map[String, Any]) {
 
   def this(
       id: String,
       createTime: Long,
       state: IndexState,
-      entryVersion: JMap[String, _],
-      error: String) {
-    this(id, createTime, state, entryVersion.asScala.toMap, error)
+      entryVersion: JMap[String, Any],
+      error: String,
+      storageContext: JMap[String, Any]) = {
+    this(id, createTime, state, entryVersion.asScala.toMap, error, storageContext.asScala.toMap)
+  }
+
+  def this(
+      id: String,
+      createTime: Long,
+      state: IndexState,
+      entryVersion: JMap[String, Any],
+      error: String,
+      storageContext: Map[String, Any]) = {
+    this(id, createTime, state, entryVersion.asScala.toMap, error, storageContext)
   }
 }
 

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
@@ -16,10 +16,6 @@ import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState
  *
  * @param id
  *   log entry id
- * @param indexName
- *   Flint index name
- * @param createTime
- *   streaming job start time
  * @param state
  *   Flint index state
  * @param entryVersion
@@ -29,7 +25,6 @@ import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState
  */
 case class FlintMetadataLogEntry(
     id: String,
-    indexName: String,
     /**
      * This is currently used as streaming job start time. In future, this should represent the
      * create timestamp of the log entry
@@ -41,12 +36,11 @@ case class FlintMetadataLogEntry(
 
   def this(
       id: String,
-      indexName: String,
       createTime: Long,
       state: IndexState,
       entryVersion: JMap[String, _],
       error: String) {
-    this(id, indexName, createTime, state, entryVersion.asScala.toMap, error)
+    this(id, createTime, state, entryVersion.asScala.toMap, error)
   }
 }
 

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
@@ -22,8 +22,8 @@ import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState
  *   entry version fields for consistency control
  * @param error
  *   error details if in error state
- * @param storageContext
- *   extra context fields required for storage
+ * @param properties
+ *   extra properties fields
  */
 case class FlintMetadataLogEntry(
     id: String,
@@ -35,7 +35,7 @@ case class FlintMetadataLogEntry(
     state: IndexState,
     entryVersion: Map[String, Any],
     error: String,
-    storageContext: Map[String, Any]) {
+    properties: Map[String, Any]) {
 
   def this(
       id: String,

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
@@ -89,7 +89,7 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
           initialLog.state(),
           latest.entryVersion(),
           initialLog.error(),
-          initialLog.storageContext());
+          initialLog.properties());
     }
 
     // Perform operation

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
@@ -85,7 +85,6 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
       // Copy latest entryVersion to initialLog for potential rollback use
       initialLog = initialLog.copy(
           initialLog.id(),
-          initialLog.indexName(),
           initialLog.createTime(),
           initialLog.state(),
           latest.entryVersion(),

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
@@ -88,7 +88,8 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
           initialLog.createTime(),
           initialLog.state(),
           latest.entryVersion(),
-          initialLog.error());
+          initialLog.error(),
+          initialLog.storageContext());
     }
 
     // Perform operation

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
@@ -7,9 +7,6 @@ package org.opensearch.flint.core.metadata.log;
 
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
-import static org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState$;
-import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
-import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -31,11 +28,6 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
   private static final Logger LOG = Logger.getLogger(DefaultOptimisticTransaction.class.getName());
 
   /**
-   * Data source name. TODO: remove this in future.
-   */
-  private final String dataSourceName;
-
-  /**
    * Flint metadata log
    */
   private final FlintMetadataLog<FlintMetadataLogEntry> metadataLog;
@@ -44,10 +36,7 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
   private Function<FlintMetadataLogEntry, FlintMetadataLogEntry> transientAction = null;
   private Function<FlintMetadataLogEntry, FlintMetadataLogEntry> finalAction = null;
 
-  public DefaultOptimisticTransaction(
-      String dataSourceName,
-      FlintMetadataLog<FlintMetadataLogEntry> metadataLog) {
-    this.dataSourceName = dataSourceName;
+  public DefaultOptimisticTransaction(FlintMetadataLog<FlintMetadataLogEntry> metadataLog) {
     this.metadataLog = metadataLog;
   }
 
@@ -79,7 +68,7 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
 
     // Get the latest log and create if not exists
     FlintMetadataLogEntry latest =
-        metadataLog.getLatest().orElseGet(() -> metadataLog.add(emptyLogEntry()));
+        metadataLog.getLatest().orElseGet(() -> metadataLog.add(metadataLog.emptyLogEntry()));
 
     // Perform initial log check
     if (!initialCondition.test(latest)) {
@@ -93,14 +82,14 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
     if (transientAction != null) {
       latest = metadataLog.add(transientAction.apply(latest));
 
-      // Copy latest seqNo and primaryTerm to initialLog for potential rollback use
+      // Copy latest entryVersion to initialLog for potential rollback use
       initialLog = initialLog.copy(
           initialLog.id(),
-          latest.seqNo(),
-          latest.primaryTerm(),
+          initialLog.indexName(),
+          initialLog.dataSource(),
           initialLog.createTime(),
           initialLog.state(),
-          initialLog.dataSource(),
+          latest.entryVersion(),
           initialLog.error());
     }
 
@@ -128,16 +117,5 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
       }
       throw new IllegalStateException("Failed to commit transaction operation", e);
     }
-  }
-
-  private FlintMetadataLogEntry emptyLogEntry() {
-    return new FlintMetadataLogEntry(
-        "",
-        UNASSIGNED_SEQ_NO,
-        UNASSIGNED_PRIMARY_TERM,
-        0L,
-        IndexState$.MODULE$.EMPTY(),
-        dataSourceName,
-        "");
   }
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
@@ -86,7 +86,6 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
       initialLog = initialLog.copy(
           initialLog.id(),
           initialLog.indexName(),
-          initialLog.dataSource(),
           initialLog.createTime(),
           initialLog.state(),
           latest.entryVersion(),

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintMetadataLogEntryOpenSearchConverter.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintMetadataLogEntryOpenSearchConverter.java
@@ -82,7 +82,7 @@ public class FlintMetadataLogEntryOpenSearchConverter {
 
   /**
    * Convert a log entry to json string for persisting to OpenSearch.
-   * Expects the following field in storage context:
+   * Expects the following field in properties:
    * - dataSourceName: data source name
    *
    * @param logEntry

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintMetadataLogEntryOpenSearchConverter.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintMetadataLogEntryOpenSearchConverter.java
@@ -9,7 +9,10 @@ import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry;
 
 import java.util.Map;
 
-public class FlintOpenSearchMetadataLogEntryStorageUtils {
+/**
+ * Utility class for handling Flint metadata log entries in OpenSearch storage.
+ */
+public class FlintMetadataLogEntryOpenSearchConverter {
 
   public static final String QUERY_EXECUTION_REQUEST_MAPPING = String.join("\n",
       "{",
@@ -105,7 +108,14 @@ public class FlintOpenSearchMetadataLogEntryStorageUtils {
             "  \"lastUpdateTime\": %d,\n" +
             "  \"error\": \"%s\"\n" +
             "}",
-        logEntry.id(), logEntry.state(), applicationId, jobId, logEntry.storageContext().get("dataSourceName").get(), logEntry.createTime(), lastUpdateTime, logEntry.error());
+        logEntry.id(),
+        logEntry.state(),
+        applicationId,
+        jobId,
+        logEntry.storageContext().get("dataSourceName").get(),
+        logEntry.createTime(),
+        lastUpdateTime,
+        logEntry.error());
   }
 
   /**

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -50,7 +50,6 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
    * Reuse query request index as Flint metadata log store
    */
   private final String metadataLogIndexName;
-  private final String flintIndexName;
   private final String dataSourceName;
 
   /**
@@ -61,7 +60,6 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
   public FlintOpenSearchMetadataLog(FlintOptions options, String flintIndexName, String metadataLogIndexName) {
     this.options = options;
     this.metadataLogIndexName = metadataLogIndexName;
-    this.flintIndexName = flintIndexName;
     this.dataSourceName = options.getDataSourceName();
     this.latestId = Base64.getEncoder().encodeToString(flintIndexName.getBytes());
   }
@@ -92,7 +90,6 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
 
       if (response.isExists()) {
         FlintMetadataLogEntry latest = constructLogEntry(
-            flintIndexName,
             response.getId(),
             response.getSeqNo(),
             response.getPrimaryTerm(),
@@ -128,7 +125,6 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
   public FlintMetadataLogEntry emptyLogEntry() {
     return new FlintMetadataLogEntry(
         "",
-        "",
         0L,
         FlintMetadataLogEntry.IndexState$.MODULE$.EMPTY(),
         Map.of("seqNo", UNASSIGNED_SEQ_NO, "primaryTerm", UNASSIGNED_PRIMARY_TERM),
@@ -137,7 +133,6 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
 
   public FlintMetadataLogEntry failLogEntry(String error) {
     return new FlintMetadataLogEntry(
-        "",
         "",
         0L,
         FlintMetadataLogEntry.IndexState$.MODULE$.FAILED(),
@@ -149,9 +144,8 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
     LOG.info("Creating log entry " + logEntry);
     // Assign doc ID here
     FlintMetadataLogEntry logEntryWithId =
-        new FlintMetadataLogEntry(
+        logEntry.copy(
             latestId,
-            flintIndexName,
             logEntry.createTime(),
             logEntry.state(),
             logEntry.entryVersion(),
@@ -189,7 +183,6 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
       // Copy latest seqNo and primaryTerm after write
       logEntry = new FlintMetadataLogEntry(
           logEntry.id(),
-          flintIndexName,
           logEntry.createTime(),
           logEntry.state(),
           Map.of("seqNo", response.getSeqNo(), "primaryTerm", response.getPrimaryTerm()),

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -36,6 +36,12 @@ import org.opensearch.flint.core.IRestHighLevelClient;
 /**
  * Flint metadata log in OpenSearch store. For now use single doc instead of maintaining history
  * of metadata log.
+ * Expects the following fields from maps in FlintMetadataLogEntry:
+ * - entryVersion:
+ *   - seqNo (Long): OpenSearch sequence number
+ *   - primaryTerm (Long): OpenSearch primary term
+ * - storageContext:
+ *   - dataSourceName (String): OpenSearch data source associated
  */
 public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadataLogEntry> {
 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -6,8 +6,8 @@
 package org.opensearch.flint.core.storage;
 
 import static java.util.logging.Level.SEVERE;
-import static org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogEntryStorageUtils.constructLogEntry;
-import static org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogEntryStorageUtils.toJson;
+import static org.opensearch.flint.core.storage.FlintMetadataLogEntryOpenSearchConverter.constructLogEntry;
+import static org.opensearch.flint.core.storage.FlintMetadataLogEntryOpenSearchConverter.toJson;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -138,16 +138,6 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
         Map.of("dataSourceName", dataSourceName));
   }
 
-  public FlintMetadataLogEntry failLogEntry(String error) {
-    return new FlintMetadataLogEntry(
-        "",
-        0L,
-        FlintMetadataLogEntry.IndexState$.MODULE$.FAILED(),
-        Map.of("seqNo", UNASSIGNED_SEQ_NO, "primaryTerm", UNASSIGNED_PRIMARY_TERM),
-        error,
-        Map.of("dataSourceName", dataSourceName));
-  }
-
   private FlintMetadataLogEntry createLogEntry(FlintMetadataLogEntry logEntry) {
     LOG.info("Creating log entry " + logEntry);
     // Assign doc ID here

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -158,7 +158,7 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
             logEntry.state(),
             logEntry.entryVersion(),
             logEntry.error(),
-            logEntry.storageContext());
+            logEntry.properties());
 
     return writeLogEntry(logEntryWithId,
         client -> client.index(
@@ -196,7 +196,7 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
           logEntry.state(),
           Map.of("seqNo", response.getSeqNo(), "primaryTerm", response.getPrimaryTerm()),
           logEntry.error(),
-          logEntry.storageContext());
+          logEntry.properties());
 
       LOG.info("Log entry written as " + logEntry);
       return logEntry;

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogEntryStorageUtils.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogEntryStorageUtils.java
@@ -130,7 +130,7 @@ public class FlintOpenSearchMetadataLogEntryStorageUtils {
     return new FlintMetadataLogEntry(
         id,
         /* sourceMap may use Integer or Long even though it's always long in index mapping */
-        (Long) sourceMap.get("jobStartTime"),
+        ((Number) sourceMap.get("jobStartTime")).longValue(),
         FlintMetadataLogEntry.IndexState$.MODULE$.from((String) sourceMap.get("state")),
         Map.of("seqNo", seqNo, "primaryTerm", primaryTerm),
         (String) sourceMap.get("error"),

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogEntryStorageUtils.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogEntryStorageUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core.storage;
+
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry;
+
+import java.util.Map;
+
+public class FlintOpenSearchMetadataLogEntryStorageUtils {
+
+  public static final String QUERY_EXECUTION_REQUEST_MAPPING = String.join("\n",
+      "{",
+      "  \"dynamic\": false,",
+      "  \"properties\": {",
+      "    \"version\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"type\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"state\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"statementId\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"applicationId\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"sessionId\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"sessionType\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"error\": {",
+      "      \"type\": \"text\"",
+      "    },",
+      "    \"lang\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"query\": {",
+      "      \"type\": \"text\"",
+      "    },",
+      "    \"dataSourceName\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"submitTime\": {",
+      "      \"type\": \"date\",",
+      "      \"format\": \"strict_date_time||epoch_millis\"",
+      "    },",
+      "    \"jobId\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"lastUpdateTime\": {",
+      "      \"type\": \"date\",",
+      "      \"format\": \"strict_date_time||epoch_millis\"",
+      "    },",
+      "    \"queryId\": {",
+      "      \"type\": \"keyword\"",
+      "    },",
+      "    \"excludeJobIds\": {",
+      "      \"type\": \"keyword\"",
+      "    }",
+      "  }",
+      "}");
+
+  public static final String QUERY_EXECUTION_REQUEST_SETTINGS = String.join("\n",
+      "{",
+      "  \"index\": {",
+      "    \"number_of_shards\": \"1\",",
+      "    \"auto_expand_replicas\": \"0-2\",",
+      "    \"number_of_replicas\": \"0\"",
+      "  }",
+      "}");
+
+  // TODO: move dataSourceName to entry
+  public static String toJson(FlintMetadataLogEntry logEntry, String dataSourceName) {
+    String applicationId = System.getenv().getOrDefault("SERVERLESS_EMR_VIRTUAL_CLUSTER_ID", "unknown");
+    String jobId = System.getenv().getOrDefault("SERVERLESS_EMR_JOB_ID", "unknown");
+    long lastUpdateTime = System.currentTimeMillis();
+
+    return String.format(
+        "{\n" +
+            "  \"version\": \"1.0\",\n" +
+            "  \"latestId\": \"%s\",\n" +
+            "  \"type\": \"flintindexstate\",\n" +
+            "  \"state\": \"%s\",\n" +
+            "  \"applicationId\": \"%s\",\n" +
+            "  \"jobId\": \"%s\",\n" +
+            "  \"dataSourceName\": \"%s\",\n" +
+            "  \"jobStartTime\": %d,\n" +
+            "  \"lastUpdateTime\": %d,\n" +
+            "  \"error\": \"%s\"\n" +
+            "}",
+        logEntry.id(), logEntry.state(), applicationId, jobId, dataSourceName, logEntry.createTime(), lastUpdateTime, logEntry.error());
+  }
+
+  // TODO: remove flintIndexName from argument?
+  public static FlintMetadataLogEntry constructLogEntry(
+      String flintIndexName,
+      String id,
+      Long seqNo,
+      Long primaryTerm,
+      Map<String, Object> sourceMap) {
+    return new FlintMetadataLogEntry(
+        id,
+        flintIndexName,
+        /* getSourceAsMap() may use Integer or Long even though it's always long in index mapping */
+        (Long) sourceMap.get("jobStartTime"),
+        FlintMetadataLogEntry.IndexState$.MODULE$.from((String) sourceMap.get("state")),
+        Map.of("seqNo", seqNo, "primaryTerm", primaryTerm),
+        (String) sourceMap.get("error"));
+  }
+}

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogEntryStorageUtils.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogEntryStorageUtils.java
@@ -99,16 +99,13 @@ public class FlintOpenSearchMetadataLogEntryStorageUtils {
         logEntry.id(), logEntry.state(), applicationId, jobId, dataSourceName, logEntry.createTime(), lastUpdateTime, logEntry.error());
   }
 
-  // TODO: remove flintIndexName from argument?
   public static FlintMetadataLogEntry constructLogEntry(
-      String flintIndexName,
       String id,
       Long seqNo,
       Long primaryTerm,
       Map<String, Object> sourceMap) {
     return new FlintMetadataLogEntry(
         id,
-        flintIndexName,
         /* getSourceAsMap() may use Integer or Long even though it's always long in index mapping */
         (Long) sourceMap.get("jobStartTime"),
         FlintMetadataLogEntry.IndexState$.MODULE$.from((String) sourceMap.get("state")),

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
@@ -88,8 +88,8 @@ public class FlintOpenSearchMetadataLogService implements FlintMetadataLogServic
     LOG.info("Initializing metadata log index " + metadataLogIndexName);
     try (IRestHighLevelClient client = createOpenSearchClient()) {
       CreateIndexRequest request = new CreateIndexRequest(metadataLogIndexName);
-      request.mapping(FlintOpenSearchMetadataLogEntryStorageUtils.QUERY_EXECUTION_REQUEST_MAPPING, XContentType.JSON);
-      request.settings(FlintOpenSearchMetadataLogEntryStorageUtils.QUERY_EXECUTION_REQUEST_SETTINGS, XContentType.JSON);
+      request.mapping(FlintMetadataLogEntryOpenSearchConverter.QUERY_EXECUTION_REQUEST_MAPPING, XContentType.JSON);
+      request.settings(FlintMetadataLogEntryOpenSearchConverter.QUERY_EXECUTION_REQUEST_SETTINGS, XContentType.JSON);
       client.createIndex(request, RequestOptions.DEFAULT);
     } catch (Exception e) {
       throw new IllegalStateException("Failed to initialize metadata log index " + metadataLogIndexName, e);

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
@@ -88,8 +88,8 @@ public class FlintOpenSearchMetadataLogService implements FlintMetadataLogServic
     LOG.info("Initializing metadata log index " + metadataLogIndexName);
     try (IRestHighLevelClient client = createOpenSearchClient()) {
       CreateIndexRequest request = new CreateIndexRequest(metadataLogIndexName);
-      request.mapping(FlintMetadataLogEntry.QUERY_EXECUTION_REQUEST_MAPPING(), XContentType.JSON);
-      request.settings(FlintMetadataLogEntry.QUERY_EXECUTION_REQUEST_SETTINGS(), XContentType.JSON);
+      request.mapping(FlintOpenSearchMetadataLogEntryStorageUtils.QUERY_EXECUTION_REQUEST_MAPPING, XContentType.JSON);
+      request.settings(FlintOpenSearchMetadataLogEntryStorageUtils.QUERY_EXECUTION_REQUEST_SETTINGS, XContentType.JSON);
       client.createIndex(request, RequestOptions.DEFAULT);
     } catch (Exception e) {
       throw new IllegalStateException("Failed to initialize metadata log index " + metadataLogIndexName, e);

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
@@ -48,7 +48,7 @@ public class FlintOpenSearchMetadataLogService implements FlintMetadataLogServic
       String errorMsg = "Metadata log index not found " + metadataLogIndexName;
       throw new IllegalStateException(errorMsg);
     }
-    return new DefaultOptimisticTransaction<>(dataSourceName, metadataLog.get());
+    return new DefaultOptimisticTransaction<>(metadataLog.get());
   }
 
   @Override

--- a/flint-core/src/test/scala/org/opensearch/flint/core/storage/FlintMetadataLogEntryOpenSearchConverterSuite.scala
+++ b/flint-core/src/test/scala/org/opensearch/flint/core/storage/FlintMetadataLogEntryOpenSearchConverterSuite.scala
@@ -37,7 +37,7 @@ class FlintMetadataLogEntryOpenSearchConverterTest
     when(mockLogEntry.state).thenReturn(FlintMetadataLogEntry.IndexState.ACTIVE)
     when(mockLogEntry.createTime).thenReturn(1234567890123L)
     when(mockLogEntry.error).thenReturn("")
-    when(mockLogEntry.storageContext).thenReturn(Map("dataSourceName" -> "testDataSource"))
+    when(mockLogEntry.properties).thenReturn(Map("dataSourceName" -> "testDataSource"))
   }
 
   it should "convert to json" in {
@@ -69,7 +69,7 @@ class FlintMetadataLogEntryOpenSearchConverterTest
     logEntry.createTime shouldBe 1234567890123L
     logEntry.state shouldBe FlintMetadataLogEntry.IndexState.ACTIVE
     logEntry.error shouldBe ""
-    logEntry.storageContext.get("dataSourceName").get shouldBe "testDataSource"
+    logEntry.properties.get("dataSourceName").get shouldBe "testDataSource"
   }
 
   it should "construct log entry with integer jobStartTime value" in {
@@ -89,7 +89,7 @@ class FlintMetadataLogEntryOpenSearchConverterTest
     logEntry.createTime shouldBe 1234567890
     logEntry.state shouldBe FlintMetadataLogEntry.IndexState.ACTIVE
     logEntry.error shouldBe ""
-    logEntry.storageContext.get("dataSourceName").get shouldBe "testDataSource"
+    logEntry.properties.get("dataSourceName").get shouldBe "testDataSource"
   }
 
   private def removeJsonField(json: String, field: String): String = {

--- a/flint-core/src/test/scala/org/opensearch/flint/core/storage/FlintMetadataLogEntryOpenSearchConverterSuite.scala
+++ b/flint-core/src/test/scala/org/opensearch/flint/core/storage/FlintMetadataLogEntryOpenSearchConverterSuite.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core.storage
+
+import java.util.{Map => JMap}
+
+import com.stephenn.scalatest.jsonassert.JsonMatchers.matchJson
+import org.mockito.Mockito.when
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.libs.json.{Json, JsValue}
+
+class FlintMetadataLogEntryOpenSearchConverterTest
+    extends AnyFlatSpec
+    with BeforeAndAfter
+    with Matchers {
+  val mockLogEntry: FlintMetadataLogEntry = mock[FlintMetadataLogEntry]
+
+  val sourceMap = JMap.of(
+    "jobStartTime",
+    1234567890123L.asInstanceOf[Object],
+    "state",
+    "active".asInstanceOf[Object],
+    "dataSourceName",
+    "testDataSource".asInstanceOf[Object],
+    "error",
+    "".asInstanceOf[Object])
+
+  before {
+    when(mockLogEntry.id).thenReturn("id")
+    when(mockLogEntry.state).thenReturn(FlintMetadataLogEntry.IndexState.ACTIVE)
+    when(mockLogEntry.createTime).thenReturn(1234567890123L)
+    when(mockLogEntry.error).thenReturn("")
+    when(mockLogEntry.storageContext).thenReturn(Map("dataSourceName" -> "testDataSource"))
+  }
+
+  it should "convert to json" in {
+    // Removing lastUpdateTime since System.currentTimeMillis() cannot be mocked
+    val expectedJsonWithoutLastUpdateTime =
+      s"""
+         |{
+         |  "version": "1.0",
+         |  "latestId": "id",
+         |  "type": "flintindexstate",
+         |  "state": "active",
+         |  "applicationId": "unknown",
+         |  "jobId": "unknown",
+         |  "dataSourceName": "testDataSource",
+         |  "jobStartTime": 1234567890123,
+         |  "error": ""
+         |}
+         |""".stripMargin
+    val actualJson = FlintMetadataLogEntryOpenSearchConverter.toJson(mockLogEntry)
+    removeJsonField(actualJson, "lastUpdateTime") should matchJson(
+      expectedJsonWithoutLastUpdateTime)
+  }
+
+  it should "construct log entry" in {
+    val logEntry =
+      FlintMetadataLogEntryOpenSearchConverter.constructLogEntry("id", 1L, 1L, sourceMap)
+    logEntry shouldBe a[FlintMetadataLogEntry]
+    logEntry.id shouldBe "id"
+    logEntry.createTime shouldBe 1234567890123L
+    logEntry.state shouldBe FlintMetadataLogEntry.IndexState.ACTIVE
+    logEntry.error shouldBe ""
+    logEntry.storageContext.get("dataSourceName").get shouldBe "testDataSource"
+  }
+
+  it should "construct log entry with integer jobStartTime value" in {
+    val testSourceMap = JMap.of(
+      "jobStartTime",
+      1234567890.asInstanceOf[Object], // Integer instead of Long
+      "state",
+      "active".asInstanceOf[Object],
+      "dataSourceName",
+      "testDataSource".asInstanceOf[Object],
+      "error",
+      "".asInstanceOf[Object])
+    val logEntry =
+      FlintMetadataLogEntryOpenSearchConverter.constructLogEntry("id", 1L, 1L, testSourceMap)
+    logEntry shouldBe a[FlintMetadataLogEntry]
+    logEntry.id shouldBe "id"
+    logEntry.createTime shouldBe 1234567890
+    logEntry.state shouldBe FlintMetadataLogEntry.IndexState.ACTIVE
+    logEntry.error shouldBe ""
+    logEntry.storageContext.get("dataSourceName").get shouldBe "testDataSource"
+  }
+
+  private def removeJsonField(json: String, field: String): String = {
+    Json.stringify(Json.toJson(Json.parse(json).as[Map[String, JsValue]] - field))
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -424,7 +424,7 @@ class FlintSpark(val spark: SparkSession) extends FlintSparkTransactionSupport w
     val indexLogEntry = index.latestLogEntry.get
     tx
       .initialLog(latest =>
-        latest.state == REFRESHING && latest.seqNo == indexLogEntry.seqNo && latest.primaryTerm == indexLogEntry.primaryTerm)
+        latest.state == REFRESHING && latest.entryVersion == indexLogEntry.entryVersion)
       .transientLog(latest => latest.copy(state = UPDATING))
       .finalLog(latest => latest.copy(state = ACTIVE))
       .commit(_ => {
@@ -444,7 +444,7 @@ class FlintSpark(val spark: SparkSession) extends FlintSparkTransactionSupport w
     val indexRefresh = FlintSparkIndexRefresh.create(indexName, index)
     tx
       .initialLog(latest =>
-        latest.state == ACTIVE && latest.seqNo == indexLogEntry.seqNo && latest.primaryTerm == indexLogEntry.primaryTerm)
+        latest.state == ACTIVE && latest.entryVersion == indexLogEntry.entryVersion)
       .transientLog(latest =>
         latest.copy(state = UPDATING, createTime = System.currentTimeMillis()))
       .finalLog(latest => {

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -174,7 +174,13 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
     def withIndex(index: FlintSparkCoveringIndex, state: IndexState = ACTIVE): AssertionHelper = {
       this.indexes = indexes :+
         index.copy(latestLogEntry = Some(
-          new FlintMetadataLogEntry("id", 0, state, Map("seqNo" -> 0, "primaryTerm" -> 0), "")))
+          new FlintMetadataLogEntry(
+            "id",
+            0,
+            state,
+            Map("seqNo" -> 0, "primaryTerm" -> 0),
+            "",
+            Map("dataSourceName" -> "dataSource"))))
       this
     }
 

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -173,8 +173,14 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
 
     def withIndex(index: FlintSparkCoveringIndex, state: IndexState = ACTIVE): AssertionHelper = {
       this.indexes = indexes :+
-        index.copy(latestLogEntry =
-          Some(new FlintMetadataLogEntry("id", 0, 0, 0, state, "spark_catalog", "")))
+        index.copy(latestLogEntry = Some(
+          new FlintMetadataLogEntry(
+            "id",
+            index.name(),
+            0,
+            state,
+            Map("seqNo" -> 0, "primaryTerm" -> 0),
+            "")))
       this
     }
 

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -174,13 +174,7 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
     def withIndex(index: FlintSparkCoveringIndex, state: IndexState = ACTIVE): AssertionHelper = {
       this.indexes = indexes :+
         index.copy(latestLogEntry = Some(
-          new FlintMetadataLogEntry(
-            "id",
-            index.name(),
-            0,
-            state,
-            Map("seqNo" -> 0, "primaryTerm" -> 0),
-            "")))
+          new FlintMetadataLogEntry("id", 0, state, Map("seqNo" -> 0, "primaryTerm" -> 0), "")))
       this
     }
 

--- a/integ-test/src/test/scala/org/opensearch/flint/OpenSearchTransactionSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/OpenSearchTransactionSuite.scala
@@ -17,8 +17,9 @@ import org.opensearch.client.RequestOptions
 import org.opensearch.client.indices.{CreateIndexRequest, GetIndexRequest}
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
-import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.{QUERY_EXECUTION_REQUEST_MAPPING, QUERY_EXECUTION_REQUEST_SETTINGS}
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.IndexState
+import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogEntryStorageUtils.{QUERY_EXECUTION_REQUEST_MAPPING, QUERY_EXECUTION_REQUEST_SETTINGS}
+import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogEntryStorageUtils.toJson
 import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService.METADATA_LOG_INDEX_NAME_PREFIX
 import org.opensearch.flint.spark.FlintSparkSuite
 
@@ -66,14 +67,14 @@ trait OpenSearchTransactionSuite extends FlintSparkSuite {
       new IndexRequest()
         .index(testMetaLogIndex)
         .id(latest.id)
-        .source(latest.toJson, XContentType.JSON),
+        .source(toJson(latest, testDataSourceName), XContentType.JSON),
       RequestOptions.DEFAULT)
   }
 
   def updateLatestLogEntry(latest: FlintMetadataLogEntry, newState: IndexState): Unit = {
     openSearchClient.update(
       new UpdateRequest(testMetaLogIndex, latest.id)
-        .doc(latest.copy(state = newState).toJson, XContentType.JSON),
+        .doc(toJson(latest.copy(state = newState), testDataSourceName), XContentType.JSON),
       RequestOptions.DEFAULT)
   }
 

--- a/integ-test/src/test/scala/org/opensearch/flint/OpenSearchTransactionSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/OpenSearchTransactionSuite.scala
@@ -18,8 +18,7 @@ import org.opensearch.client.indices.{CreateIndexRequest, GetIndexRequest}
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.IndexState
-import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogEntryStorageUtils.{QUERY_EXECUTION_REQUEST_MAPPING, QUERY_EXECUTION_REQUEST_SETTINGS}
-import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogEntryStorageUtils.toJson
+import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogEntryStorageUtils.{toJson, QUERY_EXECUTION_REQUEST_MAPPING, QUERY_EXECUTION_REQUEST_SETTINGS}
 import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService.METADATA_LOG_INDEX_NAME_PREFIX
 import org.opensearch.flint.spark.FlintSparkSuite
 

--- a/integ-test/src/test/scala/org/opensearch/flint/OpenSearchTransactionSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/OpenSearchTransactionSuite.scala
@@ -18,7 +18,7 @@ import org.opensearch.client.indices.{CreateIndexRequest, GetIndexRequest}
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.IndexState
-import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogEntryStorageUtils.{toJson, QUERY_EXECUTION_REQUEST_MAPPING, QUERY_EXECUTION_REQUEST_SETTINGS}
+import org.opensearch.flint.core.storage.FlintMetadataLogEntryOpenSearchConverter.{toJson, QUERY_EXECUTION_REQUEST_MAPPING, QUERY_EXECUTION_REQUEST_SETTINGS}
 import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogService.METADATA_LOG_INDEX_NAME_PREFIX
 import org.opensearch.flint.spark.FlintSparkSuite
 

--- a/integ-test/src/test/scala/org/opensearch/flint/OpenSearchTransactionSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/OpenSearchTransactionSuite.scala
@@ -66,14 +66,14 @@ trait OpenSearchTransactionSuite extends FlintSparkSuite {
       new IndexRequest()
         .index(testMetaLogIndex)
         .id(latest.id)
-        .source(toJson(latest, testDataSourceName), XContentType.JSON),
+        .source(toJson(latest), XContentType.JSON),
       RequestOptions.DEFAULT)
   }
 
   def updateLatestLogEntry(latest: FlintMetadataLogEntry, newState: IndexState): Unit = {
     openSearchClient.update(
       new UpdateRequest(testMetaLogIndex, latest.id)
-        .doc(toJson(latest.copy(state = newState), testDataSourceName), XContentType.JSON),
+        .doc(toJson(latest.copy(state = newState)), XContentType.JSON),
       RequestOptions.DEFAULT)
   }
 

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -124,7 +124,7 @@ case class TestMetadataLogService(sparkConf: SparkConf) extends FlintMetadataLog
       forceInit: Boolean): OptimisticTransaction[T] = {
     val flintOptions = new FlintOptions(Map[String, String]().asJava)
     val metadataLog = new FlintOpenSearchMetadataLog(flintOptions, "", "")
-    new DefaultOptimisticTransaction("", metadataLog)
+    new DefaultOptimisticTransaction(metadataLog)
   }
 
   override def startTransaction[T](indexName: String): OptimisticTransaction[T] = {

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -29,7 +29,6 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
   val testCreateTime = 1234567890123L
   val flintMetadataLogEntry = FlintMetadataLogEntry(
     testLatestId,
-    testFlintIndex,
     testCreateTime,
     ACTIVE,
     Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -87,7 +87,7 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
     latest.get.id shouldBe testLatestId
     latest.get.createTime shouldBe testCreateTime
     latest.get.error shouldBe ""
-    latest.get.storageContext.get("dataSourceName").get shouldBe testDataSourceName
+    latest.get.properties.get("dataSourceName").get shouldBe testDataSourceName
   }
 
   test("should not get index metadata log if not exist") {

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -32,7 +32,8 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
     testCreateTime,
     ACTIVE,
     Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
-    "")
+    "",
+    Map("dataSourceName" -> testDataSourceName))
 
   var flintMetadataLogService: FlintMetadataLogService = _
 
@@ -86,6 +87,7 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
     latest.get.id shouldBe testLatestId
     latest.get.createTime shouldBe testCreateTime
     latest.get.error shouldBe ""
+    latest.get.storageContext.get("dataSourceName").get shouldBe testDataSourceName
   }
 
   test("should not get index metadata log if not exist") {

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -28,13 +28,12 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
   val testLatestId: String = Base64.getEncoder.encodeToString(testFlintIndex.getBytes)
   val testCreateTime = 1234567890123L
   val flintMetadataLogEntry = FlintMetadataLogEntry(
-    id = testLatestId,
-    seqNo = UNASSIGNED_SEQ_NO,
-    primaryTerm = UNASSIGNED_PRIMARY_TERM,
-    createTime = testCreateTime,
-    state = ACTIVE,
-    dataSource = testDataSourceName,
-    error = "")
+    testLatestId,
+    testFlintIndex,
+    testCreateTime,
+    ACTIVE,
+    Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
+    "")
 
   var flintMetadataLogService: FlintMetadataLogService = _
 
@@ -87,7 +86,6 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
     latest.isPresent shouldBe true
     latest.get.id shouldBe testLatestId
     latest.get.createTime shouldBe testCreateTime
-    latest.get.dataSource shouldBe testDataSourceName
     latest.get.error shouldBe ""
   }
 

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
@@ -53,11 +53,11 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
     createLatestLogEntry(
       FlintMetadataLogEntry(
         id = testLatestId,
-        seqNo = UNASSIGNED_SEQ_NO,
-        primaryTerm = UNASSIGNED_PRIMARY_TERM,
+        indexName = testFlintIndex,
+        dataSource = testDataSourceName,
         createTime = testCreateTime,
         state = ACTIVE,
-        dataSource = testDataSourceName,
+        Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
         error = ""))
 
     flintMetadataLogService
@@ -113,11 +113,11 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
     createLatestLogEntry(
       FlintMetadataLogEntry(
         id = testLatestId,
-        seqNo = UNASSIGNED_SEQ_NO,
-        primaryTerm = UNASSIGNED_PRIMARY_TERM,
+        indexName = testFlintIndex,
+        dataSource = testDataSourceName,
         createTime = 1234567890123L,
         state = ACTIVE,
-        dataSource = testDataSourceName,
+        Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
         error = ""))
 
     flintMetadataLogService
@@ -200,11 +200,11 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
     createLatestLogEntry(
       FlintMetadataLogEntry(
         id = testLatestId,
-        seqNo = UNASSIGNED_SEQ_NO,
-        primaryTerm = UNASSIGNED_PRIMARY_TERM,
+        indexName = testFlintIndex,
+        dataSource = testDataSourceName,
         createTime = 1234567890123L,
         state = ACTIVE,
-        dataSource = testDataSourceName,
+        Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
         error = ""))
 
     the[IllegalStateException] thrownBy {

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
@@ -41,7 +41,7 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         latest.state shouldBe EMPTY
         latest.createTime shouldBe 0L
         latest.error shouldBe ""
-        latest.storageContext.get("dataSourceName").get shouldBe testDataSourceName
+        latest.properties.get("dataSourceName").get shouldBe testDataSourceName
         true
       })
       .finalLog(latest => latest)
@@ -65,7 +65,7 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         latest.id shouldBe testLatestId
         latest.createTime shouldBe testCreateTime
         latest.error shouldBe ""
-        latest.storageContext.get("dataSourceName").get shouldBe testDataSourceName
+        latest.properties.get("dataSourceName").get shouldBe testDataSourceName
         true
       })
       .transientLog(latest => latest.copy(state = DELETING))
@@ -74,7 +74,7 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         latest.id shouldBe testLatestId
         latest.createTime shouldBe testCreateTime
         latest.error shouldBe ""
-        latest.storageContext.get("dataSourceName").get shouldBe testDataSourceName
+        latest.properties.get("dataSourceName").get shouldBe testDataSourceName
       })
 
     latestLogEntry(testLatestId) should (contain("latestId" -> testLatestId) and
@@ -241,7 +241,7 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         latest.state shouldBe EMPTY
         latest.createTime shouldBe 0L
         latest.error shouldBe ""
-        latest.storageContext.get("dataSourceName").get shouldBe testDataSourceName
+        latest.properties.get("dataSourceName").get shouldBe testDataSourceName
         true
       })
       .finalLog(latest => latest)

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
@@ -40,7 +40,6 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         latest.id shouldBe testLatestId
         latest.state shouldBe EMPTY
         latest.createTime shouldBe 0L
-        latest.dataSource shouldBe testDataSourceName
         latest.error shouldBe ""
         true
       })
@@ -54,7 +53,6 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
       FlintMetadataLogEntry(
         id = testLatestId,
         indexName = testFlintIndex,
-        dataSource = testDataSourceName,
         createTime = testCreateTime,
         state = ACTIVE,
         Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
@@ -65,7 +63,6 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
       .initialLog(latest => {
         latest.id shouldBe testLatestId
         latest.createTime shouldBe testCreateTime
-        latest.dataSource shouldBe testDataSourceName
         latest.error shouldBe ""
         true
       })
@@ -74,7 +71,6 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
       .commit(latest => {
         latest.id shouldBe testLatestId
         latest.createTime shouldBe testCreateTime
-        latest.dataSource shouldBe testDataSourceName
         latest.error shouldBe ""
       })
 
@@ -114,7 +110,6 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
       FlintMetadataLogEntry(
         id = testLatestId,
         indexName = testFlintIndex,
-        dataSource = testDataSourceName,
         createTime = 1234567890123L,
         state = ACTIVE,
         Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
@@ -201,7 +196,6 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
       FlintMetadataLogEntry(
         id = testLatestId,
         indexName = testFlintIndex,
-        dataSource = testDataSourceName,
         createTime = 1234567890123L,
         state = ACTIVE,
         Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
@@ -243,7 +237,6 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         latest.id shouldBe testLatestId
         latest.state shouldBe EMPTY
         latest.createTime shouldBe 0L
-        latest.dataSource shouldBe testDataSourceName
         latest.error shouldBe ""
         true
       })

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
@@ -52,7 +52,6 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
     createLatestLogEntry(
       FlintMetadataLogEntry(
         id = testLatestId,
-        indexName = testFlintIndex,
         createTime = testCreateTime,
         state = ACTIVE,
         Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
@@ -109,7 +108,6 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
     createLatestLogEntry(
       FlintMetadataLogEntry(
         id = testLatestId,
-        indexName = testFlintIndex,
         createTime = 1234567890123L,
         state = ACTIVE,
         Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
@@ -195,7 +193,6 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
     createLatestLogEntry(
       FlintMetadataLogEntry(
         id = testLatestId,
-        indexName = testFlintIndex,
         createTime = 1234567890123L,
         state = ACTIVE,
         Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),

--- a/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/core/FlintTransactionITSuite.scala
@@ -41,6 +41,7 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         latest.state shouldBe EMPTY
         latest.createTime shouldBe 0L
         latest.error shouldBe ""
+        latest.storageContext.get("dataSourceName").get shouldBe testDataSourceName
         true
       })
       .finalLog(latest => latest)
@@ -55,7 +56,8 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         createTime = testCreateTime,
         state = ACTIVE,
         Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
-        error = ""))
+        error = "",
+        Map("dataSourceName" -> testDataSourceName)))
 
     flintMetadataLogService
       .startTransaction(testFlintIndex)
@@ -63,6 +65,7 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         latest.id shouldBe testLatestId
         latest.createTime shouldBe testCreateTime
         latest.error shouldBe ""
+        latest.storageContext.get("dataSourceName").get shouldBe testDataSourceName
         true
       })
       .transientLog(latest => latest.copy(state = DELETING))
@@ -71,6 +74,7 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         latest.id shouldBe testLatestId
         latest.createTime shouldBe testCreateTime
         latest.error shouldBe ""
+        latest.storageContext.get("dataSourceName").get shouldBe testDataSourceName
       })
 
     latestLogEntry(testLatestId) should (contain("latestId" -> testLatestId) and
@@ -111,7 +115,8 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         createTime = 1234567890123L,
         state = ACTIVE,
         Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
-        error = ""))
+        error = "",
+        Map("dataSourceName" -> testDataSourceName)))
 
     flintMetadataLogService
       .startTransaction(testFlintIndex)
@@ -196,7 +201,8 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         createTime = 1234567890123L,
         state = ACTIVE,
         Map("seqNo" -> UNASSIGNED_SEQ_NO, "primaryTerm" -> UNASSIGNED_PRIMARY_TERM),
-        error = ""))
+        error = "",
+        Map("dataSourceName" -> testDataSourceName)))
 
     the[IllegalStateException] thrownBy {
       flintMetadataLogService
@@ -235,6 +241,7 @@ class FlintTransactionITSuite extends OpenSearchTransactionSuite with Matchers {
         latest.state shouldBe EMPTY
         latest.createTime shouldBe 0L
         latest.error shouldBe ""
+        latest.storageContext.get("dataSourceName").get shouldBe testDataSourceName
         true
       })
       .finalLog(latest => latest)

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
@@ -11,7 +11,7 @@ import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 import org.opensearch.flint.OpenSearchTransactionSuite
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState._
-import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogEntryStorageUtils.constructLogEntry
+import org.opensearch.flint.core.storage.FlintMetadataLogEntryOpenSearchConverter.constructLogEntry
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
 import org.opensearch.index.seqno.SequenceNumbers.{UNASSIGNED_PRIMARY_TERM, UNASSIGNED_SEQ_NO}
 import org.scalatest.matchers.should.Matchers

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
@@ -70,7 +70,6 @@ class FlintSparkIndexJobITSuite extends OpenSearchTransactionSuite with Matchers
 
       updateLatestLogEntry(
         constructLogEntry(
-          testIndex,
           latestId,
           UNASSIGNED_SEQ_NO,
           UNASSIGNED_PRIMARY_TERM,
@@ -94,7 +93,6 @@ class FlintSparkIndexJobITSuite extends OpenSearchTransactionSuite with Matchers
 
       updateLatestLogEntry(
         constructLogEntry(
-          testIndex,
           latestId,
           UNASSIGNED_SEQ_NO,
           UNASSIGNED_PRIMARY_TERM,

--- a/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
+++ b/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
@@ -10,8 +10,8 @@ import java.util.Base64
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 import org.opensearch.flint.OpenSearchTransactionSuite
-import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState._
+import org.opensearch.flint.core.storage.FlintOpenSearchMetadataLogEntryStorageUtils.constructLogEntry
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
 import org.opensearch.index.seqno.SequenceNumbers.{UNASSIGNED_PRIMARY_TERM, UNASSIGNED_SEQ_NO}
 import org.scalatest.matchers.should.Matchers
@@ -69,7 +69,8 @@ class FlintSparkIndexJobITSuite extends OpenSearchTransactionSuite with Matchers
         .create()
 
       updateLatestLogEntry(
-        new FlintMetadataLogEntry(
+        constructLogEntry(
+          testIndex,
           latestId,
           UNASSIGNED_SEQ_NO,
           UNASSIGNED_PRIMARY_TERM,
@@ -92,7 +93,8 @@ class FlintSparkIndexJobITSuite extends OpenSearchTransactionSuite with Matchers
         .create()
 
       updateLatestLogEntry(
-        new FlintMetadataLogEntry(
+        constructLogEntry(
+          testIndex,
           latestId,
           UNASSIGNED_SEQ_NO,
           UNASSIGNED_PRIMARY_TERM,


### PR DESCRIPTION
### Description
* Refactor `FlintMetadataLogEntry` to be generic to data storage
* Remove `dataSourceName` from `DefaultOptimisticTransaction`
* Move persistence logic for OpenSearch away from `FlintMetadataLogEntry` and `DefaultOptimisticTransaction` into `FlintMetadataLogEntryOpenSearchConverter`

#### Before
```
FlintMetadataLogEntry(
    id: String,
    seqNo: Long,
    primaryTerm: Long,
    createTime: Long,
    state: IndexState,
    dataSource: String,
    error: String)
```

#### After
```
FlintMetadataLogEntry(
    id: String,
    createTime: Long,
    state: IndexState,
    entryVersion: Map[String, Any],
    error: String,
    storageContext: Map[String, Any])
```
* `entryVersion` is used for `FlintSpark` `updateIndex`. For OpenSearch, it should specify `seqNo` and `primaryTerm`
* `storageContext` can be used to store additional context required for persistence. For example, `dataSourceName` for OpenSearch

### Issues Resolved
* #371 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
