### PR TITLE
Terminate streaming job when index data is deleted

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -58,7 +58,7 @@ class FlintSpark(val spark: SparkSession) extends FlintSparkTransactionSupport w
 
   /** Flint Spark index monitor */
   val flintIndexMonitor: FlintSparkIndexMonitor =
-    new FlintSparkIndexMonitor(spark, flintMetadataLogService)
+    new FlintSparkIndexMonitor(spark, flintClient, flintMetadataLogService)
 
   /**
    * Create index builder for creating index with fluent API.

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
@@ -18,6 +18,7 @@ import dev.failsafe.event.ExecutionAttemptedEvent
 import dev.failsafe.function.CheckedRunnable
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.{FAILED, REFRESHING}
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogService
+import org.opensearch.flint.core.FlintClient
 import org.opensearch.flint.core.logging.ExceptionMessages.extractRootCause
 import org.opensearch.flint.core.metrics.{MetricConstants, MetricsUtil}
 
@@ -36,6 +37,7 @@ import org.apache.spark.sql.flint.newDaemonThreadPoolScheduledExecutor
  */
 class FlintSparkIndexMonitor(
     spark: SparkSession,
+    flintClient: FlintClient,
     flintMetadataLogService: FlintMetadataLogService)
     extends Logging {
 
@@ -157,7 +159,13 @@ class FlintSparkIndexMonitor(
       try {
         if (isStreamingJobActive(indexName)) {
           logInfo("Streaming job is still active")
-          flintMetadataLogService.recordHeartbeat(indexName)
+
+          if (flintClient.exists(indexName)) {
+            flintMetadataLogService.recordHeartbeat(indexName)
+          } else {
+            logInfo("Streaming job is active but data is deleted")
+            stopStreamingJobAndMonitor(indexName)
+          }
         } else {
           logError("Streaming job is not active. Cancelling monitor task")
           stopMonitor(indexName)
@@ -172,10 +180,7 @@ class FlintSparkIndexMonitor(
 
           // Stop streaming job and its monitor if max retry limit reached
           if (errorCnt >= MAX_ERROR_COUNT) {
-            logInfo(s"Terminating streaming job and index monitor for $indexName")
-            stopStreamingJob(indexName)
-            stopMonitor(indexName)
-            logInfo(s"Streaming job and index monitor terminated")
+            stopStreamingJobAndMonitor(indexName)
           }
       }
     }
@@ -183,6 +188,13 @@ class FlintSparkIndexMonitor(
 
   private def isStreamingJobActive(indexName: String): Boolean =
     spark.streams.active.exists(_.name == indexName)
+
+  private def stopStreamingJobAndMonitor(indexName: String): Unit = {
+    logInfo(s"Terminating streaming job and index monitor for $indexName")
+    stopStreamingJob(indexName)
+    stopMonitor(indexName)
+    logInfo(s"Streaming job and index monitor terminated")
+  }
 
   private def stopStreamingJob(indexName: String): Unit = {
     val job = spark.streams.active.find(_.name == indexName)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
@@ -164,7 +164,7 @@ class FlintSparkIndexMonitor(
           flintMetadataLogService.recordHeartbeat(indexName)
 
           if (!flintClient.exists(indexName)) {
-            logInfo("Streaming job is active but data is deleted")
+            logWarning("Streaming job is active but data is deleted")
             stopStreamingJobAndMonitor(indexName)
           }
         } else {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
@@ -32,6 +32,8 @@ import org.apache.spark.sql.flint.newDaemonThreadPoolScheduledExecutor
  *
  * @param spark
  *   Spark session
+ * @param flintClient
+ *   Flint client
  * @param flintMetadataLogService
  *   Flint metadata log service
  */
@@ -159,10 +161,9 @@ class FlintSparkIndexMonitor(
       try {
         if (isStreamingJobActive(indexName)) {
           logInfo("Streaming job is still active")
+          flintMetadataLogService.recordHeartbeat(indexName)
 
-          if (flintClient.exists(indexName)) {
-            flintMetadataLogService.recordHeartbeat(indexName)
-          } else {
+          if (!flintClient.exists(indexName)) {
             logInfo("Streaming job is active but data is deleted")
             stopStreamingJobAndMonitor(indexName)
           }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
@@ -162,6 +162,10 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
     Thread.sleep(5000)
     task.isCancelled shouldBe true
     spark.streams.active.exists(_.name == testFlintIndex) shouldBe false
+
+    // Assert index state is still refreshing
+    val latestLog = latestLogEntry(testLatestId)
+    latestLog should contain("state" -> "refreshing")
   }
 
   test("await monitor terminated without exception should stay refreshing state") {
@@ -173,7 +177,7 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
     // Await until streaming job terminated
     flint.flintIndexMonitor.awaitMonitor()
 
-    // Assert index state is active now
+    // Assert index state is still refreshing
     val latestLog = latestLogEntry(testLatestId)
     latestLog should contain("state" -> "refreshing")
   }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
@@ -9,9 +9,11 @@ import java.util.Base64
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{doAnswer, spy}
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.opensearch.client.RequestOptions
 import org.opensearch.flint.OpenSearchTransactionSuite
@@ -148,12 +150,25 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
     spark.streams.active.exists(_.name == testFlintIndex) shouldBe false
   }
 
+  test("monitor task and streaming job should terminate if data index is deleted") {
+    val task = FlintSparkIndexMonitor.indexMonitorTracker(testFlintIndex)
+    async {
+      openSearchClient
+        .indices()
+        .delete(new DeleteIndexRequest(testFlintIndex), RequestOptions.DEFAULT)
+    }
+
+    // Wait for index monitor execution and assert
+    Thread.sleep(5000)
+    task.isCancelled shouldBe true
+    spark.streams.active.exists(_.name == testFlintIndex) shouldBe false
+  }
+
   test("await monitor terminated without exception should stay refreshing state") {
     // Setup a timer to terminate the streaming job
-    new Thread(() => {
-      Thread.sleep(3000L)
+    asyncAfter(3.seconds) {
       spark.streams.active.find(_.name == testFlintIndex).get.stop()
-    }).start()
+    }
 
     // Await until streaming job terminated
     flint.flintIndexMonitor.awaitMonitor()
@@ -164,9 +179,7 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
   }
 
   test("await monitor terminated with exception should update index state to failed with error") {
-    new Thread(() => {
-      Thread.sleep(3000L)
-
+    asyncAfter(3.seconds) {
       // Set Flint index readonly to simulate streaming job exception
       val settings = Map("index.blocks.write" -> true)
       val request = new UpdateSettingsRequest(testFlintIndex).settings(settings.asJava)
@@ -178,7 +191,7 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
            | PARTITION (year=2023, month=6)
            | VALUES ('Test', 35, 'Vancouver')
            | """.stripMargin)
-    }).start()
+    }
 
     // Await until streaming job terminated
     flint.flintIndexMonitor.awaitMonitor()
@@ -202,6 +215,19 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
     val latestLog = latestLogEntry(testLatestId)
     latestLog should contain("state" -> "failed")
     latestLog should not contain "error"
+  }
+
+  private def async(block: => Unit): Unit = {
+    new Thread(() => {
+      block
+    }).start()
+  }
+
+  private def asyncAfter(delay: FiniteDuration)(block: => Unit): Unit = {
+    new Thread(() => {
+      Thread.sleep(delay.toMillis)
+      block
+    }).start()
   }
 
   private def getLatestTimestamp: (Long, Long) = {

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
@@ -152,14 +152,12 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
 
   test("monitor task and streaming job should terminate if data index is deleted") {
     val task = FlintSparkIndexMonitor.indexMonitorTracker(testFlintIndex)
-    async {
-      openSearchClient
-        .indices()
-        .delete(new DeleteIndexRequest(testFlintIndex), RequestOptions.DEFAULT)
-    }
+    openSearchClient
+      .indices()
+      .delete(new DeleteIndexRequest(testFlintIndex), RequestOptions.DEFAULT)
 
     // Wait for index monitor execution and assert
-    Thread.sleep(5000)
+    waitForMonitorTaskRun()
     task.isCancelled shouldBe true
     spark.streams.active.exists(_.name == testFlintIndex) shouldBe false
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -69,7 +69,8 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
         flint.deleteIndex(testIndex)
         flint.vacuumIndex(testIndex)
       } catch {
-        case _: IllegalStateException =>
+        // Forcefully delete index data and log entry in case of any errors, such as version conflict
+        case _: Exception =>
           if (openSearchClient
               .indices()
               .exists(new GetIndexRequest(testIndex), RequestOptions.DEFAULT)) {


### PR DESCRIPTION
### Description

This PR adds the capability to terminate the streaming job when the associated Flint data index no longer exists. The termination is managed by the index monitor rather than the Spark streaming listener, ensuring that the job can be terminated even if it remains idle without any new micro-batches being triggered.

Please note that this PR solely addresses the termination of the streaming job and the index monitor itself. The handling of dangling metadata log entries will be addressed in the upcoming PR for [issue #356](https://github.com/opensearch-project/opensearch-spark/issues/356).

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/244

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
