### PR TITLE
Lazy clean up dangling index metadata log entry

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
@@ -159,18 +159,22 @@ class FlintSparkIndexMonitor(
     override def run(): Unit = {
       logInfo(s"Scheduler trigger index monitor task for $indexName")
       try {
-        if (isStreamingJobActive(indexName)) {
-          if (flintClient.exists(indexName)) {
-            logInfo("Streaming job is still active")
+        val isJobActive = isStreamingJobActive(indexName)
+        val indexExists = flintClient.exists(indexName)
+
+        (isJobActive, indexExists) match {
+          case (true, true) =>
+            logInfo("Streaming job is active and index exists")
             flintMetadataLogService.recordHeartbeat(indexName)
-          } else {
-            logWarning("Streaming job is active but data is deleted")
+
+          case (true, false) =>
+            logWarning("Streaming job is active but index is deleted")
             stopStreamingJobAndMonitor(indexName)
-          }
-        } else {
-          logError("Streaming job is not active. Cancelling monitor task")
-          stopMonitor(indexName)
-          logInfo("Index monitor task is cancelled")
+
+          case (false, _) =>
+            logError("Streaming job is not active. Cancelling monitor task")
+            stopMonitor(indexName)
+            logInfo("Index monitor task is cancelled")
         }
         errorCnt = 0 // Reset counter if no error
       } catch {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexMonitor.scala
@@ -160,10 +160,10 @@ class FlintSparkIndexMonitor(
       logInfo(s"Scheduler trigger index monitor task for $indexName")
       try {
         if (isStreamingJobActive(indexName)) {
-          logInfo("Streaming job is still active")
-          flintMetadataLogService.recordHeartbeat(indexName)
-
-          if (!flintClient.exists(indexName)) {
+          if (flintClient.exists(indexName)) {
+            logInfo("Streaming job is still active")
+            flintMetadataLogService.recordHeartbeat(indexName)
+          } else {
             logWarning("Streaming job is active but data is deleted")
             stopStreamingJobAndMonitor(indexName)
           }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkTransactionSupport.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkTransactionSupport.scala
@@ -6,6 +6,8 @@
 package org.opensearch.flint.spark
 
 import org.opensearch.flint.common.metadata.log.{FlintMetadataLogService, OptimisticTransaction}
+import org.opensearch.flint.common.metadata.log.OptimisticTransaction.NO_LOG_ENTRY
+import org.opensearch.flint.core.FlintClient
 
 import org.apache.spark.internal.Logging
 
@@ -13,11 +15,13 @@ import org.apache.spark.internal.Logging
  * Provides transaction support with proper error handling and logging capabilities.
  *
  * @note
- *   This trait requires the mixing class to extend Spark's `Logging` to utilize its logging
- *   functionalities. Meanwhile it needs to provide `FlintClient` and data source name so this
- *   trait can help create transaction context.
+ *   This trait requires the mixing class to provide both `FlintClient` and
+ *   `FlintMetadataLogService` so this trait can help create transaction context.
  */
-trait FlintSparkTransactionSupport { self: Logging =>
+trait FlintSparkTransactionSupport extends Logging {
+
+  /** Flint client defined in the mixing class */
+  protected def flintClient: FlintClient
 
   /** Flint metadata log service defined in the mixing class */
   protected def flintMetadataLogService: FlintMetadataLogService
@@ -25,7 +29,9 @@ trait FlintSparkTransactionSupport { self: Logging =>
   /**
    * Executes a block of code within a transaction context, handling and logging errors
    * appropriately. This method logs the start and completion of the transaction and captures any
-   * exceptions that occur, enriching them with detailed error messages before re-throwing.
+   * exceptions that occur, enriching them with detailed error messages before re-throwing. If the
+   * index data is missing (excluding index creation actions), the operation is bypassed, and any
+   * dangling metadata log entries are cleaned up.
    *
    * @param indexName
    *   the name of the index on which the operation is performed
@@ -39,19 +45,38 @@ trait FlintSparkTransactionSupport { self: Logging =>
    * @tparam T
    *   the type of the result produced by the operation block
    * @return
-   *   the result of the operation block
+   *   Some(result) of the operation block if the operation is executed, or None if the operation
+   *   execution is bypassed due to missing index data
    */
   def withTransaction[T](indexName: String, opName: String, forceInit: Boolean = false)(
-      opBlock: OptimisticTransaction[T] => T): T = {
+      opBlock: OptimisticTransaction[T] => T): Option[T] = {
     logInfo(s"Starting index operation [$opName $indexName] with forceInit=$forceInit")
     try {
-      // Create transaction (only have side effect if forceInit is true)
-      val tx: OptimisticTransaction[T] =
-        flintMetadataLogService.startTransaction(indexName, forceInit)
+      // Execute the action if data index exists or create index action (indicated by forceInit)
+      if (forceInit || flintClient.exists(indexName)) {
 
-      val result = opBlock(tx)
-      logInfo(s"Index operation [$opName $indexName] complete")
-      result
+        // Create transaction (only have side effect if forceInit is true)
+        val tx: OptimisticTransaction[T] =
+          flintMetadataLogService.startTransaction(indexName, forceInit)
+        val result = opBlock(tx)
+        logInfo(s"Index operation [$opName $indexName] complete")
+        Some(result)
+      } else {
+        /*
+         * If execution reaches this point, it indicates that the Flint index is corrupted.
+         * In such cases, clean up the metadata log, as the index data no longer exists.
+         * There is a very small possibility that users may recreate the index in the
+         * interim, but metadata log get deleted by this cleanup process.
+         */
+        logWarning(
+          s"Bypassing index operation [$opName $indexName] as index data has been deleted")
+        flintMetadataLogService
+          .startTransaction(indexName)
+          .initialLog(_ => true)
+          .finalLog(_ => NO_LOG_ENTRY)
+          .commit(_ => {})
+        None
+      }
     } catch {
       case e: Exception =>
         logError(s"Failed to execute index operation [$opName $indexName]", e)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkTransactionSupport.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkTransactionSupport.scala
@@ -110,12 +110,6 @@ trait FlintSparkTransactionSupport extends Logging {
     isCorrupted
   }
 
-  /*
-   * If execution reaches this point, it indicates that the Flint index is corrupted.
-   * In such cases, clean up the metadata log, as the index data no longer exists.
-   * There is a very small possibility that users may recreate the index in the
-   * interim, but metadata log get deleted by this cleanup process.
-   */
   private def cleanupCorruptedIndex(indexName: String): Unit = {
     flintMetadataLogService
       .startTransaction(indexName)

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkTransactionSupportSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkTransactionSupportSuite.scala
@@ -32,8 +32,11 @@ class FlintSparkTransactionSupportSuite extends FlintSuite with Matchers {
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
+
+    val logEntry = mock[FlintMetadataLog[FlintMetadataLogEntry]]
+    when(logEntry.getLatest).thenReturn(Optional.of(mock[FlintMetadataLogEntry]))
     when(mockFlintMetadataLogService.getIndexMetadataLog(testIndex))
-      .thenReturn(Optional.of(mock[FlintMetadataLog[FlintMetadataLogEntry]]))
+      .thenReturn(Optional.of(logEntry))
   }
 
   override protected def afterEach(): Unit = {

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkTransactionSupportSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkTransactionSupportSuite.scala
@@ -5,40 +5,76 @@
 
 package org.opensearch.flint.spark
 
-import org.mockito.Mockito.{times, verify}
+import org.mockito.Mockito.{never, reset, times, verify, when, RETURNS_DEEP_STUBS}
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogService
+import org.opensearch.flint.core.FlintClient
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.spark.FlintSuite
-import org.apache.spark.internal.Logging
 
 class FlintSparkTransactionSupportSuite extends FlintSuite with Matchers {
 
-  private val mockFlintMetadataLogService: FlintMetadataLogService = mock[FlintMetadataLogService]
+  private val mockFlintClient: FlintClient = mock[FlintClient]
+  private val mockFlintMetadataLogService: FlintMetadataLogService =
+    mock[FlintMetadataLogService](RETURNS_DEEP_STUBS)
   private val testIndex = "test_index"
   private val testOpName = "test operation"
 
   /** Creating a fake FlintSparkTransactionSupport subclass for test */
-  private val transactionSupport = new FlintSparkTransactionSupport with Logging {
+  private val transactionSupport = new FlintSparkTransactionSupport {
+    override protected def flintClient: FlintClient = mockFlintClient
     override protected def flintMetadataLogService: FlintMetadataLogService =
       mockFlintMetadataLogService
   }
 
-  test("with transaction without force initialization") {
-    transactionSupport.withTransaction[Unit](testIndex, testOpName) { _ => }
+  override protected def beforeEach(): Unit = {
+    reset(mockFlintClient, mockFlintMetadataLogService)
+  }
 
+  test("execute transaction without force initialization when index exists") {
+    when(mockFlintClient.exists(testIndex)).thenReturn(true)
+    val result =
+      transactionSupport
+        .withTransaction[Boolean](testIndex, testOpName) { _ => true }
+
+    result shouldBe Some(true)
     verify(mockFlintMetadataLogService, times(1)).startTransaction(testIndex, false)
   }
 
-  test("with transaction with force initialization") {
-    transactionSupport.withTransaction[Unit](testIndex, testOpName, forceInit = true) { _ => }
+  test("execute transaction with force initialization when index exists") {
+    when(mockFlintClient.exists(testIndex)).thenReturn(true)
+    val result =
+      transactionSupport
+        .withTransaction[Boolean](testIndex, testOpName, forceInit = true) { _ => true }
 
+    result shouldBe Some(true)
     verify(mockFlintMetadataLogService, times(1)).startTransaction(testIndex, true)
   }
 
-  test("should throw original exception") {
+  test("bypass transaction without force initialization when index does not exist") {
+    when(mockFlintClient.exists(testIndex)).thenReturn(false)
+    val result =
+      transactionSupport
+        .withTransaction[Boolean](testIndex, testOpName) { _ => true }
+
+    result shouldBe None
+  }
+
+  test("execute transaction with force initialization even if index does not exist") {
+    when(mockFlintClient.exists(testIndex)).thenReturn(false)
+    val result =
+      transactionSupport
+        .withTransaction[Boolean](testIndex, testOpName, forceInit = true) { _ => true }
+
+    result shouldBe Some(true)
+    verify(mockFlintMetadataLogService, times(1)).startTransaction(testIndex, true)
+  }
+
+  test("propagate original exception thrown within transaction") {
     the[RuntimeException] thrownBy {
+      when(mockFlintClient.exists(testIndex)).thenReturn(true)
+
       transactionSupport.withTransaction[Unit](testIndex, testOpName) { _ =>
         val rootCause = new IllegalArgumentException("Fake root cause")
         val cause = new RuntimeException("Fake cause", rootCause)


### PR DESCRIPTION
### Description

This PR introduces a lazy approach to handling potentially corrupted indices. Previously only `recoverIndex` API has such capability introduced in https://github.com/opensearch-project/opensearch-spark/pull/241 and this PR makes this logic generic across all Flint APIs.

A corrupted index is defined as a Flint index **has an index log entry but no corresponding data index**. Upon the next Flint API call, the system will check for such corrupted indices and perform the necessary cleanup, ensuring that users can recreate indices without encountering errors.

#### Typical Scenario

The most common scenario this PR aims to address is:

1. Users delete OS data index for a Flint index directly
2. Index monitor terminates streaming job if auto refresh enabled
3. Users attempt to create index again
    a. **Before changes**: the creation failed and require to remove the log entry manually
    b. **After changes**: the log entry is cleaned up automatically and creation succeeds

#### Uncommon Scenarios and Handling

After step 1 above, user may rarely attempt to:

1. **Create or vacuum index again concurrently**: Skip corruption check if index in `CREATING` or `VACUUMIGN` state to reduce the possibility of race condition, ensuring log entry won't be removed mistakenly during ongoing operation.
2. **Operate before index monitor terminates streaming job**: If index corrupted, skip heartbeat reporting in index monitor which relies on log entry to reduce potential conflict.

> Note: The changes aim to reduce the possibility of race conditions with best efforts. However, due to the lack of transaction support in OpenSearch, any checks performed before acquiring an optimistic lock are still subject to **"dirty reads."** This means there remains a small possibility of inconsistencies during concurrent operations.

### Example

Prepare corrupted Flint index:

<pre>
# Create an auto refresh Flint index
CREATE SKIPPING INDEX ON glue.default.http_logs (
  year PARTITION
)
WITH (
  auto_refresh = true,
  checkpoint_location = 's3://checkpoint-1'
);

# Delete OS index once all data refreshed
DELETE flint_glue_default_http_logs_skipping_index

# Index monitor detects and terminates streaming job
24/09/30 18:27:43 WARN FlintSparkIndexMonitor: Streaming job is active but data is deleted
24/09/30 18:27:43 INFO FlintSparkIndexMonitor: Terminating streaming job and index monitor for
 flint_glue_default_http_logs_skipping_index

# Flint index log entry is dangling in failed state
GET .query_execution_request_glue/_search
          "version": "1.0",
          "latestId": "ZmxpbnRfZ2x1ZV9kZWZhdWx0X2h0dHBfbG9nc19za2lwcGluZ19pbmRleA==",
          "type": "flintindexstate",
          <b>"state": "failed",</b>
          "applicationId": "XXX",
          "jobId": "YYY",
          "dataSourceName": "glue",
          "jobStartTime": 1727720050924,
          "lastUpdateTime": 1727720863284,
          "error": ""
        }
</pre>

Verify cleanup logic works:

<pre>
# Attempt to create the same index again
CREATE SKIPPING INDEX ON glue.default.http_logs (
  year PARTITION
)
WITH (
  auto_refresh = true,
  checkpoint_location = 's3://checkpoint-2'
);

# Index metadata log entry is cleaned up
24/09/30 18:34:35 INFO FlintSpark: Starting index operation 
[Create Flint index flint_glue_default_http_logs_skipping_index] with forceInit=true
<b>24/09/30 18:34:35 WARN FlintSpark: 
 Cleaning up corrupted index:
 - logEntryExists [true]
 - dataIndexExists [false]
 - isCreatingOrVacuuming [false]</b>
24/09/30 18:34:39 INFO FlintSpark: Index operation
[Create Flint index flint_glue_default_http_logs_skipping_index] complete

GET .query_execution_request_glue/_search
          "version": "1.0",
          "latestId": "ZmxpbnRfZ2x1ZV9kZWZhdWx0X2h0dHBfbG9nc19za2lwcGluZ19pbmRleA==",
          "type": "flintindexstate",
          <b>"state": "refreshing",</b>
          "applicationId": "XXX",
          "jobId": "YYY",
          "dataSourceName": "glue",
          "jobStartTime": 1727721279398,
          "lastUpdateTime": 1727723128616,
          "error": ""
        }
</pre>

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/356

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
