### PR TITLE
Add rate limiter for bulk request

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -527,6 +527,7 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.datasource.flint.write.batch_size`: "The number of documents written to Flint in a single batch request. Default value is Integer.MAX_VALUE.
 - `spark.datasource.flint.write.batch_bytes`: The approximately amount of data in bytes written to Flint in a single batch request. The actual data write to OpenSearch may more than it. Default value is 1mb. The writing process checks after each document whether the total number of documents (docCount) has reached batch_size or the buffer size has surpassed batch_bytes. If either condition is met, the current batch is flushed and the document count resets to zero.
 - `spark.datasource.flint.write.refresh_policy`: default value is false. valid values [NONE(false), IMMEDIATE(true), WAIT_UNTIL(wait_for)]
+- `spark.datasource.flint.write.bulkRequestRateLimitPerNode`: default value is 0, which disables rate limit.
 - `spark.datasource.flint.read.scroll_size`: default value is 100.
 - `spark.datasource.flint.read.scroll_duration`: default value is 5 minutes. scroll context keep alive duration.
 - `spark.datasource.flint.retry.max_retries`: max retries on failed HTTP request. default value is 3. Use 0 to disable retry.

--- a/docs/index.md
+++ b/docs/index.md
@@ -521,13 +521,13 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.datasource.flint.auth.username`: basic auth username.
 - `spark.datasource.flint.auth.password`: basic auth password.
 - `spark.datasource.flint.region`: default is us-west-2. only been used when auth=sigv4
-- `spark.datasource.flint.customAWSCredentialsProvider`: default is empty.   
+- `spark.datasource.flint.customAWSCredentialsProvider`: default is empty.
 - `spark.datasource.flint.write.id_name`: no default value.
 - `spark.datasource.flint.ignore.id_column` : default value is true.
 - `spark.datasource.flint.write.batch_size`: "The number of documents written to Flint in a single batch request. Default value is Integer.MAX_VALUE.
 - `spark.datasource.flint.write.batch_bytes`: The approximately amount of data in bytes written to Flint in a single batch request. The actual data write to OpenSearch may more than it. Default value is 1mb. The writing process checks after each document whether the total number of documents (docCount) has reached batch_size or the buffer size has surpassed batch_bytes. If either condition is met, the current batch is flushed and the document count resets to zero.
 - `spark.datasource.flint.write.refresh_policy`: default value is false. valid values [NONE(false), IMMEDIATE(true), WAIT_UNTIL(wait_for)]
-- `spark.datasource.flint.write.bulkRequestRateLimitPerNode`: default value is 0, which disables rate limit.
+- `spark.datasource.flint.write.bulkRequestRateLimitPerNode`: Rate limit(request/sec) for bulk request per worker node. Only accept integer value. To reduce the traffic less than 1 req/sec, batch_bytes or batch_size should be reduced. Default value is 0, which disables rate limit.
 - `spark.datasource.flint.read.scroll_size`: default value is 100.
 - `spark.datasource.flint.read.scroll_duration`: default value is 5 minutes. scroll context keep alive duration.
 - `spark.datasource.flint.retry.max_retries`: max retries on failed HTTP request. default value is 3. Use 0 to disable retry.

