### PR TITLE
Remove unimplemented syntax

### DIFF
--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -236,10 +236,6 @@ statsFunctionName
    | SUM
    | MIN
    | MAX
-   | VAR_SAMP
-   | VAR_POP
-   | STDDEV_SAMP
-   | STDDEV_POP
    ;
 
 takeAggFunction
@@ -810,9 +806,14 @@ keywordsCanBeId
    : D // OD SQL and ODBC special
    | timespanUnit
    | SPAN
+   | evalFunctionName
    | relevanceArgName
    | intervalUnit
-   // commands
+   | dateTimeFunctionName
+   | textFunctionName
+   | mathematicalFunctionName
+   | positionFunctionName
+// commands
    | SEARCH
    | DESCRIBE
    | SHOW

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -27,8 +27,6 @@ queryStatement
 // commands
 pplCommands
    : searchCommand
-   | describeCommand
-   | showDataSourcesCommand
    ;
 
 commands

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -811,7 +811,7 @@ keywordsCanBeId
    | textFunctionName
    | mathematicalFunctionName
    | positionFunctionName
-// commands
+   // commands
    | SEARCH
    | DESCRIBE
    | SHOW

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -37,18 +37,8 @@ commands
    | fieldsCommand
    | renameCommand
    | statsCommand
-   | dedupCommand
    | sortCommand
-   | evalCommand
    | headCommand
-   | topCommand
-   | rareCommand
-   | grokCommand
-   | parseCommand
-   | patternsCommand
-   | kmeansCommand
-   | adCommand
-   | mlCommand
    ;
 
 searchCommand
@@ -190,8 +180,6 @@ mlArg
 fromClause
    : SOURCE EQUAL tableSourceClause
    | INDEX EQUAL tableSourceClause
-   | SOURCE EQUAL tableFunction
-   | INDEX EQUAL tableFunction
    ;
 
 tableSourceClause
@@ -281,24 +269,17 @@ logicalExpression
 
 comparisonExpression
    : left = valueExpression comparisonOperator right = valueExpression  # compareExpr
-   | valueExpression IN valueList                                       # inExpr
    ;
 
 valueExpression
    : left = valueExpression binaryOperator = (STAR | DIVIDE | MODULE) right = valueExpression   # binaryArithmetic
    | left = valueExpression binaryOperator = (PLUS | MINUS) right = valueExpression             # binaryArithmetic
    | primaryExpression                                                                          # valueExpressionDefault
-   | positionFunction                                                                           # positionFunctionCall
-   | extractFunction                                                                            # extractFunctionCall
-   | getFormatFunction                                                                          # getFormatFunctionCall
-   | timestampFunction                                                                          # timestampFunctionCall
    | LT_PRTHS valueExpression RT_PRTHS                                                          # parentheticValueExpr
    ;
 
 primaryExpression
-   : evalFunctionCall
-   | dataTypeFunctionCall
-   | fieldExpression
+   : fieldExpression
    | literalValue
    ;
 
@@ -700,8 +681,7 @@ multiFieldRelevanceFunctionName
 
 // literals and values
 literalValue
-   : intervalLiteral
-   | stringLiteral
+   : stringLiteral
    | integerLiteral
    | decimalLiteral
    | booleanLiteral
@@ -830,13 +810,8 @@ keywordsCanBeId
    : D // OD SQL and ODBC special
    | timespanUnit
    | SPAN
-   | evalFunctionName
    | relevanceArgName
    | intervalUnit
-   | dateTimeFunctionName
-   | textFunctionName
-   | mathematicalFunctionName
-   | positionFunctionName
    // commands
    | SEARCH
    | DESCRIBE

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -287,11 +287,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   /** From clause. */
   @Override
   public UnresolvedPlan visitFromClause(OpenSearchPPLParser.FromClauseContext ctx) {
-    if (ctx.tableFunction() != null) {
-      return visitTableFunction(ctx.tableFunction());
-    } else {
-      return visitTableSourceClause(ctx.tableSourceClause());
-    }
+    return visitTableSourceClause(ctx.tableSourceClause());
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -244,55 +244,6 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
                 Arrays.asList(visitFunctionArg(ctx.functionArg(0)), visitFunctionArg(ctx.functionArg(1))));
     }
 
-    @Override
-    public UnresolvedExpression visitExtractFunctionCall(
-            OpenSearchPPLParser.ExtractFunctionCallContext ctx) {
-        return new Function(
-                ctx.extractFunction().EXTRACT().toString(), getExtractFunctionArguments(ctx));
-    }
-
-    private List<UnresolvedExpression> getExtractFunctionArguments(
-            OpenSearchPPLParser.ExtractFunctionCallContext ctx) {
-        List<UnresolvedExpression> args =
-                Arrays.asList(
-                        new Literal(ctx.extractFunction().datetimePart().getText(), DataType.STRING),
-                        visitFunctionArg(ctx.extractFunction().functionArg()));
-        return args;
-    }
-
-    @Override
-    public UnresolvedExpression visitGetFormatFunctionCall(
-            OpenSearchPPLParser.GetFormatFunctionCallContext ctx) {
-        return new Function(
-                ctx.getFormatFunction().GET_FORMAT().toString(), getFormatFunctionArguments(ctx));
-    }
-
-    private List<UnresolvedExpression> getFormatFunctionArguments(
-            OpenSearchPPLParser.GetFormatFunctionCallContext ctx) {
-        List<UnresolvedExpression> args =
-                Arrays.asList(
-                        new Literal(ctx.getFormatFunction().getFormatType().getText(), DataType.STRING),
-                        visitFunctionArg(ctx.getFormatFunction().functionArg()));
-        return args;
-    }
-
-    @Override
-    public UnresolvedExpression visitTimestampFunctionCall(
-            OpenSearchPPLParser.TimestampFunctionCallContext ctx) {
-        return new Function(
-                ctx.timestampFunction().timestampFunctionName().getText(), timestampFunctionArguments(ctx));
-    }
-
-    private List<UnresolvedExpression> timestampFunctionArguments(
-            OpenSearchPPLParser.TimestampFunctionCallContext ctx) {
-        List<UnresolvedExpression> args =
-                Arrays.asList(
-                        new Literal(ctx.timestampFunction().simpleDateTimePart().getText(), DataType.STRING),
-                        visitFunctionArg(ctx.timestampFunction().firstArg),
-                        visitFunctionArg(ctx.timestampFunction().secondArg));
-        return args;
-    }
-
     /**
      * Literal and value.
      */


### PR DESCRIPTION
### Description
- Remove unimplemented syntax so that frontend can utilize the .g4 files for validation/auto-complete.
- I considered comment-out, but ended up deleting them as we can refer this PR or [file in SQL plugin](https://github.com/opensearch-project/sql/blob/main/ppl/src/main/antlr/OpenSearchPPLParser.g4) to see the original implementation, and it became a bit messy when I commented out them with TODO tag.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
