### PR TITLE
Use refresh policy from config

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -27,6 +27,7 @@ If you get integration test failures with error message "Previous attempts to fi
 The `aws-integration` folder contains tests for cloud server providers. For instance, test against AWS OpenSearch domain, configure the following settings. The client will use the default credential provider to access the AWS OpenSearch domain.
 ```
 export AWS_OPENSEARCH_HOST=search-xxx.us-west-2.on.aws
+export AWS_OPENSEARCH_SERVERLESS_HOST=xxx.us-west-2.aoss.amazonaws.com
 export AWS_REGION=us-west-2
 export AWS_EMRS_APPID=xxx
 export AWS_EMRS_EXECUTION_ROLE=xxx

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -155,7 +155,7 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
             new IndexRequest()
                 .index(metadataLogIndexName)
                 .id(logEntryWithId.id())
-                .setRefreshPolicy(RefreshPolicy.WAIT_UNTIL)
+                .setRefreshPolicy(options.getRefreshPolicy())
                 .source(toJson(logEntryWithId), XContentType.JSON),
             RequestOptions.DEFAULT));
   }
@@ -166,7 +166,7 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
         client -> client.update(
             new UpdateRequest(metadataLogIndexName, logEntry.id())
                 .doc(toJson(logEntry), XContentType.JSON)
-                .setRefreshPolicy(RefreshPolicy.WAIT_UNTIL)
+                .setRefreshPolicy(options.getRefreshPolicy())
                 .setIfSeqNo((Long) logEntry.entryVersion().get("seqNo").get())
                 .setIfPrimaryTerm((Long) logEntry.entryVersion().get("primaryTerm").get()),
             RequestOptions.DEFAULT));

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchUpdater.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchUpdater.java
@@ -6,6 +6,7 @@ import org.opensearch.client.RequestOptions;
 import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.flint.core.FlintClient;
+import org.opensearch.flint.core.FlintOptions;
 import org.opensearch.flint.core.IRestHighLevelClient;
 
 import java.io.IOException;
@@ -25,10 +26,12 @@ public class OpenSearchUpdater {
 
     private final String indexName;
     private final FlintClient flintClient;
+    private final FlintOptions options;
 
-    public OpenSearchUpdater(String indexName, FlintClient flintClient) {
+    public OpenSearchUpdater(String indexName, FlintClient flintClient, FlintOptions options) {
         this.indexName = indexName;
         this.flintClient = flintClient;
+        this.options = options;
     }
 
     public void upsert(String id, String doc) {
@@ -61,7 +64,7 @@ public class OpenSearchUpdater {
             assertIndexExist(client, indexName);
             UpdateRequest updateRequest = new UpdateRequest(indexName, id)
                     .doc(doc, XContentType.JSON)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+                    .setRefreshPolicy(options.getRefreshPolicy());
 
             if (upsert) {
                 updateRequest.docAsUpsert(true);

--- a/integ-test/src/aws-integration/scala/org/opensearch/flint/spark/aws/AWSEmrServerlessAccessTestSuite.scala
+++ b/integ-test/src/aws-integration/scala/org/opensearch/flint/spark/aws/AWSEmrServerlessAccessTestSuite.scala
@@ -5,13 +5,14 @@
 
 package org.opensearch.flint.spark.aws
 
+import java.io.File
 import java.time.LocalDateTime
 
 import scala.concurrent.duration.DurationInt
 
-import com.amazonaws.services.emrserverless.AWSEMRServerlessClientBuilder
+import com.amazonaws.services.emrserverless.{AWSEMRServerless, AWSEMRServerlessClientBuilder}
 import com.amazonaws.services.emrserverless.model.{GetJobRunRequest, JobDriver, SparkSubmit, StartJobRunRequest}
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -19,12 +20,13 @@ import org.scalatest.matchers.should.Matchers
 import org.apache.spark.internal.Logging
 
 class AWSEmrServerlessAccessTestSuite
-    extends AnyFlatSpec
+  extends AnyFlatSpec
     with BeforeAndAfter
     with Matchers
     with Logging {
 
   lazy val testHost: String = System.getenv("AWS_OPENSEARCH_HOST")
+  lazy val testServerlessHost: String = System.getenv("AWS_OPENSEARCH_SERVERLESS_HOST")
   lazy val testPort: Int = -1
   lazy val testRegion: String = System.getenv("AWS_REGION")
   lazy val testScheme: String = "https"
@@ -36,10 +38,94 @@ class AWSEmrServerlessAccessTestSuite
   lazy val testS3CodePrefix: String = System.getenv("AWS_S3_CODE_PREFIX")
   lazy val testResultIndex: String = System.getenv("AWS_OPENSEARCH_RESULT_INDEX")
 
-  "EMR Serverless job" should "run successfully" in {
+  "EMR Serverless job with AOS" should "run successfully" in {
     val s3Client = AmazonS3ClientBuilder.standard().withRegion(testRegion).build()
     val emrServerless = AWSEMRServerlessClientBuilder.standard().withRegion(testRegion).build()
 
+    uploadJarsToS3(s3Client)
+
+    val jobRunRequest = startJobRun("SELECT 1", testHost, "es")
+
+    val jobRunResponse = emrServerless.startJobRun(jobRunRequest)
+
+    verifyJobSucceed(emrServerless, jobRunResponse.getJobRunId)
+  }
+
+  "EMR Serverless job with AOSS" should "run successfully" in {
+    val s3Client = AmazonS3ClientBuilder.standard().withRegion(testRegion).build()
+    val emrServerless = AWSEMRServerlessClientBuilder.standard().withRegion(testRegion).build()
+
+    uploadJarsToS3(s3Client)
+
+    val jobRunRequest = startJobRun(
+      "SELECT 1",
+      testServerlessHost,
+      "aoss",
+      conf("spark.datasource.flint.write.refresh_policy", "false")
+    )
+
+    val jobRunResponse = emrServerless.startJobRun(jobRunRequest)
+
+    verifyJobSucceed(emrServerless, jobRunResponse.getJobRunId)
+  }
+
+  private def verifyJobSucceed(emrServerless: AWSEMRServerless, jobRunId: String): Unit = {
+    val startTime = System.currentTimeMillis()
+    val timeout = 5.minutes.toMillis
+    var jobState = "STARTING"
+
+    while (System.currentTimeMillis() - startTime < timeout
+      && (jobState != "FAILED" && jobState != "SUCCESS")) {
+      Thread.sleep(30000)
+      val request = new GetJobRunRequest()
+        .withApplicationId(testAppId)
+        .withJobRunId(jobRunId)
+      jobState = emrServerless.getJobRun(request).getJobRun.getState
+      logInfo(s"Current job state: $jobState at ${System.currentTimeMillis()}")
+    }
+    jobState shouldBe "SUCCESS"
+  }
+
+  private def startJobRun(query: String, host: String, authServiceName: String, additionalParams: String*) = {
+    new StartJobRunRequest()
+      .withApplicationId(testAppId)
+      .withExecutionRoleArn(testExecutionRole)
+      .withName(s"integration-${authServiceName}-${LocalDateTime.now()}")
+      .withJobDriver(new JobDriver()
+        .withSparkSubmit(new SparkSubmit()
+          .withEntryPoint(s"s3://$testS3CodeBucket/$testS3CodePrefix/sql-job.jar")
+          .withEntryPointArguments(testResultIndex)
+          .withSparkSubmitParameters(
+            join(
+              clazz("org.apache.spark.sql.FlintJob"),
+              jars(s"s3://$testS3CodeBucket/$testS3CodePrefix/extension.jar", s"s3://$testS3CodeBucket/$testS3CodePrefix/ppl.jar"),
+              conf("spark.datasource.flint.host", host),
+              conf("spark.datasource.flint.port", s"$testPort"),
+              conf("spark.datasource.flint.scheme", testScheme),
+              conf("spark.datasource.flint.auth", testAuth),
+              conf("spark.datasource.flint.auth.servicename", authServiceName),
+              conf("spark.sql.catalog.glue", "org.opensearch.sql.FlintDelegatingSessionCatalog"),
+              conf("spark.flint.datasource.name", "glue"),
+              conf("spark.flint.job.query", quote(query)),
+              conf("spark.hadoop.hive.metastore.client.factory.class", "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"),
+              join(additionalParams: _*)
+            )
+          )
+        )
+      )
+  }
+
+  private def join(params: String*): String = params.mkString(" ")
+
+  private def clazz(clazz: String): String = s"--class $clazz"
+
+  private def jars(jars: String*): String = s"--jars ${jars.mkString(",")}"
+
+  private def quote(str: String): String = "\"" + str + "\""
+
+  private def conf(name: String, value: String): String = s"--conf $name=$value"
+
+  private def uploadJarsToS3(s3Client: AmazonS3) = {
     val appJarPath =
       sys.props.getOrElse("appJar", throw new IllegalArgumentException("appJar not set"))
     val extensionJarPath = sys.props.getOrElse(
@@ -51,52 +137,14 @@ class AWSEmrServerlessAccessTestSuite
     s3Client.putObject(
       testS3CodeBucket,
       s"$testS3CodePrefix/sql-job.jar",
-      new java.io.File(appJarPath))
+      new File(appJarPath))
     s3Client.putObject(
       testS3CodeBucket,
       s"$testS3CodePrefix/extension.jar",
-      new java.io.File(extensionJarPath))
+      new File(extensionJarPath))
     s3Client.putObject(
       testS3CodeBucket,
       s"$testS3CodePrefix/ppl.jar",
-      new java.io.File(pplJarPath))
-
-    val jobRunRequest = new StartJobRunRequest()
-      .withApplicationId(testAppId)
-      .withExecutionRoleArn(testExecutionRole)
-      .withName(s"integration-${LocalDateTime.now()}")
-      .withJobDriver(new JobDriver()
-        .withSparkSubmit(new SparkSubmit()
-          .withEntryPoint(s"s3://$testS3CodeBucket/$testS3CodePrefix/sql-job.jar")
-          .withEntryPointArguments(testResultIndex)
-          .withSparkSubmitParameters(s"--class org.apache.spark.sql.FlintJob --jars " +
-            s"s3://$testS3CodeBucket/$testS3CodePrefix/extension.jar," +
-            s"s3://$testS3CodeBucket/$testS3CodePrefix/ppl.jar " +
-            s"--conf spark.datasource.flint.host=$testHost " +
-            s"--conf spark.datasource.flint.port=-1  " +
-            s"--conf spark.datasource.flint.scheme=$testScheme  " +
-            s"--conf spark.datasource.flint.auth=$testAuth " +
-            s"--conf spark.sql.catalog.glue=org.opensearch.sql.FlintDelegatingSessionCatalog  " +
-            s"--conf spark.flint.datasource.name=glue " +
-            s"""--conf spark.flint.job.query="SELECT 1" """ +
-            s"--conf spark.hadoop.hive.metastore.client.factory.class=com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory")))
-
-    val jobRunResponse = emrServerless.startJobRun(jobRunRequest)
-
-    val startTime = System.currentTimeMillis()
-    val timeout = 5.minutes.toMillis
-    var jobState = "STARTING"
-
-    while (System.currentTimeMillis() - startTime < timeout
-      && (jobState != "FAILED" && jobState != "SUCCESS")) {
-      Thread.sleep(30000)
-      val request = new GetJobRunRequest()
-        .withApplicationId(testAppId)
-        .withJobRunId(jobRunResponse.getJobRunId)
-      jobState = emrServerless.getJobRun(request).getJobRun.getState
-      logInfo(s"Current job state: $jobState at ${System.currentTimeMillis()}")
-    }
-
-    jobState shouldBe "SUCCESS"
+      new File(pplJarPath))
   }
 }

--- a/integ-test/src/integration/scala/org/apache/spark/sql/FlintREPLITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/sql/FlintREPLITSuite.scala
@@ -118,10 +118,8 @@ class FlintREPLITSuite extends SparkFunSuite with OpenSearchSuite with JobTest {
 
     flintClient = new FlintOpenSearchClient(new FlintOptions(openSearchOptions.asJava));
     osClient = new OSClient(new FlintOptions(openSearchOptions.asJava))
-    updater = new OpenSearchUpdater(
-      requestIndex,
-      new FlintOpenSearchClient(new FlintOptions(openSearchOptions.asJava)))
-
+    val options = new FlintOptions(openSearchOptions.asJava)
+    updater = new OpenSearchUpdater(requestIndex, new FlintOpenSearchClient(options), options)
   }
 
   override def afterEach(): Unit = {

--- a/integ-test/src/integration/scala/org/opensearch/flint/core/OpenSearchUpdaterSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/core/OpenSearchUpdaterSuite.scala
@@ -32,9 +32,8 @@ class OpenSearchUpdaterSuite extends OpenSearchTransactionSuite with Matchers {
   override def beforeAll(): Unit = {
     super.beforeAll()
     flintClient = new FlintOpenSearchClient(new FlintOptions(openSearchOptions.asJava));
-    updater = new OpenSearchUpdater(
-      testMetaLogIndex,
-      new FlintOpenSearchClient(new FlintOptions(openSearchOptions.asJava)))
+    val options = new FlintOptions(openSearchOptions.asJava)
+    updater = new OpenSearchUpdater(testMetaLogIndex, new FlintOpenSearchClient(options), options)
   }
 
   test("upsert flintJob should success") {

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -129,11 +129,14 @@ trait FlintJobExecutor {
     builder.getOrCreate()
   }
 
-  private def writeData(resultData: DataFrame, resultIndex: String): Unit = {
+  private def writeData(
+      resultData: DataFrame,
+      resultIndex: String,
+      refreshPolicy: String): Unit = {
     try {
       resultData.write
         .format("flint")
-        .option(REFRESH_POLICY.optionKey, "wait_for")
+        .option(REFRESH_POLICY.optionKey, refreshPolicy)
         .mode("append")
         .save(resultIndex)
       IRestHighLevelClient.recordOperationSuccess(
@@ -160,11 +163,12 @@ trait FlintJobExecutor {
       resultData: DataFrame,
       resultIndex: String,
       osClient: OSClient): Unit = {
+    val refreshPolicy = osClient.flintOptions.getRefreshPolicy;
     if (osClient.doesIndexExist(resultIndex)) {
-      writeData(resultData, resultIndex)
+      writeData(resultData, resultIndex, refreshPolicy)
     } else {
       createResultIndex(osClient, resultIndex, resultIndexMapping)
-      writeData(resultData, resultIndex)
+      writeData(resultData, resultIndex, refreshPolicy)
     }
   }
 

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/OSClient.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/OSClient.scala
@@ -111,7 +111,7 @@ class OSClient(val flintOptions: FlintOptions) extends Logging {
   }
 
   def createUpdater(indexName: String): OpenSearchUpdater =
-    new OpenSearchUpdater(indexName, flintClient)
+    new OpenSearchUpdater(indexName, flintClient, flintOptions)
 
   def getDoc(osIndexName: String, id: String): GetResponse = {
     using(flintClient.createClient()) { client =>


### PR DESCRIPTION
### Description
- Use refresh policy from config when calling OpenSearch APIs
- This will allow Flint to connect to OpenSearch Serverless collection. It originally use WAIT_FOR refresh policy for some requests and it failed against Serverless collection since it only accept NONE refresh policy.
- To use Serverless collection as index store, `spark.datasource.flint.write.refresh_policy=false` config needs to be specified.
- Added integration test for Serverless

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
