### PR TITLE
Add conf for specifying flint checkpoint location

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -539,6 +539,7 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.flint.optimizer.enabled`: default is true. enable the Flint optimizer for improving query performance.
 - `spark.flint.optimizer.covering.enabled`: default is true. enable the Flint covering index optimizer for improving query performance.
 - `spark.flint.index.hybridscan.enabled`: default is false.
+- `spark.flint.index.checkpointLocation.rootDir`: default is None.
 - `spark.flint.index.checkpoint.mandatory`: default is true.
 - `spark.datasource.flint.socket_timeout_millis`: default value is 60000.
 - `spark.flint.monitor.initialDelaySeconds`: Initial delay in seconds before starting the monitoring task. Default value is 15.

--- a/docs/index.md
+++ b/docs/index.md
@@ -538,8 +538,8 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.datasource.flint.read.support_shard`: default is true. set to false if index does not support shard (AWS OpenSearch Serverless collection). Do not use in production, this setting will be removed in later version. 
 - `spark.flint.optimizer.enabled`: default is true. enable the Flint optimizer for improving query performance.
 - `spark.flint.optimizer.covering.enabled`: default is true. enable the Flint covering index optimizer for improving query performance.
-- `spark.flint.index.hybridscan.enabled`: default is false.
-- `spark.flint.index.checkpointLocation.rootDir`: default is None.
+- `spark.flint.index.hybridscan.enabled`: default is false. 
+- `spark.flint.index.checkpointLocation.rootDir`: default is None. Flint will create a default checkpoint location in format of '<rootDir>/<indexName>/<UUID>' to isolate checkpoint data.
 - `spark.flint.index.checkpoint.mandatory`: default is true.
 - `spark.datasource.flint.socket_timeout_millis`: default value is 60000.
 - `spark.flint.monitor.initialDelaySeconds`: Initial delay in seconds before starting the monitoring task. Default value is 15.

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -167,6 +167,10 @@ object FlintSparkConf {
     .doc("Enable hybrid scan to include latest source data not refreshed to index yet")
     .createWithDefault("false")
 
+  val CHECKPOINT_LOCATION_ROOT_DIR = FlintConfig("spark.flint.index.checkpointLocation.rootDir")
+    .doc("Root directory of a user specified checkpoint location for index refresh")
+    .createOptional()
+
   val CHECKPOINT_MANDATORY = FlintConfig("spark.flint.index.checkpoint.mandatory")
     .doc("Checkpoint location for incremental refresh index will be mandatory if enabled")
     .createWithDefault("true")
@@ -260,6 +264,8 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
     OPTIMIZER_RULE_COVERING_INDEX_ENABLED.readFrom(reader).toBoolean
 
   def isHybridScanEnabled: Boolean = HYBRID_SCAN_ENABLED.readFrom(reader).toBoolean
+
+  def checkpointLocationRootDir: Option[String] = CHECKPOINT_LOCATION_ROOT_DIR.readFrom(reader)
 
   def isCheckpointMandatory: Boolean = CHECKPOINT_MANDATORY.readFrom(reader).toBoolean
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/covering/FlintSparkCoveringIndexAstBuilder.scala
@@ -47,7 +47,7 @@ trait FlintSparkCoveringIndexAstBuilder extends FlintSparkSqlExtensionsVisitor[A
       val ignoreIfExists = ctx.EXISTS() != null
       val indexOptions = visitPropertyList(ctx.propertyList())
       indexBuilder
-        .options(indexOptions)
+        .options(indexOptions, indexName)
         .create(ignoreIfExists)
 
       // Trigger auto refresh if enabled and not using external scheduler

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/mv/FlintSparkMaterializedViewAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/mv/FlintSparkMaterializedViewAstBuilder.scala
@@ -39,14 +39,15 @@ trait FlintSparkMaterializedViewAstBuilder extends FlintSparkSqlExtensionsVisito
 
       val ignoreIfExists = ctx.EXISTS() != null
       val indexOptions = visitPropertyList(ctx.propertyList())
+      val flintIndexName = getFlintIndexName(flint, ctx.mvName)
+
       mvBuilder
-        .options(indexOptions)
+        .options(indexOptions, flintIndexName)
         .create(ignoreIfExists)
 
       // Trigger auto refresh if enabled and not using external scheduler
       if (indexOptions
           .autoRefresh() && SchedulerMode.INTERNAL == indexOptions.schedulerMode()) {
-        val flintIndexName = getFlintIndexName(flint, ctx.mvName)
         flint.refreshIndex(flintIndexName)
       }
       Seq.empty

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSkippingIndexAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/skipping/FlintSparkSkippingIndexAstBuilder.scala
@@ -72,14 +72,15 @@ trait FlintSparkSkippingIndexAstBuilder extends FlintSparkSqlExtensionsVisitor[A
 
       val ignoreIfExists = ctx.EXISTS() != null
       val indexOptions = visitPropertyList(ctx.propertyList())
+      val indexName = getSkippingIndexName(flint, ctx.tableName)
+
       indexBuilder
-        .options(indexOptions)
+        .options(indexOptions, indexName)
         .create(ignoreIfExists)
 
       // Trigger auto refresh if enabled and not using external scheduler
       if (indexOptions
           .autoRefresh() && SchedulerMode.INTERNAL == indexOptions.schedulerMode()) {
-        val indexName = getSkippingIndexName(flint, ctx.tableName)
         flint.refreshIndex(indexName)
       }
       Seq.empty

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -104,7 +104,7 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
       .name(testIndex)
       .onTable(testTable)
       .addIndexColumns("name", "age")
-      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testIndex)
       .create()
 
     val jobId = flint.refreshIndex(testFlintIndex)
@@ -131,7 +131,8 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
             Map(
               "auto_refresh" -> "true",
               "scheduler_mode" -> "external",
-              "checkpoint_location" -> checkpointDir.getAbsolutePath)))
+              "checkpoint_location" -> checkpointDir.getAbsolutePath)),
+          testIndex)
         .create()
 
       val jobId = flint.refreshIndex(testFlintIndex)

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -15,6 +15,7 @@ import org.scalatest.matchers.must.Matchers.defined
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.flint.config.FlintSparkConf
 
 class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
 
