### PR TITLE
[Bugfix] Insights on query execution error

### DIFF
--- a/integ-test/src/test/scala/org/apache/spark/sql/FlintREPLITSuite.scala
+++ b/integ-test/src/test/scala/org/apache/spark/sql/FlintREPLITSuite.scala
@@ -447,7 +447,13 @@ class FlintREPLITSuite extends SparkFunSuite with OpenSearchSuite with JobTest {
         submitQuery(s"${makeJsonCompliant(createTableStatement)}", testQueryId)
 
       val createTableStatementValidation: REPLResult => Boolean = result => {
-        successValidation(result)
+        assert(
+          result.results.size == 0,
+          s"expected result size is 0, but got ${result.results.size}")
+        assert(
+          result.schemas.size == 0,
+          s"expected schema size is 0, but got ${result.schemas.size}")
+        failureValidation(result)
         true
       }
       pollForResultAndAssert(createTableStatementValidation, testQueryId)

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -436,10 +436,11 @@ trait FlintJobExecutor {
 
   private def handleQueryException(
       e: Exception,
-      message: String,
+      messagePrefix: String,
       errorSource: Option[String] = None,
       statusCode: Option[Int] = None): String = {
-    val errorDetails = Map("Message" -> s"$message: ${e.getMessage}") ++
+    val errorMessage = s"$messagePrefix: ${e.getMessage}"
+    val errorDetails = Map("Message" -> errorMessage) ++
       errorSource.map("ErrorSource" -> _) ++
       statusCode.map(code => "StatusCode" -> code.toString)
 
@@ -448,9 +449,9 @@ trait FlintJobExecutor {
     // CustomLogging will call log4j logger.error() underneath
     statusCode match {
       case Some(code) =>
-        CustomLogging.logError(new OperationMessage(message, code), e)
+        CustomLogging.logError(new OperationMessage(errorMessage, code), e)
       case None =>
-        CustomLogging.logError(message, e)
+        CustomLogging.logError(errorMessage, e)
     }
 
     errorJson


### PR DESCRIPTION
### Description
While the root cause of the exception is parsed and returned as part of the contract, the actual ex should be logged as well.

### Test output

Example 1:
```
2024-07-25T22:38:43.2312843Z 24/07/25 15:38:43 ERROR CustomLogging: {"timestamp":1721947123230,"severityText":"ERROR","severityNumber":17,"body":{"message":"Fail to analyze query. Cause: Table or view not found: testTable; line 1 pos 22;\n'Project ['name, 'age]\n+- 'UnresolvedRelation [testTable], [], false\n"},"attributes":{"domainName":"UNKNOWN:UNKNOWN","clientId":"UNKNOWN","exception.type":"org.apache.spark.sql.AnalysisException","exception.message":"Table or view not found: testTable; line 1 pos 22;\n'Project ['name, 'age]\n+- 'UnresolvedRelation [testTable], [], false\n"}}
2024-07-25T22:38:43.2317673Z org.apache.spark.sql.AnalysisException: Table or view not found: testTable; line 1 pos 22;
2024-07-25T22:38:43.2318792Z 'Project ['name, 'age]
2024-07-25T22:38:43.2319394Z +- 'UnresolvedRelation [testTable], [], false
2024-07-25T22:38:43.2321244Z 
2024-07-25T22:38:43.2321947Z 	at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.failAnalysis(package.scala:42)
2024-07-25T22:38:43.2323607Z 	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis$1(CheckAnalysis.scala:131)
2024-07-25T22:38:43.2325416Z 	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis$1$adapted(CheckAnalysis.scala:102)
2024-07-25T22:38:43.2327205Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(TreeNode.scala:367)
2024-07-25T22:38:43.2328527Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1(TreeNode.scala:366)
2024-07-25T22:38:43.2329966Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1$adapted(TreeNode.scala:366)
2024-07-25T22:38:43.2331175Z 	at scala.collection.Iterator.foreach(Iterator.scala:943)
2024-07-25T22:38:43.2332081Z 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
2024-07-25T22:38:43.2333087Z 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
2024-07-25T22:38:43.2334157Z 	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
2024-07-25T22:38:43.2335202Z 	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
2024-07-25T22:38:43.2336242Z 	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
2024-07-25T22:38:43.2337413Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(TreeNode.scala:366)
2024-07-25T22:38:43.2338891Z 	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.checkAnalysis(CheckAnalysis.scala:102)
2024-07-25T22:38:43.2340798Z 	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.checkAnalysis$(CheckAnalysis.scala:97)
2024-07-25T22:38:43.2342361Z 	at org.apache.spark.sql.catalyst.analysis.Analyzer.checkAnalysis(Analyzer.scala:188)
2024-07-25T22:38:43.2343894Z 	at org.apache.spark.sql.catalyst.analysis.Analyzer.$anonfun$executeAndCheck$1(Analyzer.scala:214)
2024-07-25T22:38:43.2345590Z 	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.markInAnalyzer(AnalysisHelper.scala:330)
2024-07-25T22:38:43.2347208Z 	at org.apache.spark.sql.catalyst.analysis.Analyzer.executeAndCheck(Analyzer.scala:211)
2024-07-25T22:38:43.2348711Z 	at org.apache.spark.sql.execution.QueryExecution.$anonfun$analyzed$1(QueryExecution.scala:76)
2024-07-25T22:38:43.2350323Z 	at org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:111)
2024-07-25T22:38:43.2352107Z 	at org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$2(QueryExecution.scala:185)
2024-07-25T22:38:43.2353664Z 	at org.apache.spark.sql.execution.QueryExecution$.withInternalError(QueryExecution.scala:510)
2024-07-25T22:38:43.2355239Z 	at org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$1(QueryExecution.scala:185)
2024-07-25T22:38:43.2356633Z 	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779)
2024-07-25T22:38:43.2357945Z 	at org.apache.spark.sql.execution.QueryExecution.executePhase(QueryExecution.scala:184)
2024-07-25T22:38:43.2359602Z 	at org.apache.spark.sql.execution.QueryExecution.analyzed$lzycompute(QueryExecution.scala:76)
2024-07-25T22:38:43.2361070Z 	at org.apache.spark.sql.execution.QueryExecution.analyzed(QueryExecution.scala:74)
2024-07-25T22:38:43.2362501Z 	at org.apache.spark.sql.execution.QueryExecution.assertAnalyzed(QueryExecution.scala:66)
2024-07-25T22:38:43.2363820Z 	at org.apache.spark.sql.Dataset$.$anonfun$ofRows$2(Dataset.scala:99)
2024-07-25T22:38:43.2364965Z 	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779)
2024-07-25T22:38:43.2366025Z 	at org.apache.spark.sql.Dataset$.ofRows(Dataset.scala:97)
2024-07-25T22:38:43.2367205Z 	at org.apache.spark.sql.SparkSession.$anonfun$sql$1(SparkSession.scala:622)
2024-07-25T22:38:43.2368413Z 	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779)
2024-07-25T22:38:43.2369523Z 	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:617)
2024-07-25T22:38:43.2370706Z 	at org.apache.spark.sql.FlintJobExecutor.executeQuery(FlintJobExecutor.scala:423)
2024-07-25T22:38:43.2372063Z 	at org.apache.spark.sql.FlintJobExecutor.executeQuery$(FlintJobExecutor.scala:412)
2024-07-25T22:38:43.2373347Z 	at org.apache.spark.sql.FlintREPL$.executeQuery(FlintREPL.scala:49)
2024-07-25T22:38:43.2374536Z 	at org.apache.spark.sql.FlintREPL$.$anonfun$executeQueryAsync$1(FlintREPL.scala:821)
2024-07-25T22:38:43.2375799Z 	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
2024-07-25T22:38:43.2376667Z 	at scala.util.Success.$anonfun$map$1(Try.scala:255)
2024-07-25T22:38:43.2377387Z 	at scala.util.Success.map(Try.scala:213)
2024-07-25T22:38:43.2378156Z 	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
2024-07-25T22:38:43.2379139Z 	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
2024-07-25T22:38:43.2380389Z 	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
2024-07-25T22:38:43.2381475Z 	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
2024-07-25T22:38:43.2382668Z 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
2024-07-25T22:38:43.2383892Z 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
2024-07-25T22:38:43.2385428Z 	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
2024-07-25T22:38:43.2387242Z 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
2024-07-25T22:38:43.2388784Z 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
2024-07-25T22:38:43.2389944Z 	at java.base/java.lang.Thread.run(Thread.java:829)
2024-07-25T22:38:43.2588380Z 24/07/25 15:38:43 INFO FlintREPL: command complete: FlintStatement(state=failed, query=SELECT name, age FROM testTable, statementId=bc04b19a-05b1-490b-a5c3-a7cf46fa4505, queryId=104, submitTime=1721947114027, error=Some({"Message":"Fail to analyze query. Cause: Table or view not found: testTable; line 1 pos 22;\n'Project ['name, 'age]\n+- 'UnresolvedRelation [testTable], [], false\n"}))
```

Example 2:
```
2024-07-25T22:38:58.3114369Z 24/07/25 15:38:58 ERROR CustomLogging: {"timestamp":1721947138303,"severityText":"ERROR","severityNumber":17,"body":{"message":"Fail to run query. Cause: No FileSystem for scheme \"s3\""},"attributes":{"domainName":"UNKNOWN:UNKNOWN","clientId":"UNKNOWN","exception.type":"org.apache.hadoop.fs.UnsupportedFileSystemException","exception.message":"No FileSystem for scheme \"s3\""}}
2024-07-25T22:38:58.3117967Z org.apache.hadoop.fs.UnsupportedFileSystemException: No FileSystem for scheme "s3"
2024-07-25T22:38:58.3119302Z 	at org.apache.hadoop.fs.FileSystem.getFileSystemClass(FileSystem.java:3443)
2024-07-25T22:38:58.3120573Z 	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3466)
2024-07-25T22:38:58.3121821Z 	at org.apache.hadoop.fs.FileSystem.access$300(FileSystem.java:174)
2024-07-25T22:38:58.3122973Z 	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:3574)
2024-07-25T22:38:58.3124105Z 	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3521)
2024-07-25T22:38:58.3125341Z 	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:540)
2024-07-25T22:38:58.3126330Z 	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:365)
2024-07-25T22:38:58.3127794Z 	at org.apache.spark.sql.execution.datasources.DataSource$.$anonfun$checkAndGlobPathIfNecessary$1(DataSource.scala:752)
2024-07-25T22:38:58.3129236Z 	at scala.collection.immutable.List.map(List.scala:293)
2024-07-25T22:38:58.3130591Z 	at org.apache.spark.sql.execution.datasources.DataSource$.checkAndGlobPathIfNecessary(DataSource.scala:750)
2024-07-25T22:38:58.3132472Z 	at org.apache.spark.sql.execution.datasources.DataSource.checkAndGlobPathIfNecessary(DataSource.scala:579)
2024-07-25T22:38:58.3134288Z 	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:408)
2024-07-25T22:38:58.3136092Z 	at org.apache.spark.sql.execution.command.CreateDataSourceTableCommand.run(createDataSourceTables.scala:79)
2024-07-25T22:38:58.3138033Z 	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:75)
2024-07-25T22:38:58.3140064Z 	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:73)
2024-07-25T22:38:58.3141752Z 	at org.apache.spark.sql.execution.command.ExecutedCommandExec.executeCollect(commands.scala:84)
2024-07-25T22:38:58.3143652Z 	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.$anonfun$applyOrElse$1(QueryExecution.scala:98)
2024-07-25T22:38:58.3145519Z 	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$6(SQLExecution.scala:109)
2024-07-25T22:38:58.3147127Z 	at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:169)
2024-07-25T22:38:58.3148715Z 	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:95)
2024-07-25T22:38:58.3150155Z 	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779)
2024-07-25T22:38:58.3151512Z 	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:64)
2024-07-25T22:38:58.3153418Z 	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:98)
2024-07-25T22:38:58.3155427Z 	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:94)
2024-07-25T22:38:58.3157252Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDownWithPruning$1(TreeNode.scala:584)
2024-07-25T22:38:58.3158789Z 	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:176)
2024-07-25T22:38:58.3160478Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning(TreeNode.scala:584)
2024-07-25T22:38:58.3162755Z 	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.org$apache$spark$sql$catalyst$plans$logical$AnalysisHelper$$super$transformDownWithPruning(LogicalPlan.scala:30)
2024-07-25T22:38:58.3165177Z 	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning(AnalysisHelper.scala:267)
2024-07-25T22:38:58.3167134Z 	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning$(AnalysisHelper.scala:263)
2024-07-25T22:38:58.3169072Z 	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:30)
2024-07-25T22:38:58.3171115Z 	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:30)
2024-07-25T22:38:58.3172676Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:560)
2024-07-25T22:38:58.3174176Z 	at org.apache.spark.sql.execution.QueryExecution.eagerlyExecuteCommands(QueryExecution.scala:94)
2024-07-25T22:38:58.3175800Z 	at org.apache.spark.sql.execution.QueryExecution.commandExecuted$lzycompute(QueryExecution.scala:81)
2024-07-25T22:38:58.3177283Z 	at org.apache.spark.sql.execution.QueryExecution.commandExecuted(QueryExecution.scala:79)
2024-07-25T22:38:58.3178480Z 	at org.apache.spark.sql.Dataset.<init>(Dataset.scala:220)
2024-07-25T22:38:58.3179860Z 	at org.apache.spark.sql.Dataset$.$anonfun$ofRows$2(Dataset.scala:100)
2024-07-25T22:38:58.3180989Z 	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779)
2024-07-25T22:38:58.3182003Z 	at org.apache.spark.sql.Dataset$.ofRows(Dataset.scala:97)
2024-07-25T22:38:58.3182995Z 	at org.apache.spark.sql.SparkSession.$anonfun$sql$1(SparkSession.scala:622)
2024-07-25T22:38:58.3184148Z 	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779)
2024-07-25T22:38:58.3185237Z 	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:617)
2024-07-25T22:38:58.3186419Z 	at org.apache.spark.sql.FlintJobExecutor.executeQuery(FlintJobExecutor.scala:423)
2024-07-25T22:38:58.3187746Z 	at org.apache.spark.sql.FlintJobExecutor.executeQuery$(FlintJobExecutor.scala:412)
2024-07-25T22:38:58.3188912Z 	at org.apache.spark.sql.FlintREPL$.executeQuery(FlintREPL.scala:49)
2024-07-25T22:38:58.3190062Z 	at org.apache.spark.sql.FlintREPL$.$anonfun$executeQueryAsync$1(FlintREPL.scala:821)
2024-07-25T22:38:58.3191195Z 	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
2024-07-25T22:38:58.3192092Z 	at scala.util.Success.$anonfun$map$1(Try.scala:255)
2024-07-25T22:38:58.3192815Z 	at scala.util.Success.map(Try.scala:213)
2024-07-25T22:38:58.3193599Z 	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
2024-07-25T22:38:58.3194573Z 	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
2024-07-25T22:38:58.3195630Z 	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
2024-07-25T22:38:58.3196693Z 	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
2024-07-25T22:38:58.3197890Z 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
2024-07-25T22:38:58.3199081Z 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
2024-07-25T22:38:58.3200691Z 	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
2024-07-25T22:38:58.3202466Z 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
2024-07-25T22:38:58.3204134Z 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
2024-07-25T22:38:58.3205226Z 	at java.base/java.lang.Thread.run(Thread.java:829)
2024-07-25T22:38:58.3239520Z 24/07/25 15:38:58 INFO FlintREPL: command complete: FlintStatement(state=failed, query=  CREATE TABLE my_glue1.default.flint_sql_test  (    name STRING,    age INT  )  USING CSV  LOCATION 's3://path/to/dummy/location'  OPTIONS (   header 'false',   delimiter '	'  ) , statementId=4f944382-800a-4941-9f63-59f47a4182f4, queryId=110, submitTime=1721947136272, error=Some({"Message":"Fail to run query. Cause: No FileSystem for scheme \"s3\""}))
```

Example 3:
```
2024-07-25T22:39:01.3304532Z 24/07/25 15:39:01 ERROR CustomLogging: {"timestamp":1721947141329,"severityText":"ERROR","severityNumber":17,"body":{"message":"Fail to analyze query. Cause: Table or view not found: my_glue1.default.flint_sql_test; line 1 pos 11;\n'DropTable false, false\n+- 'UnresolvedTableOrView [my_glue1, default, flint_sql_test], DROP TABLE, true\n"},"attributes":{"domainName":"UNKNOWN:UNKNOWN","clientId":"UNKNOWN","exception.type":"org.apache.spark.sql.AnalysisException","exception.message":"Table or view not found: my_glue1.default.flint_sql_test; line 1 pos 11;\n'DropTable false, false\n+- 'UnresolvedTableOrView [my_glue1, default, flint_sql_test], DROP TABLE, true\n"}}
2024-07-25T22:39:01.3363568Z org.apache.spark.sql.AnalysisException: Table or view not found: my_glue1.default.flint_sql_test; line 1 pos 11;
2024-07-25T22:39:01.3364990Z 'DropTable false, false
2024-07-25T22:39:01.3365952Z +- 'UnresolvedTableOrView [my_glue1, default, flint_sql_test], DROP TABLE, true
2024-07-25T22:39:01.3366700Z 
2024-07-25T22:39:01.3367847Z 	at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.failAnalysis(package.scala:42)
2024-07-25T22:39:01.3369480Z 	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis$1(CheckAnalysis.scala:128)
2024-07-25T22:39:01.3371141Z 	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis$1$adapted(CheckAnalysis.scala:102)
2024-07-25T22:39:01.3372655Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(TreeNode.scala:367)
2024-07-25T22:39:01.3374145Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1(TreeNode.scala:366)
2024-07-25T22:39:01.3375610Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1$adapted(TreeNode.scala:366)
2024-07-25T22:39:01.3376805Z 	at scala.collection.Iterator.foreach(Iterator.scala:943)
2024-07-25T22:39:01.3377822Z 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
2024-07-25T22:39:01.3378806Z 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
2024-07-25T22:39:01.3381762Z 	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
2024-07-25T22:39:01.3382887Z 	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
2024-07-25T22:39:01.3383877Z 	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
2024-07-25T22:39:01.3385049Z 	at org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(TreeNode.scala:366)
2024-07-25T22:39:01.3386519Z 	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.checkAnalysis(CheckAnalysis.scala:102)
2024-07-25T22:39:01.3388097Z 	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.checkAnalysis$(CheckAnalysis.scala:97)
2024-07-25T22:39:01.3389611Z 	at org.apache.spark.sql.catalyst.analysis.Analyzer.checkAnalysis(Analyzer.scala:188)
2024-07-25T22:39:01.3391538Z 	at org.apache.spark.sql.catalyst.analysis.Analyzer.$anonfun$executeAndCheck$1(Analyzer.scala:214)
2024-07-25T22:39:01.3393419Z 	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper$.markInAnalyzer(AnalysisHelper.scala:330)
2024-07-25T22:39:01.3395029Z 	at org.apache.spark.sql.catalyst.analysis.Analyzer.executeAndCheck(Analyzer.scala:211)
2024-07-25T22:39:01.3396530Z 	at org.apache.spark.sql.execution.QueryExecution.$anonfun$analyzed$1(QueryExecution.scala:76)
2024-07-25T22:39:01.3398146Z 	at org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:111)
2024-07-25T22:39:01.3399855Z 	at org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$2(QueryExecution.scala:185)
2024-07-25T22:39:01.3401421Z 	at org.apache.spark.sql.execution.QueryExecution$.withInternalError(QueryExecution.scala:510)
2024-07-25T22:39:01.3402981Z 	at org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$1(QueryExecution.scala:185)
2024-07-25T22:39:01.3404323Z 	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779)
2024-07-25T22:39:01.3405613Z 	at org.apache.spark.sql.execution.QueryExecution.executePhase(QueryExecution.scala:184)
2024-07-25T22:39:01.3407099Z 	at org.apache.spark.sql.execution.QueryExecution.analyzed$lzycompute(QueryExecution.scala:76)
2024-07-25T22:39:01.3408533Z 	at org.apache.spark.sql.execution.QueryExecution.analyzed(QueryExecution.scala:74)
2024-07-25T22:39:01.3409925Z 	at org.apache.spark.sql.execution.QueryExecution.assertAnalyzed(QueryExecution.scala:66)
2024-07-25T22:39:01.3411117Z 	at org.apache.spark.sql.Dataset$.$anonfun$ofRows$2(Dataset.scala:99)
2024-07-25T22:39:01.3412208Z 	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779)
2024-07-25T22:39:01.3413105Z 	at org.apache.spark.sql.Dataset$.ofRows(Dataset.scala:97)
2024-07-25T22:39:01.3414015Z 	at org.apache.spark.sql.SparkSession.$anonfun$sql$1(SparkSession.scala:622)
2024-07-25T22:39:01.3414834Z 	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779)
2024-07-25T22:39:01.3415462Z 	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:617)
2024-07-25T22:39:01.3416142Z 	at org.apache.spark.sql.FlintJobExecutor.executeQuery(FlintJobExecutor.scala:423)
2024-07-25T22:39:01.3417074Z 	at org.apache.spark.sql.FlintJobExecutor.executeQuery$(FlintJobExecutor.scala:412)
2024-07-25T22:39:01.3417812Z 	at org.apache.spark.sql.FlintREPL$.executeQuery(FlintREPL.scala:49)
2024-07-25T22:39:01.3418486Z 	at org.apache.spark.sql.FlintREPL$.$anonfun$executeQueryAsync$1(FlintREPL.scala:821)
2024-07-25T22:39:01.3419126Z 	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
2024-07-25T22:39:01.3420236Z 	at scala.util.Success.$anonfun$map$1(Try.scala:255)
2024-07-25T22:39:01.3421081Z 	at scala.util.Success.map(Try.scala:213)
2024-07-25T22:39:01.3421846Z 	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
2024-07-25T22:39:01.3422817Z 	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
2024-07-25T22:39:01.3423829Z 	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
2024-07-25T22:39:01.3424875Z 	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
2024-07-25T22:39:01.3425966Z 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
2024-07-25T22:39:01.3427098Z 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
2024-07-25T22:39:01.3428945Z 	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
2024-07-25T22:39:01.3430684Z 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
2024-07-25T22:39:01.3432211Z 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
2024-07-25T22:39:01.3433274Z 	at java.base/java.lang.Thread.run(Thread.java:829)
2024-07-25T22:39:01.3543120Z 24/07/25 15:39:01 INFO FlintREPL: command complete: FlintStatement(state=failed, query=DROP TABLE my_glue1.default.flint_sql_test, statementId=dae6ee25-bfe2-4585-83f1-ecba2287d22f, queryId=999, submitTime=1721947139305, error=Some({"Message":"Fail to analyze query. Cause: Table or view not found: my_glue1.default.flint_sql_test; line 1 pos 11;\n'DropTable false, false\n+- 'UnresolvedTableOrView [my_glue1, default, flint_sql_test], DROP TABLE, true\n"}))
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/392
https://github.com/opensearch-project/opensearch-spark/issues/445


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
