### PR TITLE
Add UT and IT for 2+ level aggregations PPL command

### DIFF
--- a/ppl-spark-integration/README.md
+++ b/ppl-spark-integration/README.md
@@ -285,6 +285,10 @@ Limitation: Overriding existing field is unsupported, following queries throw ex
 - `source = table | stats sum(productsAmount) by span(transactionDate, 1d) as age_date | sort age_date`
 - `source = table | stats sum(productsAmount) by span(transactionDate, 1w) as age_date, productId`
 
+**Aggregations Group by Multiple Levels**
+- `source = table | stats avg(age) as avg_state_age by country, state | stats avg(avg_state_age) as avg_country_age by country`
+- `source = table | stats avg(age) as avg_city_age by country, state, city | eval new_avg_city_age = avg_city_age - 1 | stats avg(new_avg_city_age) as avg_state_age by country, state | where avg_state_age > 18 | stats avg(avg_state_age) as avg_adult_country_age by country`
+
 **Dedup**
 - `source = table | dedup a | fields a,b,c`
 - `source = table | dedup a,b | fields a,b,c`


### PR DESCRIPTION
### Description
No additional effort needed to support 2+ level aggregations PPL command. This PR is adding some unit tests and integ-tests for this feature.

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-spark/issues/488

### Check List
- [x] Updated documentation (ppl-spark-integration/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