@@ -117,6 +118,47 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
 
     val indexData = flint.queryIndex(testFlintIndex)
     checkAnswer(indexData, Seq(Row("Hello", 30), Row("World", 25)))
+
+    val indexOptions = flint.describeIndex(testFlintIndex)
+    indexOptions shouldBe defined
+    indexOptions.get.options.checkpointLocation() shouldBe None
+  }
+
+  test("create covering index with default checkpoint location successfully") {
+    withTempDir { checkpointDir =>
+      conf.setConfString(
+        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key,
+        checkpointDir.getAbsolutePath)
+      flint
+        .coveringIndex()
+        .name(testIndex)
+        .onTable(testTable)
+        .addIndexColumns("name", "age")
+        .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testFlintIndex)
+        .create()
+
+      val jobId = flint.refreshIndex(testFlintIndex)
+      jobId shouldBe defined
+
+      val job = spark.streams.get(jobId.get)
+      failAfter(streamingTimeout) {
+        job.processAllAvailable()
+      }
+
+      val indexData = flint.queryIndex(testFlintIndex)
+      checkAnswer(indexData, Seq(Row("Hello", 30), Row("World", 25)))
+
+      val index = flint.describeIndex(testFlintIndex)
+      index shouldBe defined
+
+      val checkpointLocation = index.get.options.checkpointLocation()
+      assert(checkpointLocation.isDefined, "Checkpoint location should be defined")
+      assert(
+        checkpointLocation.get.contains(testFlintIndex),
+        s"Checkpoint location dir should contain ${testFlintIndex}")
+
+      conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
+    }
   }
 
   test("auto refresh covering index successfully with external scheduler") {

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexJobITSuite.scala
@@ -51,7 +51,7 @@ class FlintSparkIndexJobITSuite extends OpenSearchTransactionSuite with Matchers
       .skippingIndex()
       .onTable(testTable)
       .addPartitions("year")
-      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testIndex)
       .create()
 
     flint.recoverIndex(testIndex) shouldBe true
@@ -65,7 +65,7 @@ class FlintSparkIndexJobITSuite extends OpenSearchTransactionSuite with Matchers
         .skippingIndex()
         .onTable(testTable)
         .addPartitions("year")
