### PR TITLE
Add statement timeout

### DIFF
--- a/flint-commons/src/main/scala/org/opensearch/flint/common/model/ContextualDataStore.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/model/ContextualDataStore.scala
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.flint.data
+package org.opensearch.flint.common.model
 
 /**
  * Provides a mutable map to store and retrieve contextual data using key-value pairs.

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/model/FlintStatement.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/model/FlintStatement.scala
@@ -5,6 +5,8 @@
 
 package org.opensearch.flint.common.model
 
+import java.util.Locale
+
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.JsonAST.JString
 import org.json4s.native.JsonMethods.parse
@@ -53,10 +55,13 @@ class FlintStatement(
   def fail(): Unit = state = StatementStates.FAILED
   def timeout(): Unit = state = StatementStates.TIMEOUT
 
-  def isRunning: Boolean = state == StatementStates.RUNNING
-  def isComplete: Boolean = state == StatementStates.SUCCESS
-  def isFailed: Boolean = state == StatementStates.FAILED
-  def isWaiting: Boolean = state == StatementStates.WAITING
+  def isRunning: Boolean = state.equalsIgnoreCase(StatementStates.RUNNING)
+
+  def isComplete: Boolean = state.equalsIgnoreCase(StatementStates.SUCCESS)
+
+  def isFailed: Boolean = state.equalsIgnoreCase(StatementStates.FAILED)
+
+  def isWaiting: Boolean = state.equalsIgnoreCase(StatementStates.WAITING)
 
   // Does not include context, which could contain sensitive information.
   override def toString: String =
@@ -69,7 +74,7 @@ object FlintStatement {
 
   def deserialize(statement: String): FlintStatement = {
     val meta = parse(statement)
-    val state = (meta \ "state").extract[String]
+    val state = (meta \ "state").extract[String].toLowerCase(Locale.ROOT)
     val query = (meta \ "query").extract[String]
     val statementId = (meta \ "statementId").extract[String]
     val queryId = (meta \ "queryId").extract[String]
@@ -85,6 +90,8 @@ object FlintStatement {
   def serialize(flintStatement: FlintStatement): String = {
     // we only need to modify state and error
     Serialization.write(
-      Map("state" -> flintStatement.state, "error" -> flintStatement.error.getOrElse("")))
+      Map(
+        "state" -> flintStatement.state.toLowerCase(Locale.ROOT),
+        "error" -> flintStatement.error.getOrElse("")))
   }
 }

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/model/FlintStatement.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/model/FlintStatement.scala
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.flint.data
+package org.opensearch.flint.common.model
 
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.JsonAST.JString
@@ -14,6 +14,7 @@ object StatementStates {
   val RUNNING = "running"
   val SUCCESS = "success"
   val FAILED = "failed"
+  val TIMEOUT = "timeout"
   val WAITING = "waiting"
 }
 
@@ -50,6 +51,8 @@ class FlintStatement(
   def running(): Unit = state = StatementStates.RUNNING
   def complete(): Unit = state = StatementStates.SUCCESS
   def fail(): Unit = state = StatementStates.FAILED
+  def timeout(): Unit = state = StatementStates.TIMEOUT
+
   def isRunning: Boolean = state == StatementStates.RUNNING
   def isComplete: Boolean = state == StatementStates.SUCCESS
   def isFailed: Boolean = state == StatementStates.FAILED

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/model/InteractiveSession.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/model/InteractiveSession.scala
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.flint.data
+package org.opensearch.flint.common.model
 
 import java.util.{Map => JavaMap}
 
@@ -16,9 +16,8 @@ import org.json4s.native.Serialization
 
 object SessionStates {
   val RUNNING = "running"
-  val COMPLETE = "complete"
-  val FAILED = "failed"
-  val WAITING = "waiting"
+  val DEAD = "dead"
+  val FAIL = "fail"
 }
 
 /**
@@ -56,10 +55,13 @@ class InteractiveSession(
     extends ContextualDataStore {
   context = sessionContext // Initialize the context from the constructor
 
+  def running(): Unit = state = SessionStates.RUNNING
+  def complete(): Unit = state = SessionStates.DEAD
+  def fail(): Unit = state = SessionStates.FAIL
+
   def isRunning: Boolean = state == SessionStates.RUNNING
-  def isComplete: Boolean = state == SessionStates.COMPLETE
-  def isFailed: Boolean = state == SessionStates.FAILED
-  def isWaiting: Boolean = state == SessionStates.WAITING
+  def isComplete: Boolean = state == SessionStates.DEAD
+  def isFail: Boolean = state == SessionStates.FAIL
 
   override def toString: String = {
     val excludedJobIdsStr = excludedJobIds.mkString("[", ", ", "]")

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/model/InteractiveSession.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/model/InteractiveSession.scala
@@ -5,7 +5,7 @@
 
 package org.opensearch.flint.common.model
 
-import java.util.{Map => JavaMap}
+import java.util.{Locale, Map => JavaMap}
 
 import scala.collection.JavaConverters._
 
@@ -59,9 +59,11 @@ class InteractiveSession(
   def complete(): Unit = state = SessionStates.DEAD
   def fail(): Unit = state = SessionStates.FAIL
 
-  def isRunning: Boolean = state == SessionStates.RUNNING
-  def isComplete: Boolean = state == SessionStates.DEAD
-  def isFail: Boolean = state == SessionStates.FAIL
+  def isRunning: Boolean = state.equalsIgnoreCase(SessionStates.RUNNING)
+
+  def isComplete: Boolean = state.equalsIgnoreCase(SessionStates.DEAD)
+
+  def isFail: Boolean = state.equalsIgnoreCase(SessionStates.FAIL)
 
   override def toString: String = {
     val excludedJobIdsStr = excludedJobIds.mkString("[", ", ", "]")
@@ -79,7 +81,7 @@ object InteractiveSession {
   def deserialize(job: String): InteractiveSession = {
     val meta = parse(job)
     val applicationId = (meta \ "applicationId").extract[String]
-    val state = (meta \ "state").extract[String]
+    val state = (meta \ "state").extract[String].toLowerCase(Locale.ROOT)
     val jobId = (meta \ "jobId").extract[String]
     val sessionId = (meta \ "sessionId").extract[String]
     val lastUpdateTime = (meta \ "lastUpdateTime").extract[Long]
@@ -118,7 +120,7 @@ object InteractiveSession {
     val scalaSource = source.asScala
 
     val applicationId = scalaSource("applicationId").asInstanceOf[String]
-    val state = scalaSource("state").asInstanceOf[String]
+    val state = scalaSource("state").asInstanceOf[String].toLowerCase(Locale.ROOT)
     val jobId = scalaSource("jobId").asInstanceOf[String]
     val sessionId = scalaSource("sessionId").asInstanceOf[String]
     val lastUpdateTime = scalaSource("lastUpdateTime").asInstanceOf[Long]
@@ -180,7 +182,7 @@ object InteractiveSession {
       "sessionId" -> job.sessionId,
       "error" -> job.error.getOrElse(""),
       "applicationId" -> job.applicationId,
-      "state" -> job.state,
+      "state" -> job.state.toLowerCase(Locale.ROOT),
       // update last update time
       "lastUpdateTime" -> currentTime,
       // Convert a Seq[String] into a comma-separated string, such as "id1,id2".

--- a/flint-commons/src/test/scala/org/opensearch/flint/common/model/InteractiveSessionTest.scala
+++ b/flint-commons/src/test/scala/org/opensearch/flint/common/model/InteractiveSessionTest.scala
@@ -21,7 +21,7 @@ class InteractiveSessionTest extends SparkFunSuite with Matchers {
     instance.applicationId shouldBe "app-123"
     instance.jobId shouldBe "job-456"
     instance.sessionId shouldBe "session-789"
-    instance.state shouldBe "RUNNING"
+    instance.state shouldBe "running"
     instance.lastUpdateTime shouldBe 1620000000000L
     instance.jobStartTime shouldBe 1620000001000L
     instance.excludedJobIds should contain allOf ("job-101", "job-202")
@@ -44,7 +44,7 @@ class InteractiveSessionTest extends SparkFunSuite with Matchers {
     json should include(""""applicationId":"app-123"""")
     json should not include (""""jobId":"job-456"""")
     json should include(""""sessionId":"session-789"""")
-    json should include(""""state":"RUNNING"""")
+    json should include(""""state":"running"""")
     json should include(s""""lastUpdateTime":$currentTime""")
     json should include(
       """"excludeJobIds":"job-101,job-202""""
@@ -149,7 +149,7 @@ class InteractiveSessionTest extends SparkFunSuite with Matchers {
     instance.applicationId shouldBe "app-123"
     instance.jobId shouldBe "job-456"
     instance.sessionId shouldBe "session-789"
-    instance.state shouldBe "RUNNING"
+    instance.state shouldBe "running"
     instance.lastUpdateTime shouldBe 1620000000000L
     instance.jobStartTime shouldBe 0L // Default or expected value for missing jobStartTime
     instance.excludedJobIds should contain allOf ("job-101", "job-202")

--- a/flint-commons/src/test/scala/org/opensearch/flint/common/model/InteractiveSessionTest.scala
+++ b/flint-commons/src/test/scala/org/opensearch/flint/common/model/InteractiveSessionTest.scala
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.flint.data
+package org.opensearch.flint.common.model
 
 import java.util.{HashMap => JavaHashMap}
 

--- a/integ-test/src/integration/scala/org/apache/spark/sql/FlintREPLITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/sql/FlintREPLITSuite.scala
@@ -15,9 +15,9 @@ import scala.util.control.Breaks.{break, breakable}
 
 import org.opensearch.OpenSearchStatusException
 import org.opensearch.flint.OpenSearchSuite
+import org.opensearch.flint.common.model.{FlintStatement, InteractiveSession}
 import org.opensearch.flint.core.{FlintClient, FlintOptions}
 import org.opensearch.flint.core.storage.{FlintOpenSearchClient, FlintReader, OpenSearchUpdater}
-import org.opensearch.flint.data.{FlintStatement, InteractiveSession}
 import org.opensearch.search.sort.SortOrder
 
 import org.apache.spark.SparkFunSuite

--- a/integ-test/src/integration/scala/org/opensearch/flint/core/OpenSearchUpdaterSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/core/OpenSearchUpdaterSuite.scala
@@ -10,8 +10,8 @@ import scala.collection.JavaConverters.mapAsJavaMapConverter
 import org.opensearch.action.get.{GetRequest, GetResponse}
 import org.opensearch.client.RequestOptions
 import org.opensearch.flint.OpenSearchTransactionSuite
+import org.opensearch.flint.common.model.InteractiveSession
 import org.opensearch.flint.core.storage.{FlintOpenSearchClient, OpenSearchUpdater}
-import org.opensearch.flint.data.InteractiveSession
 import org.scalatest.matchers.should.Matchers
 
 class OpenSearchUpdaterSuite extends OpenSearchTransactionSuite with Matchers {

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -57,7 +57,7 @@ case class JobOperator(
       dataToWrite = Some(mappingCheckResult match {
         case Right(_) => data
         case Left(error) =>
-          getFailedData(spark, dataSource, error, "", query, "", startTime, currentTimeProvider)
+          constructErrorDF(spark, dataSource, "FAILED", error, "", query, "", startTime)
       })
       exceptionThrown = false
     } catch {
@@ -65,11 +65,11 @@ case class JobOperator(
         val error = s"Getting the mapping of index $resultIndex timed out"
         logError(error, e)
         dataToWrite = Some(
-          getFailedData(spark, dataSource, error, "", query, "", startTime, currentTimeProvider))
+          constructErrorDF(spark, dataSource, "TIMEOUT", error, "", query, "", startTime))
       case e: Exception =>
         val error = processQueryException(e)
         dataToWrite = Some(
-          getFailedData(spark, dataSource, error, "", query, "", startTime, currentTimeProvider))
+          constructErrorDF(spark, dataSource, "FAILED", error, "", query, "", startTime))
     } finally {
       cleanUpResources(exceptionThrown, threadPool, dataToWrite, resultIndex, osClient)
     }


### PR DESCRIPTION
### Description
1. Add statement timeout, the dependency change is merged https://github.com/opensearch-project/sql/pull/2724
2. Fix SessionStates to align with https://github.com/opensearch-project/sql/blob/b2403ca4fa1bbba2a1ac8827b6f7aeefe48f9f32/async-query-core/src/main/java/org/opensearch/sql/spark/execution/session/SessionState.java#L18-L21
3. Move data model from flint.data to flint.common.model

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
