### PR TITLE
Bump Flint version to 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Version compatibility:
 | 0.3.0         | 11+         | 3.3.2         | 2.12.14       | 2.13+      |
 | 0.4.0         | 11+         | 3.3.2         | 2.12.14       | 2.13+      |
 | 0.5.0         | 11+         | 3.5.1         | 2.12.14       | 2.17+      |
+| 0.5.1         | 11+         | 3.5.1         | 2.12.14       | 2.17+      |
 
 ## Flint Extension Usage 
 
@@ -54,7 +55,7 @@ sbt clean standaloneCosmetic/publishM2
 ```
 then add org.opensearch:opensearch-spark_2.12 when run spark application, for example,
 ```
-bin/spark-shell --packages "org.opensearch:opensearch-spark_2.12:0.5.0-SNAPSHOT"
+bin/spark-shell --packages "org.opensearch:opensearch-spark_2.12:0.5.1-SNAPSHOT"
 ```
 
 ### PPL Build & Run 
@@ -66,7 +67,7 @@ sbt clean sparkPPLCosmetic/publishM2
 ```
 then add org.opensearch:opensearch-spark_2.12 when run spark application, for example,
 ```
-bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.5.0-SNAPSHOT"
+bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.5.1-SNAPSHOT"
 ```
 
 ## Code of Conduct

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val sparkMinorVersion = sparkVersion.split("\\.").take(2).mkString(".")
 
 ThisBuild / organization := "org.opensearch"
 
-ThisBuild / version := "0.5.0-SNAPSHOT"
+ThisBuild / version := "0.5.1-SNAPSHOT"
 
 ThisBuild / scalaVersion := scala212
 

--- a/docs/PPL-on-Spark.md
+++ b/docs/PPL-on-Spark.md
@@ -34,7 +34,7 @@ sbt clean sparkPPLCosmetic/publishM2
 ```
 then add org.opensearch:opensearch-spark_2.12 when run spark application, for example,
 ```
-bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.5.0-SNAPSHOT"
+bin/spark-shell --packages "org.opensearch:opensearch-spark-ppl_2.12:0.5.1-SNAPSHOT"
 ```
 
 ### PPL Extension Usage
@@ -46,7 +46,7 @@ spark-sql --conf "spark.sql.extensions=org.opensearch.flint.spark.FlintPPLSparkE
 ```
 
 ### Running With both Flint & PPL Extensions
-In order to make use of both flint and ppl extension, one can simply add both jars (`org.opensearch:opensearch-spark-ppl_2.12:0.5.0-SNAPSHOT`,`org.opensearch:opensearch-spark_2.12:0.5.0-SNAPSHOT`) to the cluster's
+In order to make use of both flint and ppl extension, one can simply add both jars (`org.opensearch:opensearch-spark-ppl_2.12:0.5.1-SNAPSHOT`,`org.opensearch:opensearch-spark_2.12:0.5.1-SNAPSHOT`) to the cluster's
 classpath.
 
 Next need to configure both extensions :

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ Currently, Flint metadata is only static configuration without version control a
 
 ```json
 {
-  "version": "0.5.0",
+  "version": "0.5.1",
   "name": "...",
   "kind": "skipping",
   "source": "...",
@@ -697,7 +697,7 @@ For now, only single or conjunct conditions (conditions connected by AND) in WHE
 ### AWS EMR Spark Integration - Using execution role
 Flint use [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html). When running in EMR Spark, Flint use executionRole credentials
 ```
---conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.5.0-SNAPSHOT \
+--conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.5.1-SNAPSHOT \
 --conf spark.jars.repositories=https://aws.oss.sonatype.org/content/repositories/snapshots \
 --conf spark.emr-serverless.driverEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
@@ -739,7 +739,7 @@ Flint use [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJa
 ```
 3. Set the spark.datasource.flint.customAWSCredentialsProvider property with value as com.amazonaws.emr.AssumeRoleAWSCredentialsProvider. Set the environment variable ASSUME_ROLE_CREDENTIALS_ROLE_ARN with the ARN value of CrossAccountRoleB.
 ```
---conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.5.0-SNAPSHOT \
+--conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:0.5.1-SNAPSHOT \
 --conf spark.jars.repositories=https://aws.oss.sonatype.org/content/repositories/snapshots \
 --conf spark.emr-serverless.driverEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/FlintVersion.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/FlintVersion.scala
@@ -19,6 +19,7 @@ object FlintVersion {
   val V_0_3_0: FlintVersion = FlintVersion("0.3.0")
   val V_0_4_0: FlintVersion = FlintVersion("0.4.0")
   val V_0_5_0: FlintVersion = FlintVersion("0.5.0")
+  val V_0_5_1: FlintVersion = FlintVersion("0.5.1")
 
-  def current(): FlintVersion = V_0_5_0
+  def current(): FlintVersion = V_0_5_1
 }


### PR DESCRIPTION
### Description
Bumped Flint version to 0.5.1. Ref: https://github.com/opensearch-project/opensearch-spark/pull/360

### Testing

$ sbt clean assembly
$ find . -name "*-0.5.0-SNAPSHOT.jar"

$ find . -name "*-0.5.1-SNAPSHOT.jar"
```
% find . -name "*-0.5.1-SNAPSHOT.jar"
./integ-test/target/scala-2.12/integ-test-assembly-0.5.1-SNAPSHOT.jar
./spark-sql-application/target/scala-2.12/sql-job-assembly-0.5.1-SNAPSHOT.jar
./flint-spark-integration/target/scala-2.12/flint-spark-integration-assembly-0.5.1-SNAPSHOT.jar
./ppl-spark-integration/target/scala-2.12/ppl-spark-integration-assembly-0.5.1-SNAPSHOT.jar
./flint-commons/target/scala-2.12/flint-commons-assembly-0.5.1-SNAPSHOT.jar
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
