### PR TITLE
Fix missed renames for log entry properties in comments and constructors

### DIFF
--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/log/FlintMetadataLogEntry.scala
@@ -43,8 +43,8 @@ case class FlintMetadataLogEntry(
       state: IndexState,
       entryVersion: JMap[String, Any],
       error: String,
-      storageContext: JMap[String, Any]) = {
-    this(id, createTime, state, entryVersion.asScala.toMap, error, storageContext.asScala.toMap)
+      properties: JMap[String, Any]) = {
+    this(id, createTime, state, entryVersion.asScala.toMap, error, properties.asScala.toMap)
   }
 
   def this(
@@ -53,8 +53,8 @@ case class FlintMetadataLogEntry(
       state: IndexState,
       entryVersion: JMap[String, Any],
       error: String,
-      storageContext: Map[String, Any]) = {
-    this(id, createTime, state, entryVersion.asScala.toMap, error, storageContext)
+      properties: Map[String, Any]) = {
+    this(id, createTime, state, entryVersion.asScala.toMap, error, properties)
   }
 }
 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -40,7 +40,7 @@ import org.opensearch.flint.core.IRestHighLevelClient;
  * - entryVersion:
  *   - seqNo (Long): OpenSearch sequence number
  *   - primaryTerm (Long): OpenSearch primary term
- * - storageContext:
+ * - properties:
  *   - dataSourceName (String): OpenSearch data source associated
  */
 public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadataLogEntry> {


### PR DESCRIPTION
### Description
There were some missing parameter and comment change for renaming `storageContext` into `properties` in #406 

### Issues Resolved
* #371 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
