### PR TITLE
Update checkpoint location on alter path

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
@@ -81,8 +81,9 @@ abstract class FlintSparkIndexBuilder(flint: FlintSpark) {
       index: FlintSparkIndex,
       updateOptions: FlintSparkIndexOptions): FlintSparkIndex = {
     val originalOptions = index.options
-    val updatedOptions =
-      originalOptions.copy(options = originalOptions.options ++ updateOptions.options)
+    val updatedOptions = updateOptionWithDefaultCheckpointLocation(
+      index.name(),
+      originalOptions.copy(options = originalOptions.options ++ updateOptions.options))
     val updatedMetadata = index
       .metadata()
       .copy(options = updatedOptions.options.mapValues(_.asInstanceOf[AnyRef]).asJava)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
@@ -5,7 +5,7 @@
 
 package org.opensearch.flint.spark
 
-import java.util.{Collections, UUID}
+import java.util.Collections
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
@@ -160,22 +160,13 @@ abstract class FlintSparkIndexBuilder(flint: FlintSpark) {
       indexName: String,
       options: FlintSparkIndexOptions): FlintSparkIndexOptions = {
 
-    val checkpointLocationRootDirOption = new FlintSparkConf(
-      Collections.emptyMap[String, String]).checkpointLocationRootDir
+    val flintSparkConf = new FlintSparkConf(Collections.emptyMap[String, String])
+    val checkpointLocation = options.checkpointLocation(indexName, flintSparkConf)
 
-    if (options.checkpointLocation().isEmpty) {
-      checkpointLocationRootDirOption match {
-        case Some(checkpointLocationRootDir) =>
-          // Currently, deleting and recreating the flint index will enter same checkpoint dir.
-          // Use a UUID to isolate checkpoint data.
-          val checkpointLocation =
-            s"${checkpointLocationRootDir.stripSuffix("/")}/$indexName/${UUID.randomUUID().toString}"
-          FlintSparkIndexOptions(
-            options.options + (CHECKPOINT_LOCATION.toString -> checkpointLocation))
-        case None => options
-      }
-    } else {
-      options
+    checkpointLocation match {
+      case Some(location) =>
+        FlintSparkIndexOptions(options.options + (CHECKPOINT_LOCATION.toString -> location))
+      case None => options
     }
   }
 }

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexBuilderSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexBuilderSuite.scala
@@ -58,7 +58,7 @@ class FlintSparkIndexBuilderSuite extends FlintSuite {
   }
 
   test("indexOptions should not override existing checkpoint location with conf") {
-    conf.setConfString(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key, testCheckpointLocation)
+    setFlintSparkConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR, testCheckpointLocation)
     assert(conf.contains(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key))
 
     val options =
@@ -70,7 +70,7 @@ class FlintSparkIndexBuilderSuite extends FlintSuite {
   }
 
   test("indexOptions should have default checkpoint location with conf") {
-    conf.setConfString(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key, testCheckpointLocation)
+    setFlintSparkConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR, testCheckpointLocation)
     assert(conf.contains(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key))
 
     val options = FlintSparkIndexOptions(Map.empty)

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -126,8 +126,8 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
 
   test("create covering index with default checkpoint location successfully") {
     withTempDir { checkpointDir =>
-      conf.setConfString(
-        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key,
+      setFlintSparkConf(
+        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR,
         checkpointDir.getAbsolutePath)
       flint
         .coveringIndex()
@@ -231,8 +231,8 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
       assert(checkpointLocation.isEmpty, "Checkpoint location should not be defined")
 
       // 2. Update the spark conf with a custom checkpoint location
-      conf.setConfString(
-        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key,
+      setFlintSparkConf(
+        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR,
         checkpointDir.getAbsolutePath)
 
       index = flint.describeIndex(testFlintIndex)

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -103,8 +103,8 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
 
   test("create materialized view with default checkpoint location successfully") {
     withTempDir { checkpointDir =>
-      conf.setConfString(
-        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key,
+      setFlintSparkConf(
+        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR,
         checkpointDir.getAbsolutePath)
 
       val indexOptions =
@@ -285,8 +285,8 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
       assert(checkpointLocation.isEmpty, "Checkpoint location should not be defined")
 
       // 2. Update the spark conf with a custom checkpoint location
-      conf.setConfString(
-        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key,
+      setFlintSparkConf(
+        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR,
         checkpointDir.getAbsolutePath)
 
       index = flint.describeIndex(testFlintIndex)

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -268,6 +268,70 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
     }
   }
 
+  test("update materialized view successfully with custom checkpoint location") {
+    withTempDir { checkpointDir =>
+      // 1. Create full refresh MV
+      flint
+        .materializedView()
+        .name(testMvName)
+        .query(testQuery)
+        .options(FlintSparkIndexOptions.empty, testFlintIndex)
+        .create()
+      var indexData = flint.queryIndex(testFlintIndex)
+      checkAnswer(indexData, Seq())
+
+      var index = flint.describeIndex(testFlintIndex)
+      var checkpointLocation = index.get.options.checkpointLocation()
+      assert(checkpointLocation.isEmpty, "Checkpoint location should not be defined")
+
+      // 2. Update the spark conf with a custom checkpoint location
+      conf.setConfString(
+        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key,
+        checkpointDir.getAbsolutePath)
+
+      index = flint.describeIndex(testFlintIndex)
+      checkpointLocation = index.get.options.checkpointLocation()
+      assert(checkpointLocation.isEmpty, "Checkpoint location should not be defined")
+
+      // 3. Update Flint index to auto refresh and wait for complete
+      val updatedIndex = flint
+        .materializedView()
+        .copyWithUpdate(
+          index.get,
+          FlintSparkIndexOptions(Map("auto_refresh" -> "true", "watermark_delay" -> "1 Minute")))
+      val jobId = flint.updateIndex(updatedIndex)
+      jobId shouldBe defined
+
+      val job = spark.streams.get(jobId.get)
+      failAfter(streamingTimeout) {
+        job.processAllAvailable()
+      }
+
+      indexData = flint.queryIndex(testFlintIndex)
+      checkAnswer(
+        indexData.select("startTime", "count"),
+        Seq(
+          Row(timestamp("2023-10-01 00:00:00"), 1),
+          Row(timestamp("2023-10-01 00:10:00"), 2),
+          Row(timestamp("2023-10-01 01:00:00"), 1)
+          /*
+           * The last row is pending to fire upon watermark
+           *   Row(timestamp("2023-10-01 02:00:00"), 1)
+           */
+        ))
+
+      index = flint.describeIndex(testFlintIndex)
+
+      checkpointLocation = index.get.options.checkpointLocation()
+      assert(checkpointLocation.isDefined, "Checkpoint location should be defined")
+      assert(
+        checkpointLocation.get.contains(testFlintIndex),
+        s"Checkpoint location dir should contain ${testFlintIndex}")
+
+      conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
+    }
+  }
+
   private def timestamp(ts: String): Timestamp = Timestamp.valueOf(ts)
 
   private def withIncrementalMaterializedView(query: String)(

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -186,8 +186,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
 
   test("create skipping index with default checkpoint location successfully") {
     withTempDir { checkpointDir =>
-      conf.setConfString(
-        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key,
+      setFlintSparkConf(
+        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR,
         checkpointDir.getAbsolutePath)
       flint
         .skippingIndex()
@@ -386,8 +386,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
       assert(checkpointLocation.isEmpty, "Checkpoint location should not be defined")
 
       // 2. Update the spark conf with a custom checkpoint location
-      conf.setConfString(
-        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key,
+      setFlintSparkConf(
+        FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR,
         checkpointDir.getAbsolutePath)
 
       index = flint.describeIndex(testIndex)


### PR DESCRIPTION
### Description
Currently, there are two ways of creating a Flint index representation:

```
1. FlintSparkIndexFactory.create
2. FlintSparkIndexBuilder.create
```

The FlintSparkIndexFactory.create method doesn't call the option() method in FlintSparkIndexBuilder. Instead, it constructs options from metadata directly:

```
val indexOptions = FlintSparkIndexOptions(
  metadata.options.asScala.mapValues(_.asInstanceOf[String]).toMap)
```

This becomes problematic on the ALTER statement, which retrieves the index via describeIndex. The describeIndex method uses FlintSparkIndexFactory.create, bypassing the option() method call. As a result, the custom checkpoint location is not properly set for ALTER statements. This inconsistency needs to be addressed to ensure proper functionality across all index operations.

### Proposed Solution

Update the copyWithUpdate method to set the custom checkpoint location after FlintSparkIndexFactory.create is called in describeIndex method. This will ensure that the checkpoint location is correctly updated for ALTER statements, maintaining consistency with other index creation and modification methods.


### Steps to Reproduce
1. Create a batch job with auto_refresh=false
2. Create a streaming job with auto_refresh=true

```
Error:
Checkpoint location is required if spark.flint.index.checkpoint.mandatory option enabled"}}
java.lang.IllegalArgumentException: requirement failed: Checkpoint location is required if spark.flint.index.checkpoint.mandatory option enabled
```

### Expected Behavior

The ALTER statement should properly set and use the custom checkpoint location.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