-        .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+        .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testIndex)
         .create()
 
       updateLatestLogEntry(
@@ -88,7 +88,7 @@ class FlintSparkIndexJobITSuite extends OpenSearchTransactionSuite with Matchers
         .skippingIndex()
         .onTable(testTable)
         .addPartitions("year")
-        .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+        .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testIndex)
         .create()
 
       updateLatestLogEntry(

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexMonitorITSuite.scala
@@ -53,7 +53,7 @@ class FlintSparkIndexMonitorITSuite extends OpenSearchTransactionSuite with Matc
       .skippingIndex()
       .onTable(testTable)
       .addValueSet("name")
-      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testFlintIndex)
       .create()
     flint.refreshIndex(testFlintIndex)
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
@@ -109,7 +109,9 @@ class FlintSparkIndexSqlITSuite extends FlintSparkSuite with Matchers {
       .skippingIndex()
       .onTable(testTableQualifiedName)
       .addValueSet("name")
-      .options(FlintSparkIndexOptions(Map(AUTO_REFRESH.toString -> "true")))
+      .options(
+        FlintSparkIndexOptions(Map(AUTO_REFRESH.toString -> "true")),
+        testSkippingFlintIndex)
       .create()
     flint.refreshIndex(testSkippingFlintIndex)
     val activeJob = spark.streams.active.find(_.name == testSkippingFlintIndex)
@@ -153,7 +155,7 @@ class FlintSparkIndexSqlITSuite extends FlintSparkSuite with Matchers {
       .name(testCoveringIndex)
       .onTable(testTableQualifiedName)
       .addIndexColumns("name", "age")
-      .options(FlintSparkIndexOptions(Map(AUTO_REFRESH.toString -> "true")))
+      .options(FlintSparkIndexOptions(Map(AUTO_REFRESH.toString -> "true")), testCoveringIndex)
       .create()
     flint.refreshIndex(testCoveringFlintIndex)
 
@@ -228,7 +230,7 @@ class FlintSparkIndexSqlITSuite extends FlintSparkSuite with Matchers {
       .name(testCoveringIndexSpecial)
       .onTable(testTableQualifiedName)
       .addIndexColumns("name", "age")
-      .options(FlintSparkIndexOptions(Map(AUTO_REFRESH.toString -> "true")))
+      .options(FlintSparkIndexOptions(Map(AUTO_REFRESH.toString -> "true")), testCoveringIndex)
       .create()
     flint.refreshIndex(testCoveringFlintIndexSpecial)
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexSqlITSuite.scala
@@ -155,7 +155,9 @@ class FlintSparkIndexSqlITSuite extends FlintSparkSuite with Matchers {
       .name(testCoveringIndex)
       .onTable(testTableQualifiedName)
       .addIndexColumns("name", "age")
-      .options(FlintSparkIndexOptions(Map(AUTO_REFRESH.toString -> "true")), testCoveringIndex)
+      .options(
+        FlintSparkIndexOptions(Map(AUTO_REFRESH.toString -> "true")),
+        testCoveringFlintIndex)
       .create()
     flint.refreshIndex(testCoveringFlintIndex)
 
@@ -230,7 +232,9 @@ class FlintSparkIndexSqlITSuite extends FlintSparkSuite with Matchers {
       .name(testCoveringIndexSpecial)
       .onTable(testTableQualifiedName)
       .addIndexColumns("name", "age")
-      .options(FlintSparkIndexOptions(Map(AUTO_REFRESH.toString -> "true")), testCoveringIndex)
+      .options(
+        FlintSparkIndexOptions(Map(AUTO_REFRESH.toString -> "true")),
+        testCoveringFlintIndexSpecial)
       .create()
     flint.refreshIndex(testCoveringFlintIndexSpecial)
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -55,7 +55,7 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
         .materializedView()
         .name(testMvName)
         .query(testQuery)
-        .options(indexOptions)
+        .options(indexOptions, testMvName)
         .create()
 
       val index = flint.describeIndex(testFlintIndex)
@@ -255,7 +255,7 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
         .materializedView()
         .name(testMvName)
         .query(query)
-        .options(indexOptions)
+        .options(indexOptions, testMvName)
         .create()
 
       flint

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -11,11 +11,13 @@ import java.util.Base64
 import com.stephenn.scalatest.jsonassert.JsonMatchers.matchJson
 import org.opensearch.flint.common.FlintVersion.current
 import org.opensearch.flint.core.storage.FlintOpenSearchIndexMetadataService
+import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.CHECKPOINT_LOCATION
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.getFlintIndexName
 import org.scalatest.matchers.must.Matchers.defined
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.flint.config.FlintSparkConf
 
 class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
 
@@ -55,7 +57,7 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
         .materializedView()
         .name(testMvName)
         .query(testQuery)
-        .options(indexOptions, testMvName)
+        .options(indexOptions, testFlintIndex)
         .create()
 
       val index = flint.describeIndex(testFlintIndex)
@@ -96,6 +98,34 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
            |  }
            | }
            |""".stripMargin)
+    }
+  }
+
+  test("create materialized view with default checkpoint location successfully") {
+    withTempDir { checkpointDir =>
+      conf.setConfString(
+        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key,
+        checkpointDir.getAbsolutePath)
+
+      val indexOptions =
+        FlintSparkIndexOptions(Map("auto_refresh" -> "true", "watermark_delay" -> "30 Seconds"))
+      flint
+        .materializedView()
+        .name(testMvName)
+        .query(testQuery)
+        .options(indexOptions, testFlintIndex)
+        .create()
+
+      val index = flint.describeIndex(testFlintIndex)
+      index shouldBe defined
+
+      val checkpointLocation = index.get.options.checkpointLocation()
+      assert(checkpointLocation.isDefined, "Checkpoint location should be defined")
+      assert(
+        checkpointLocation.get.contains(testFlintIndex),
+        s"Checkpoint location dir should contain ${testFlintIndex}")
+
+      conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
     }
   }
 
@@ -255,7 +285,7 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
         .materializedView()
         .name(testMvName)
         .query(query)
-        .options(indexOptions, testMvName)
+        .options(indexOptions, testFlintIndex)
         .create()
 
       flint

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -146,11 +146,13 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
         .skippingIndex()
         .onTable(testTable)
         .addValueSet("address")
-        .options(FlintSparkIndexOptions(Map(
-          "auto_refresh" -> "true",
-          "refresh_interval" -> "1 Minute",
-          "checkpoint_location" -> checkpointDir.getAbsolutePath,
-          "index_settings" -> "{\"number_of_shards\": 3,\"number_of_replicas\": 2}")))
+        .options(
+          FlintSparkIndexOptions(Map(
+            "auto_refresh" -> "true",
+            "refresh_interval" -> "1 Minute",
+            "checkpoint_location" -> checkpointDir.getAbsolutePath,
+            "index_settings" -> "{\"number_of_shards\": 3,\"number_of_replicas\": 2}")),
+          testIndex)
         .create()
 
       val index = flint.describeIndex(testIndex)
@@ -218,7 +220,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
           FlintSparkIndexOptions(
             Map(
               "incremental_refresh" -> "true",
-              "checkpoint_location" -> checkpointDir.getAbsolutePath)))
+              "checkpoint_location" -> checkpointDir.getAbsolutePath)),
+          testIndex)
         .create()
 
       flint.refreshIndex(testIndex) shouldBe empty
@@ -246,7 +249,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
         .skippingIndex()
         .onTable(testTable)
         .addPartitions("year", "month")
-        .options(FlintSparkIndexOptions(Map("incremental_refresh" -> "true")))
+        .options(FlintSparkIndexOptions(Map("incremental_refresh" -> "true")), testIndex)
         .create()
     } should have message "requirement failed: Checkpoint location is required"
   }
@@ -257,7 +260,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
       .skippingIndex()
       .onTable(testTable)
       .addPartitions("year", "month")
-      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testIndex)
       .create()
 
     val jobId = flint.refreshIndex(testIndex)
@@ -283,7 +286,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
             Map(
               "auto_refresh" -> "true",
               "scheduler_mode" -> "external",
-              "checkpoint_location" -> checkpointDir.getAbsolutePath)))
+              "checkpoint_location" -> checkpointDir.getAbsolutePath)),
+          testIndex)
         .create()
 
       flint.refreshIndex(testIndex) shouldBe empty

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkTransactionITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkTransactionITSuite.scala
@@ -87,7 +87,8 @@ class FlintSparkTransactionITSuite extends OpenSearchTransactionSuite with Match
           FlintSparkIndexOptions(
             Map(
               "incremental_refresh" -> "true",
-              "checkpoint_location" -> checkpointDir.getAbsolutePath)))
+              "checkpoint_location" -> checkpointDir.getAbsolutePath)),
+          testFlintIndex)
         .create()
       flint.refreshIndex(testFlintIndex)
 
@@ -102,7 +103,7 @@ class FlintSparkTransactionITSuite extends OpenSearchTransactionSuite with Match
       .skippingIndex()
       .onTable(testTable)
       .addPartitions("year", "month")
-      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testFlintIndex)
       .create()
     flint.refreshIndex(testFlintIndex)
 
@@ -143,7 +144,7 @@ class FlintSparkTransactionITSuite extends OpenSearchTransactionSuite with Match
       .skippingIndex()
       .onTable(testTable)
       .addPartitions("year", "month")
-      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testFlintIndex)
       .create()
     flint.refreshIndex(testFlintIndex)
 
@@ -217,7 +218,7 @@ class FlintSparkTransactionITSuite extends OpenSearchTransactionSuite with Match
       .skippingIndex()
       .onTable(testTable)
       .addPartitions("year", "month")
-      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testFlintIndex)
       .create()
     flint.refreshIndex(testFlintIndex)
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkUpdateIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkUpdateIndexITSuite.scala
@@ -40,12 +40,14 @@ class FlintSparkUpdateIndexITSuite extends FlintSparkSuite {
         .skippingIndex()
         .onTable(testTable)
         .addValueSet("address")
-        .options(FlintSparkIndexOptions(Map(
-          "auto_refresh" -> "false",
-          "incremental_refresh" -> "true",
-          "refresh_interval" -> "1 Minute",
-          "checkpoint_location" -> checkpointDir.getAbsolutePath,
-          "index_settings" -> "{\"number_of_shards\": 3,\"number_of_replicas\": 2}")))
+        .options(
+          FlintSparkIndexOptions(Map(
+            "auto_refresh" -> "false",
+            "incremental_refresh" -> "true",
+            "refresh_interval" -> "1 Minute",
+            "checkpoint_location" -> checkpointDir.getAbsolutePath,
+            "index_settings" -> "{\"number_of_shards\": 3,\"number_of_replicas\": 2}")),
+          testIndex)
         .create()
       val indexInitial = flint.describeIndex(testIndex).get
 
@@ -148,7 +150,8 @@ class FlintSparkUpdateIndexITSuite extends FlintSparkSuite {
                 .get("checkpoint_location")
                 .map(_ =>
                   initialOptionsMap.updated("checkpoint_location", checkpointDir.getAbsolutePath))
-                .getOrElse(initialOptionsMap)))
+                .getOrElse(initialOptionsMap)),
+              testIndex)
             .create()
           flint.refreshIndex(testIndex)
 
@@ -280,7 +283,8 @@ class FlintSparkUpdateIndexITSuite extends FlintSparkSuite {
                 .get("checkpoint_location")
                 .map(_ =>
                   initialOptionsMap.updated("checkpoint_location", checkpointDir.getAbsolutePath))
-                .getOrElse(initialOptionsMap)))
+                .getOrElse(initialOptionsMap)),
+              testIndex)
             .create()
           flint.refreshIndex(testIndex)
 
@@ -397,7 +401,8 @@ class FlintSparkUpdateIndexITSuite extends FlintSparkSuite {
           FlintSparkIndexOptions(
             Map(
               "incremental_refresh" -> "true",
-              "checkpoint_location" -> checkpointDir.getAbsolutePath)))
+              "checkpoint_location" -> checkpointDir.getAbsolutePath)),
+          testIndex)
         .create()
 
       flint.refreshIndex(testIndex) shouldBe empty
@@ -440,7 +445,7 @@ class FlintSparkUpdateIndexITSuite extends FlintSparkSuite {
       .skippingIndex()
       .onTable(testTable)
       .addPartitions("year", "month")
-      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")))
+      .options(FlintSparkIndexOptions(Map("auto_refresh" -> "true")), testIndex)
       .create()
 
     val jobId = flint.refreshIndex(testIndex)
@@ -484,8 +489,12 @@ class FlintSparkUpdateIndexITSuite extends FlintSparkSuite {
         .skippingIndex()
         .onTable(testTable)
         .addPartitions("year", "month")
-        .options(FlintSparkIndexOptions(
-          Map("auto_refresh" -> "true", "checkpoint_location" -> checkpointDir.getAbsolutePath)))
+        .options(
+          FlintSparkIndexOptions(
+            Map(
+              "auto_refresh" -> "true",
+              "checkpoint_location" -> checkpointDir.getAbsolutePath)),
+          testIndex)
         .create()
 
       val jobId = flint.refreshIndex(testIndex)


### PR DESCRIPTION
### Description
Add conf for specifying a default checkpoint location to be re-used for index creation

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/102

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
