### PR TITLE
Enhance query rewriter rule to support partial covering index

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkQueryRewriteHelper.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkQueryRewriteHelper.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, BinaryComparison, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, Literal}
+
+/**
+ * Query rewrite helper that provides common utilities for query rewrite rule of various Flint
+ * indexes.
+ */
+trait FlintSparkQueryRewriteHelper {
+
+  /**
+   * Determines if the conditions in an index filter can subsume those in a query filter. This is
+   * essential to verify if all outputs that satisfy the index filter also satisfy the query
+   * filter, indicating that the index can potentially optimize the query.
+   *
+   * @param indexFilter
+   *   The filter expression defined from the index
+   * @param queryFilter
+   *   The filter expression present in the user query
+   * @return
+   *   True if the index filter can subsume the query filter, otherwise False
+   */
+  def subsume(indexFilter: Expression, queryFilter: Expression): Boolean = {
+    def flattenConditions(filter: Expression): Seq[Expression] = filter match {
+      case And(left, right) => flattenConditions(left) ++ flattenConditions(right)
+      case other => Seq(other)
+    }
+
+    val indexConditions = flattenConditions(indexFilter)
+    val queryConditions = flattenConditions(queryFilter)
+
+    // Each index condition must subsume in a query condition
+    // otherwise it means index data cannot "cover" query condition
+    indexConditions.forall { indexCondition =>
+      queryConditions.exists { queryCondition =>
+        (indexCondition, queryCondition) match {
+          case (
+                i @ BinaryComparison(indexCol: Attribute, _),
+                q @ BinaryComparison(queryCol: Attribute, _)) if indexCol.name == queryCol.name =>
+            Range(i).subsume(Range(q))
+          case _ => false
+        }
+      }
+    }
+  }
+
+  case class Bound(value: Literal, inclusive: Boolean) {
+
+    def lessThanOrEqualTo(other: Bound): Boolean = {
+      val cmp = value.value.asInstanceOf[Comparable[Any]].compareTo(other.value.value)
+      cmp < 0 || (cmp == 0 && inclusive && other.inclusive)
+    }
+  }
+
+  case class Range(lower: Option[Bound], upper: Option[Bound]) {
+
+    def subsume(other: Range): Boolean = {
+      val isLowerSubsumed = (lower, other.lower) match {
+        case (Some(a), Some(b)) => a.lessThanOrEqualTo(b)
+        case (None, _) => true // `bound1` is unbounded and thus can subsume anything
+        case (_, None) => false // `bound2` is unbounded and thus cannot be subsumed
+        case (None, None) => true
+      }
+      val isUpperSubsumed = (upper, other.upper) match {
+        case (Some(a), Some(b)) => b.lessThanOrEqualTo(a)
+        case (None, _) => true // `bound1` is unbounded and thus can subsume anything
+        case (_, None) => false // `bound2` is unbounded and thus cannot be subsumed
+        case (None, None) => true
+      }
+      isLowerSubsumed && isUpperSubsumed
+    }
+  }
+
+  object Range {
+    def apply(condition: BinaryComparison): Range = condition match {
+      case GreaterThan(_, value: Literal) => Range(Some(Bound(value, inclusive = false)), None)
+      case GreaterThanOrEqual(_, value: Literal) =>
+        Range(Some(Bound(value, inclusive = true)), None)
+      case LessThan(_, value: Literal) => Range(None, Some(Bound(value, inclusive = false)))
+      case LessThanOrEqual(_, value: Literal) => Range(None, Some(Bound(value, inclusive = true)))
+      case EqualTo(_, value: Literal) =>
+        Range(Some(Bound(value, inclusive = true)), Some(Bound(value, inclusive = true)))
+      case _ => Range(None, None) // For unsupported or complex conditions
+    }
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkQueryRewriteHelper.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkQueryRewriteHelper.scala
@@ -53,7 +53,7 @@ trait FlintSparkQueryRewriteHelper {
     val queryConditions = flattenConditions(queryFilter)
 
     // Ensures that every condition in the index filter is subsumed by at least one condition
-    // in the query filter
+    // on the same column in the query filter
     indexConditions.forall { indexCondition =>
       queryConditions.exists { queryCondition =>
         (indexCondition, queryCondition) match {
@@ -79,9 +79,7 @@ trait FlintSparkQueryRewriteHelper {
   case class Range(lower: Option[Bound], upper: Option[Bound]) {
 
     /**
-     * Determines if this range subsumes (completely covers) another range. A range is considered
-     * to subsume another if its lower bound is less restrictive and its upper bound is more
-     * restrictive than those of the other range.
+     * Determines if this range subsumes (completely covers) another range.
      *
      * @param other
      *   The other range to compare against.
@@ -108,7 +106,7 @@ trait FlintSparkQueryRewriteHelper {
 
     /**
      * Constructs a Range object from a binary comparison expression, translating comparison
-     * operators into bounds with appropriate inclusivity.
+     * operators into bounds with appropriate inclusiveness.
      *
      * @param condition
      *   The binary comparison
@@ -124,7 +122,7 @@ trait FlintSparkQueryRewriteHelper {
         Range(None, Some(Bound(value, inclusive = true)))
       case EqualTo(_, value: Literal) =>
         Range(Some(Bound(value, inclusive = true)), Some(Bound(value, inclusive = true)))
-      case _ => Range(None, None) // For unsupported or complex conditions
+      case _ => Range(None, None) // Infinity for unsupported or complex conditions
     }
   }
 
@@ -145,7 +143,8 @@ trait FlintSparkQueryRewriteHelper {
      * @param other
      *   The bound to compare against.
      * @return
-     *   True if this bound is less than or equal to the other bound.
+     *   True if this bound is less than or equal to the other bound, either because value is
+     *   smaller, this bound is inclusive, or both bound are exclusive.
      */
     def lessThanOrEqualTo(other: Bound): Boolean = {
       val cmp = value.value.asInstanceOf[Comparable[Any]].compareTo(other.value.value)
@@ -158,7 +157,8 @@ trait FlintSparkQueryRewriteHelper {
      * @param other
      *   The bound to compare against.
      * @return
-     *   True if this bound is greater than or equal to the other bound.
+     *   True if this bound is greater than or equal to the other bound, either because value is
+     *   greater, this bound is inclusive, or both bound are exclusive.
      */
     def greaterThanOrEqualTo(other: Bound): Boolean = {
       val cmp = value.value.asInstanceOf[Comparable[Any]].compareTo(other.value.value)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkQueryRewriteHelper.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkQueryRewriteHelper.scala
@@ -5,7 +5,7 @@
 
 package org.opensearch.flint.spark
 
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, BinaryComparison, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, Literal}
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, BinaryComparison, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, Literal, Or}
 
 /**
  * Query rewrite helper that provides common utilities for query rewrite rule of various Flint
@@ -14,78 +14,155 @@ import org.apache.spark.sql.catalyst.expressions.{And, Attribute, BinaryComparis
 trait FlintSparkQueryRewriteHelper {
 
   /**
+   * Determines if the given filter expression consists solely of AND operations and no OR
+   * operations, implying that it's a conjunction of conditions.
+   *
+   * @param filter
+   *   The filter expression to check.
+   * @return
+   *   True if the filter contains only AND operations, False if any OR operations are found.
+   */
+  def isConjunction(filter: Expression): Boolean = {
+    filter.collectFirst { case Or(_, _) =>
+      true
+    }.isEmpty
+  }
+
+  /**
    * Determines if the conditions in an index filter can subsume those in a query filter. This is
    * essential to verify if all outputs that satisfy the index filter also satisfy the query
    * filter, indicating that the index can potentially optimize the query.
    *
    * @param indexFilter
-   *   The filter expression defined from the index
+   *   The filter expression defined from the index, required to be a conjunction.
    * @param queryFilter
-   *   The filter expression present in the user query
+   *   The filter expression present in the user query, required to be a conjunction.
    * @return
-   *   True if the index filter can subsume the query filter, otherwise False
+   *   True if the index filter can subsume the query filter, otherwise False.
    */
   def subsume(indexFilter: Expression, queryFilter: Expression): Boolean = {
+    require(isConjunction(indexFilter), "Index filter is not a conjunction")
+    require(isConjunction(queryFilter), "Query filter is not a conjunction")
+
+    // Flatten a potentially nested conjunction into a sequence of individual conditions
     def flattenConditions(filter: Expression): Seq[Expression] = filter match {
       case And(left, right) => flattenConditions(left) ++ flattenConditions(right)
       case other => Seq(other)
     }
-
     val indexConditions = flattenConditions(indexFilter)
     val queryConditions = flattenConditions(queryFilter)
 
-    // Each index condition must subsume in a query condition
-    // otherwise it means index data cannot "cover" query condition
+    // Ensures that every condition in the index filter is subsumed by at least one condition
+    // in the query filter
     indexConditions.forall { indexCondition =>
       queryConditions.exists { queryCondition =>
         (indexCondition, queryCondition) match {
           case (
-                i @ BinaryComparison(indexCol: Attribute, _),
-                q @ BinaryComparison(queryCol: Attribute, _)) if indexCol.name == queryCol.name =>
-            Range(i).subsume(Range(q))
+                indexComparison @ BinaryComparison(indexCol: Attribute, _),
+                queryComparison @ BinaryComparison(queryCol: Attribute, _))
+              if indexCol.name == queryCol.name =>
+            Range(indexComparison).subsume(Range(queryComparison))
           case _ => false
         }
       }
     }
   }
 
-  case class Bound(value: Literal, inclusive: Boolean) {
-
-    def lessThanOrEqualTo(other: Bound): Boolean = {
-      val cmp = value.value.asInstanceOf[Comparable[Any]].compareTo(other.value.value)
-      cmp < 0 || (cmp == 0 && inclusive && other.inclusive)
-    }
-  }
-
+  /**
+   * Represents a range with optional lower and upper bounds.
+   *
+   * @param lower
+   *   The optional lower bound
+   * @param upper
+   *   The optional upper bound
+   */
   case class Range(lower: Option[Bound], upper: Option[Bound]) {
 
+    /**
+     * Determines if this range subsumes (completely covers) another range. A range is considered
+     * to subsume another if its lower bound is less restrictive and its upper bound is more
+     * restrictive than those of the other range.
+     *
+     * @param other
+     *   The other range to compare against.
+     * @return
+     *   True if this range subsumes the other, otherwise false.
+     */
     def subsume(other: Range): Boolean = {
-      val isLowerSubsumed = (lower, other.lower) match {
-        case (Some(a), Some(b)) => a.lessThanOrEqualTo(b)
-        case (None, _) => true // `bound1` is unbounded and thus can subsume anything
-        case (_, None) => false // `bound2` is unbounded and thus cannot be subsumed
-        case (None, None) => true
-      }
-      val isUpperSubsumed = (upper, other.upper) match {
-        case (Some(a), Some(b)) => b.lessThanOrEqualTo(a)
-        case (None, _) => true // `bound1` is unbounded and thus can subsume anything
-        case (_, None) => false // `bound2` is unbounded and thus cannot be subsumed
-        case (None, None) => true
-      }
-      isLowerSubsumed && isUpperSubsumed
+      // Subsumption check helper for lower and upper bound
+      def subsume(
+          thisBound: Option[Bound],
+          otherBound: Option[Bound],
+          comp: (Bound, Bound) => Boolean): Boolean =
+        (thisBound, otherBound) match {
+          case (Some(a), Some(b)) => comp(a, b)
+          case (None, _) => true // this is unbounded and thus can subsume any other bound
+          case (_, None) => false // other is unbounded and thus cannot be subsumed by any
+        }
+      subsume(lower, other.lower, _.lessThanOrEqualTo(_)) &&
+      subsume(upper, other.upper, _.greaterThanOrEqualTo(_))
     }
   }
 
   object Range {
+
+    /**
+     * Constructs a Range object from a binary comparison expression, translating comparison
+     * operators into bounds with appropriate inclusivity.
+     *
+     * @param condition
+     *   The binary comparison
+     */
     def apply(condition: BinaryComparison): Range = condition match {
-      case GreaterThan(_, value: Literal) => Range(Some(Bound(value, inclusive = false)), None)
+      case GreaterThan(_, value: Literal) =>
+        Range(Some(Bound(value, inclusive = false)), None)
       case GreaterThanOrEqual(_, value: Literal) =>
         Range(Some(Bound(value, inclusive = true)), None)
-      case LessThan(_, value: Literal) => Range(None, Some(Bound(value, inclusive = false)))
-      case LessThanOrEqual(_, value: Literal) => Range(None, Some(Bound(value, inclusive = true)))
+      case LessThan(_, value: Literal) =>
+        Range(None, Some(Bound(value, inclusive = false)))
+      case LessThanOrEqual(_, value: Literal) =>
+        Range(None, Some(Bound(value, inclusive = true)))
       case EqualTo(_, value: Literal) =>
         Range(Some(Bound(value, inclusive = true)), Some(Bound(value, inclusive = true)))
       case _ => Range(None, None) // For unsupported or complex conditions
+    }
+  }
+
+  /**
+   * Represents a bound (lower or upper) in a range, defined by a literal value and its
+   * inclusiveness.
+   *
+   * @param value
+   *   The literal value defining the bound.
+   * @param inclusive
+   *   Indicates whether the bound is inclusive.
+   */
+  case class Bound(value: Literal, inclusive: Boolean) {
+
+    /**
+     * Checks if this bound is less than or equal to another bound, considering inclusiveness.
+     *
+     * @param other
+     *   The bound to compare against.
+     * @return
+     *   True if this bound is less than or equal to the other bound.
+     */
+    def lessThanOrEqualTo(other: Bound): Boolean = {
+      val cmp = value.value.asInstanceOf[Comparable[Any]].compareTo(other.value.value)
+      cmp < 0 || (cmp == 0 && (inclusive || !other.inclusive))
+    }
+
+    /**
+     * Checks if this bound is greater than or equal to another bound, considering inclusiveness.
+     *
+     * @param other
+     *   The bound to compare against.
+     * @return
+     *   True if this bound is greater than or equal to the other bound.
+     */
+    def greaterThanOrEqualTo(other: Bound): Boolean = {
+      val cmp = value.value.asInstanceOf[Comparable[Any]].compareTo(other.value.value)
+      cmp > 0 || (cmp == 0 && (inclusive || !other.inclusive))
     }
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkQueryRewriteHelper.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkQueryRewriteHelper.scala
@@ -41,8 +41,9 @@ trait FlintSparkQueryRewriteHelper {
    *   True if the index filter can subsume the query filter, otherwise False.
    */
   def subsume(indexFilter: Expression, queryFilter: Expression): Boolean = {
-    require(isConjunction(indexFilter), "Index filter is not a conjunction")
-    require(isConjunction(queryFilter), "Query filter is not a conjunction")
+    if (!isConjunction(indexFilter) || !isConjunction(queryFilter)) {
+      return false
+    }
 
     // Flatten a potentially nested conjunction into a sequence of individual conditions
     def flattenConditions(filter: Expression): Seq[Expression] = filter match {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
@@ -41,7 +41,7 @@ class ApplyFlintSparkCoveringIndex(flint: FlintSpark)
     } else {
       // Iterate each sub plan tree in the given plan
       plan transform {
-        case subPlan @ Filter(condition, ExtractRelation(relation)) =>
+        case subPlan @ Filter(condition, ExtractRelation(relation)) if isConjunction(condition) =>
           doApply(plan, relation, Some(condition))
             .map(newRelation => subPlan.copy(child = newRelation))
             .getOrElse(subPlan)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
@@ -41,7 +41,7 @@ class ApplyFlintSparkCoveringIndex(flint: FlintSpark)
     } else {
       // Iterate each sub plan tree in the given plan
       plan transform {
-        case filter @ Filter(condition, Relation(sourceRelation)) if isConjunction(condition) =>
+        case filter @ Filter(condition, Relation(sourceRelation)) =>
           doApply(plan, sourceRelation, Some(condition))
             .map(newRelation => filter.copy(child = newRelation))
             .getOrElse(filter)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndex.scala
@@ -114,8 +114,8 @@ class ApplyFlintSparkCoveringIndex(flint: FlintSpark)
     val indexes =
       flint
         .describeIndexes(indexPattern)
-        .collect { // cast to covering index
-          case index: FlintSparkCoveringIndex => index
+        .collect { // cast to covering index and double check table name
+          case index: FlintSparkCoveringIndex if index.tableName == qualifiedTableName => index
         }
 
     val indexNames = indexes.map(_.name()).mkString(",")

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/ApplyFlintSparkCoveringIndexSuite.scala
@@ -84,7 +84,7 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
     "age <= 50",
     "age > 20 AND age < 50",
     "age >= 20 AND age < 50",
-    "age > 20 AND age < 50",
+    "age > 20 AND age <= 50",
     "age >=20 AND age <= 50")
   (for {
     indexFilter <- conditions
@@ -134,8 +134,8 @@ class ApplyFlintSparkCoveringIndexSuite extends FlintSuite with Matchers {
 
   // Covering index doesn't cover column age
   Seq(
-    // s"SELECT * FROM $testTable", // FIXME: only relation operator
-    // s"SELECT name, age FROM $testTable", // FIXME: only relation operator
+    s"SELECT * FROM $testTable",
+    s"SELECT name, age FROM $testTable",
     s"SELECT name FROM $testTable WHERE age = 30",
     s"SELECT COUNT(*) FROM $testTable GROUP BY age").foreach { query =>
     test(s"should not apply if column is not covered in $query") {


### PR DESCRIPTION
### Description

This PR enhances the covering index query rewriter to support query optimization using partial covering indexes (indexes created with filtering conditions). To enable this, the key question is: **Does the covering index contain all rows needed by the query filter?**

The core idea is to perform a subsumption test between the filtering conditions in the covering index and those in the user query. Subsumption testing determines if **the output of one filtering condition is "broader" than the output of another**. To utilize a Flint covering index for query acceleration, the index filter must subsume the query filter.

#### Algorithm

Ideally, we could simplify the problem by checking `queryConditions AND indexConditions = queryConditions` after expression simplification. However, there is no API in Spark Catalyst to use for this purpose, requiring a custom implementation as shown in the pseudocode below.

```
  indexConditions.forall { indexCond =>
    queryConditions.exists { queryCond =>
      indexCond.colName == queryCond.colName && 
        indexCond subsume queryCond
    }  
  }
```

This pseudocode shows that **each individual condition in the index filter must be present and less restrictive than the corresponding condition in the query filter**. For example:

- Index Filter: `a >= 10 AND a < 25`
- Query Filter: `a >= 15 AND a < 20`

In this case, the index condition `a >= 10` subsumes the query condition `a >= 15` because any value satisfying `a >= 15` will also satisfy `a >= 10`. Similarly, `a < 25` subsumes `a < 20`. Therefore, the covering index can be used to optimize the query since it covers all the rows that the query would need.

> Note that it doesn't matter if the query filter has other conditions. Because currently only conjunctions are supported, additional conditions in the query filter only make the output "narrower". For example, `a >= 10` subsumes `a >= 15 AND a < 20 AND b = 30`. Consequently, our primary focus is on the index conditions and any additional conditions in the query filter do not affect the validity of the subsumption test.

#### Examples

Create a partial covering index with filtering condition for HTTP status code 4xx:

<pre>
spark-sql> CREATE INDEX status_4xx ON myglue.ds_tables.http_logs
         > (
         >   `@timestamp`,
         >   clientip,
         >   status
         > )
         > <b>WHERE status >= 400 AND status < 500;</b>
</pre>

Test queries with different filtering condition:

<pre>
spark-sql> EXPLAIN SELECT clientip, status
         > FROM myglue.ds_tables.http_logs
         > <b>WHERE status = 404;</b>
== Physical Plan ==
*(1) Project [clientip#6, status#8]
+- BatchScan[@timestamp#5, clientip#6, status#8] class <b>org.apache.spark.sql.flint.FlintScan</b>,
PushedPredicates: [status IS NOT NULL, status = 404] RuntimeFilters: []

spark-sql> EXPLAIN SELECT clientip, status
         > FROM myglue.ds_tables.http_logs
         > <b>WHERE status >= 404 AND status < 450 AND clientip = '10.0.0.1';</b>
== Physical Plan ==
*(1) Project [clientip#6, status#8]
+- BatchScan[@timestamp#5, clientip#6, status#8] class <b>org.apache.spark.sql.flint.FlintScan,</b>
PushedPredicates: [status IS NOT NULL, clientip IS NOT NULL,
status >= 404, status < 450, clientip = '10.0.0.1'] RuntimeFilters: []


spark-sql> EXPLAIN SELECT clientip, status
         > FROM myglue.ds_tables.http_logs
         > WHERE <b>status = 500;</b>
== Physical Plan ==
*(1) Project [clientip#6, status#8]
+- *(1) Filter (isnotnull(status#8) AND (status#8 = 500))
   +- <b>FileScan json ds_tables.http_logs</b>[clientip#6,status#8,year#10,month#11,day#12]
Batched: false, DataFilters: [isnotnull(status#8), (status#8 = 500)], Format: JSON, Location: ...

spark-sql> EXPLAIN SELECT clientip, status
         > FROM myglue.ds_tables.http_logs
         > WHERE <b>status > 400;</b>
== Physical Plan ==
*(1) Project [clientip#6, status#8]
+- *(1) Filter (isnotnull(status#8) AND (status#8 > 400))
   +- <b>FileScan json ds_tables.http_logs</b>[clientip#6,status#8,year#10,month#11,day#12]
Batched: false, DataFilters: [isnotnull(status#8), (status#8 > 400)], Format: JSON, Location: ...
</pre>

#### PR Planned

- [x] https://github.com/opensearch-project/opensearch-spark/pull/318
- [x] https://github.com/opensearch-project/opensearch-spark/pull/325 *[Tracked separately]*
- [x] https://github.com/opensearch-project/opensearch-spark/pull/391
- [x] Add logging or whyNot API to explain why/whyNot index applied *[Logging added in last PR]*
- [ ] Support SQL hint for Spark conf, ex. CV rewrite, hybrid scan *[TBD]*
- [x] https://github.com/opensearch-project/opensearch-spark/pull/409 *[Current PR]*

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/298

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
