### PR TITLE
Pre-validate checkpoint location write permission

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkValidationHelper.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkValidationHelper.scala
@@ -89,7 +89,10 @@ trait FlintSparkValidationHelper extends Logging {
        * The temporary file is left in place in case additional delete permissions are required
        * for some file systems.
        */
-      val tempFilePath = new Path(checkpointLocation, s"${UUID.randomUUID().toString}.tmp")
+      val tempFilePath =
+        new Path(
+          checkpointManager.createCheckpointDirectory(),
+          s"${UUID.randomUUID().toString}.tmp")
       val outputStream = checkpointManager.createAtomic(tempFilePath, overwriteIfPossible = true)
       outputStream.close()
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/AutoIndexRefresh.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/AutoIndexRefresh.scala
@@ -56,7 +56,7 @@ class AutoIndexRefresh(indexName: String, index: FlintSparkIndex)
     if (checkpointLocation.isDefined) {
       require(
         isCheckpointLocationAccessible(spark, checkpointLocation.get),
-        s"No permission to access the checkpoint location ${checkpointLocation.get}")
+        s"No sufficient permission to access the checkpoint location ${checkpointLocation.get}")
     }
   }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/IncrementalIndexRefresh.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/IncrementalIndexRefresh.scala
@@ -39,7 +39,7 @@ class IncrementalIndexRefresh(indexName: String, index: FlintSparkIndex)
       "Checkpoint location is required by incremental refresh")
     require(
       isCheckpointLocationAccessible(spark, checkpointLocation.get),
-      s"No permission to access the checkpoint location ${checkpointLocation.get}")
+      s"No sufficient permission to access the checkpoint location ${checkpointLocation.get}")
   }
 
   override def start(spark: SparkSession, flintSparkConf: FlintSparkConf): Option[String] = {


### PR DESCRIPTION
### Description

This PR enhances the pre-validation process for checkpoint locations by adding a write permission check. Previously, only read permissions were verified. With this update, a temporary file is created at the specified location to verify write permissions.

The side effect of this change include:

1. Checkpoint folder will be created earlier than before: Previously streaming job will do it when start
2. A temporary file will remain in the checkpoint folder: This file is intentionally left undeleted to avoid requiring delete permissions, which are only necessary during the index vacuuming process after the work in https://github.com/opensearch-project/opensearch-spark/issues/102 completed.

#### Testing

Tested with an S3 bucket by first revoking the `PutObject` permission:

<pre>
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:AbortMultipartUpload",
                "s3:CreateBucket",
                "s3:DeleteObject",
                "s3:GetBucketVersioning",
                "s3:GetObject",
                "s3:GetObjectTagging",
                "s3:GetObjectVersion",
                "s3:ListBucket",
                "s3:ListBucketMultipartUploads",
                "s3:ListBucketVersions",
                "s3:ListMultipartUploadParts",
                "s3:PutBucketVersioning",
                <b><s>"s3:PutObject",</s></b>
                "s3:PutObjectTagging"
            ],
            "Resource": [
                "arn:aws:s3:::*"
            ]
        }
    ]
}
</pre>

Attempted to create a skipping index with checkpoint location option:

<pre>
spark-sql> CREATE SKIPPING INDEX ON myglue.ds_tables.http_logs (
         >   status VALUE_SET
         > )
         > WITH (
         >   auto_refresh = true,
         >   checkpoint_location = 's3://validation_test/test-1'
         > );
</pre>

Observed the expected error message:

<pre>
<b>java.lang.IllegalArgumentException: requirement failed: No sufficient permission to access
the checkpoint location s3://validation_test/test-1</b>
  at scala.Predef$.require(Predef.scala:281) ~[scala-library-2.12.15.jar:?]
  at org.opensearch.flint.spark.refresh.AutoIndexRefresh.validate(AutoIndexRefresh.scala:59)
  at org.opensearch.flint.spark.FlintSparkIndexBuilder.validateIndex(FlintSparkIndexBuilder.scala:100)
  at org.opensearch.flint.spark.FlintSparkIndexBuilder.create(FlintSparkIndexBuilder.scala:63)
</pre>

Granted the `PutObject` permission and create the index successfully. Here is the checkpoint folder looks like:

<pre>
➜  ~ aws s3 ls s3://validation_test/test-2/
                           PRE commits/
                           PRE offsets/
                           PRE sources/
<b>2024-07-10 11:39:23          0 51377eda-b2dc-4fbf-803f-aa5ac4e586b0.tmp</b>
2024-07-10 11:39:30          0 commits_$folder$
2024-07-10 11:39:30         45 metadata
2024-07-10 11:39:30          0 offsets_$folder$
2024-07-10 11:39:31          0 sources_$folder$
</pre>

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/404

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