--- a/docs/index.md
+++ b/docs/index.md
@@ -527,7 +527,7 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.datasource.flint.write.batch_size`: "The number of documents written to Flint in a single batch request. Default value is Integer.MAX_VALUE.
 - `spark.datasource.flint.write.batch_bytes`: The approximately amount of data in bytes written to Flint in a single batch request. The actual data write to OpenSearch may more than it. Default value is 1mb. The writing process checks after each document whether the total number of documents (docCount) has reached batch_size or the buffer size has surpassed batch_bytes. If either condition is met, the current batch is flushed and the document count resets to zero.
 - `spark.datasource.flint.write.refresh_policy`: default value is false. valid values [NONE(false), IMMEDIATE(true), WAIT_UNTIL(wait_for)]
-- `spark.datasource.flint.write.bulkRequestRateLimitPerNode`: Rate limit(request/sec) for bulk request per worker node. Only accept integer value. To reduce the traffic less than 1 req/sec, batch_bytes or batch_size should be reduced. Default value is 0, which disables rate limit.
+- `spark.datasource.flint.write.bulkRequestRateLimitPerNode`: [Experimental] Rate limit(request/sec) for bulk request per worker node. Only accept integer value. To reduce the traffic less than 1 req/sec, batch_bytes or batch_size should be reduced. Default value is 0, which disables rate limit.
 - `spark.datasource.flint.read.scroll_size`: default value is 100.
 - `spark.datasource.flint.read.scroll_duration`: default value is 5 minutes. scroll context keep alive duration.
 - `spark.datasource.flint.retry.max_retries`: max retries on failed HTTP request. default value is 3. Use 0 to disable retry.

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -95,11 +95,14 @@ public class FlintOptions implements Serializable {
 
   public static final String DEFAULT_BATCH_BYTES = "1mb";
 
-  public static final String CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS = "spark.datasource.flint.customFlintMetadataLogServiceClass";
+  public static final String CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS = "customFlintMetadataLogServiceClass";
 
   public static final String SUPPORT_SHARD = "read.support_shard";
 
   public static final String DEFAULT_SUPPORT_SHARD = "true";
+
+  public static final String BULK_REQUEST_RATE_LIMIT_PER_NODE = "bulkRequestRateLimitPerNode";
+  public static final String DEFAULT_BULK_REQUEST_RATE_LIMIT_PER_NODE = "0";
 
   public FlintOptions(Map<String, String> options) {
     this.options = options;
@@ -196,5 +199,11 @@ public class FlintOptions implements Serializable {
   public boolean supportShard() {
     return options.getOrDefault(SUPPORT_SHARD, DEFAULT_SUPPORT_SHARD).equalsIgnoreCase(
         DEFAULT_SUPPORT_SHARD);
+  }
+
+  public long getBulkRequestRateLimitPerNode() {
+    System.out.println("####### BULK_REQUEST_RATE_LIMIT_PER_NODE" + options.get(BULK_REQUEST_RATE_LIMIT_PER_NODE));
+    System.out.println("############### options: " + options);
+    return Long.parseLong(options.getOrDefault(BULK_REQUEST_RATE_LIMIT_PER_NODE, DEFAULT_BULK_REQUEST_RATE_LIMIT_PER_NODE));
   }
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -95,7 +95,7 @@ public class FlintOptions implements Serializable {
 
   public static final String DEFAULT_BATCH_BYTES = "1mb";
 
-  public static final String CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS = "customFlintMetadataLogServiceClass";
+  public static final String CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS = "spark.datasource.flint.customFlintMetadataLogServiceClass";
 
   public static final String SUPPORT_SHARD = "read.support_shard";
 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -202,8 +202,6 @@ public class FlintOptions implements Serializable {
   }
 
   public long getBulkRequestRateLimitPerNode() {
-    System.out.println("####### BULK_REQUEST_RATE_LIMIT_PER_NODE" + options.get(BULK_REQUEST_RATE_LIMIT_PER_NODE));
-    System.out.println("############### options: " + options);
     return Long.parseLong(options.getOrDefault(BULK_REQUEST_RATE_LIMIT_PER_NODE, DEFAULT_BULK_REQUEST_RATE_LIMIT_PER_NODE));
   }
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/BulkRequestRateLimiter.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/BulkRequestRateLimiter.java
@@ -1,0 +1,30 @@
+package org.opensearch.flint.core.storage;
+
+import dev.failsafe.RateLimiter;
+import java.time.Duration;
+import java.util.logging.Logger;
+import org.opensearch.flint.core.FlintOptions;
+
+public class BulkRequestRateLimiter {
+  private static final Logger LOG = Logger.getLogger(BulkRequestRateLimiter.class.getName());
+  private RateLimiter<Void> rateLimiter;
+
+  public BulkRequestRateLimiter(FlintOptions flintOptions) {
+    long bulkRequestRateLimitPerNode = flintOptions.getBulkRequestRateLimitPerNode();
+    if (bulkRequestRateLimitPerNode > 0) {
+      LOG.info("Setting rate limit for bulk request to " + bulkRequestRateLimitPerNode + "/sec");
+      this.rateLimiter = RateLimiter.<Void>smoothBuilder(
+          flintOptions.getBulkRequestRateLimitPerNode(),
+          Duration.ofSeconds(1)).build();
+    } else {
+      LOG.info("Rate limit for bulk request was not set.");
+    }
+  }
+
+  // Wait so it won't exceed rate limit. Does nothing if rate limit is not set.
+  public void acquirePermit() throws InterruptedException {
+    if (rateLimiter != null) {
+      this.rateLimiter.acquirePermit();
+    }
+  }
+}

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/BulkRequestRateLimiterHolder.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/BulkRequestRateLimiterHolder.java
@@ -1,0 +1,22 @@
+package org.opensearch.flint.core.storage;
+
+import org.opensearch.flint.core.FlintOptions;
+
+/**
+ * Hold shared instance of BulkRequestRateLimiter. This class is introduced to make
+ * BulkRequestRateLimiter testable and share single instance.
+ */
+public class BulkRequestRateLimiterHolder {
+
+  private static BulkRequestRateLimiter instance;
+
+  private BulkRequestRateLimiterHolder() {}
+
+  public synchronized static BulkRequestRateLimiter getBulkRequestRateLimiter(
+      FlintOptions flintOptions) {
+    if (instance == null) {
+      instance = new BulkRequestRateLimiter(flintOptions);
+    }
+    return instance;
+  }
+}

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchClientUtils.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchClientUtils.java
@@ -33,7 +33,7 @@ public class OpenSearchClientUtils {
   /**
    * Metadata log index name prefix
    */
-  public final static String META_LOG_NAME_PREFIX = "query_execution_request";
+  public final static String META_LOG_NAME_PREFIX = ".query_execution_request";
 
   /**
    * Used in IT.

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchClientUtils.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchClientUtils.java
@@ -33,7 +33,7 @@ public class OpenSearchClientUtils {
   /**
    * Metadata log index name prefix
    */
-  public final static String META_LOG_NAME_PREFIX = ".query_execution_request";
+  public final static String META_LOG_NAME_PREFIX = "query_execution_request";
 
   /**
    * Used in IT.
@@ -58,7 +58,8 @@ public class OpenSearchClientUtils {
   }
 
   public static IRestHighLevelClient createClient(FlintOptions options) {
-    return new RestHighLevelClientWrapper(createRestHighLevelClient(options));
+    return new RestHighLevelClientWrapper(createRestHighLevelClient(options),
+        BulkRequestRateLimiterHolder.getBulkRequestRateLimiter(options));
   }
 
   private static RestClientBuilder configureSigV4Auth(RestClientBuilder restClientBuilder, FlintOptions options) {

--- a/flint-core/src/test/scala/org/opensearch/flint/core/storage/BulkRequestRateLimiterHolderTest.java
+++ b/flint-core/src/test/scala/org/opensearch/flint/core/storage/BulkRequestRateLimiterHolderTest.java
@@ -1,0 +1,20 @@
+package org.opensearch.flint.core.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.opensearch.flint.core.FlintOptions;
+
+class BulkRequestRateLimiterHolderTest {
+  FlintOptions flintOptions = new FlintOptions(ImmutableMap.of());
+  @Test
+  public void getBulkRequestRateLimiter() {
+    BulkRequestRateLimiter instance0 = BulkRequestRateLimiterHolder.getBulkRequestRateLimiter(flintOptions);
+    BulkRequestRateLimiter instance1 = BulkRequestRateLimiterHolder.getBulkRequestRateLimiter(flintOptions);
+
+    assertNotNull(instance0);
+    assertEquals(instance0, instance1);
+  }
+}

--- a/flint-core/src/test/scala/org/opensearch/flint/core/storage/BulkRequestRateLimiterTest.java
+++ b/flint-core/src/test/scala/org/opensearch/flint/core/storage/BulkRequestRateLimiterTest.java
@@ -1,0 +1,46 @@
+package org.opensearch.flint.core.storage;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.opensearch.flint.core.FlintOptions;
+
+class BulkRequestRateLimiterTest {
+  FlintOptions flintOptionsWithRateLimit = new FlintOptions(ImmutableMap.of(FlintOptions.BULK_REQUEST_RATE_LIMIT_PER_NODE, "1"));
+  FlintOptions flintOptionsWithoutRateLimit = new FlintOptions(ImmutableMap.of(FlintOptions.BULK_REQUEST_RATE_LIMIT_PER_NODE, "0"));
+
+  @Test
+  void acquirePermitWithRateConfig() throws Exception {
+    BulkRequestRateLimiter limiter = new BulkRequestRateLimiter(flintOptionsWithRateLimit);
+
+    assertTrue(timer(() -> {
+      limiter.acquirePermit();
+      limiter.acquirePermit();
+    }) >= 1000);
+  }
+
+  @Test
+  void acquirePermitWithoutRateConfig() throws Exception {
+    BulkRequestRateLimiter limiter = new BulkRequestRateLimiter(flintOptionsWithoutRateLimit);
+
+    assertTrue(timer(() -> {
+      limiter.acquirePermit();
+      limiter.acquirePermit();
+    }) < 100);
+  }
+
+  private interface Procedure {
+    void run() throws Exception;
+  }
+
+  private long timer(Procedure procedure) throws Exception {
+    long start = System.currentTimeMillis();
+    procedure.run();
+    long end = System.currentTimeMillis();
+    return end - start;
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -139,7 +139,7 @@ object FlintSparkConf {
   val BULK_REQUEST_RATE_LIMIT_PER_NODE =
     FlintConfig(s"spark.datasource.flint.${FlintOptions.BULK_REQUEST_RATE_LIMIT_PER_NODE}")
       .datasourceOption()
-      .doc("Rate limit (requests/sec) for bulk request per worker node. Rate won't be limited by default")
+      .doc("[Experimental] Rate limit (requests/sec) for bulk request per worker node. Rate won't be limited by default")
       .createWithDefault(FlintOptions.DEFAULT_BULK_REQUEST_RATE_LIMIT_PER_NODE)
 
   val RETRYABLE_HTTP_STATUS_CODES =

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -136,6 +136,12 @@ object FlintSparkConf {
     .doc("max retries on failed HTTP request, 0 means retry is disabled, default is 3")
     .createWithDefault(String.valueOf(FlintRetryOptions.DEFAULT_MAX_RETRIES))
 
+  val BULK_REQUEST_RATE_LIMIT_PER_NODE =
+    FlintConfig(s"spark.datasource.flint.${FlintOptions.BULK_REQUEST_RATE_LIMIT_PER_NODE}")
+      .datasourceOption()
+      .doc("Rate limit (requests/sec) for bulk request per worker node. Rate won't be limited by default")
+      .createWithDefault(FlintOptions.DEFAULT_BULK_REQUEST_RATE_LIMIT_PER_NODE)
+
   val RETRYABLE_HTTP_STATUS_CODES =
     FlintConfig(s"spark.datasource.flint.${FlintRetryOptions.RETRYABLE_HTTP_STATUS_CODES}")
       .datasourceOption()
@@ -187,7 +193,7 @@ object FlintSparkConf {
       .doc("data source name")
       .createOptional()
   val CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS =
-    FlintConfig(FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS)
+    FlintConfig(s"spark.datasource.flint.${FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS}")
       .datasourceOption()
       .doc("custom Flint metadata log service class")
       .createOptional()
@@ -275,6 +281,7 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
       AUTH,
       MAX_RETRIES,
       RETRYABLE_HTTP_STATUS_CODES,
+      BULK_REQUEST_RATE_LIMIT_PER_NODE,
       REGION,
       CUSTOM_AWS_CREDENTIALS_PROVIDER,
       SERVICE_NAME,

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -193,7 +193,7 @@ object FlintSparkConf {
       .doc("data source name")
       .createOptional()
   val CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS =
-    FlintConfig(s"spark.datasource.flint.${FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS}")
+    FlintConfig(FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS)
       .datasourceOption()
       .doc("custom Flint metadata log service class")
       .createOptional()

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -9,6 +9,7 @@ import java.util.Optional
 
 import scala.collection.JavaConverters._
 
+import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.http.FlintRetryOptions._
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
@@ -61,6 +62,17 @@ class FlintSparkConfSuite extends FlintSuite {
     retryOptions.getMaxRetries shouldBe 5
     retryOptions.getRetryableHttpStatusCodes shouldBe "429,502,503,504"
     retryOptions.getRetryableExceptionClassNames.get() shouldBe "java.net.ConnectException"
+  }
+
+  test("test bulkRequestRateLimitPerNode default value") {
+    val options = FlintSparkConf().flintOptions()
+    options.getBulkRequestRateLimitPerNode shouldBe 0
+  }
+
+  test("test specified bulkRequestRateLimitPerNode") {
+    val options = FlintSparkConf(
+      Map("bulkRequestRateLimitPerNode" -> "5").asJava).flintOptions()
+    options.getBulkRequestRateLimitPerNode shouldBe 5
   }
 
   test("test metadata access AWS credentials provider option") {

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -70,8 +70,7 @@ class FlintSparkConfSuite extends FlintSuite {
   }
 
   test("test specified bulkRequestRateLimitPerNode") {
-    val options = FlintSparkConf(
-      Map("bulkRequestRateLimitPerNode" -> "5").asJava).flintOptions()
+    val options = FlintSparkConf(Map("bulkRequestRateLimitPerNode" -> "5").asJava).flintOptions()
     options.getBulkRequestRateLimitPerNode shouldBe 5
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -54,7 +54,8 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
   }
 
   test("should fail to build metadata log service if class name doesn't exist") {
-    val options = openSearchOptions + (FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS -> "dummy")
+    val options =
+      openSearchOptions + (FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS -> "dummy")
     val flintOptions = new FlintOptions(options.asJava)
     the[RuntimeException] thrownBy {
       FlintMetadataLogServiceBuilder.build(flintOptions, sparkConf)

--- a/integ-test/src/integration/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -46,7 +46,7 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
 
   test("should build metadata log service") {
     val customOptions =
-      openSearchOptions + (FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS -> "org.opensearch.flint.core.TestMetadataLogService")
+      openSearchOptions + (CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS.key -> "org.opensearch.flint.core.TestMetadataLogService")
     val customFlintOptions = new FlintOptions(customOptions.asJava)
     val customFlintMetadataLogService =
       FlintMetadataLogServiceBuilder.build(customFlintOptions, sparkConf)
@@ -54,8 +54,7 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
   }
 
   test("should fail to build metadata log service if class name doesn't exist") {
-    val options =
-      openSearchOptions + (FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS -> "dummy")
+    val options = openSearchOptions + (CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS.key -> "dummy")
     val flintOptions = new FlintOptions(options.asJava)
     the[RuntimeException] thrownBy {
       FlintMetadataLogServiceBuilder.build(flintOptions, sparkConf)

--- a/integ-test/src/integration/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/core/FlintMetadataLogITSuite.scala
@@ -46,7 +46,7 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
 
   test("should build metadata log service") {
     val customOptions =
-      openSearchOptions + (CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS.key -> "org.opensearch.flint.core.TestMetadataLogService")
+      openSearchOptions + (FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS -> "org.opensearch.flint.core.TestMetadataLogService")
     val customFlintOptions = new FlintOptions(customOptions.asJava)
     val customFlintMetadataLogService =
       FlintMetadataLogServiceBuilder.build(customFlintOptions, sparkConf)
@@ -54,7 +54,7 @@ class FlintMetadataLogITSuite extends OpenSearchTransactionSuite with Matchers {
   }
 
   test("should fail to build metadata log service if class name doesn't exist") {
-    val options = openSearchOptions + (CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS.key -> "dummy")
+    val options = openSearchOptions + (FlintOptions.CUSTOM_FLINT_METADATA_LOG_SERVICE_CLASS -> "dummy")
     val flintOptions = new FlintOptions(options.asJava)
     the[RuntimeException] thrownBy {
       FlintMetadataLogServiceBuilder.build(flintOptions, sparkConf)


### PR DESCRIPTION
### Description
- Add rate limiter for bulk request
- Without rate limit, it would send request until the destination OpenSearch throttle requests (especially when `NONE` refresh policy is used).
- Added config param `spark.datasource.flint.write.bulkRequestRateLimitPerNode` to specify the rate limit per node.
- The default is set to 0, which means no rate limit.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
