### PR TITLE
Remove checkpoint folder when vacuuming index

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkCheckpoint.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkCheckpoint.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import java.util.UUID
+
+import org.apache.hadoop.fs.{FSDataOutputStream, Path}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.streaming.CheckpointFileManager
+import org.apache.spark.sql.execution.streaming.CheckpointFileManager.RenameHelperMethods
+
+/**
+ * Manages the checkpoint directory for Flint indexes.
+ *
+ * @param spark
+ *   The SparkSession used for Hadoop configuration.
+ * @param checkpointLocation
+ *   The path to the checkpoint directory.
+ */
+class FlintSparkCheckpoint(spark: SparkSession, checkpointLocation: String) extends Logging {
+  private val checkpointDir = new Path(checkpointLocation)
+  private val checkpointManager =
+    CheckpointFileManager.create(checkpointDir, spark.sessionState.newHadoopConf())
+
+  /**
+   * Checks if the checkpoint directory exists.
+   *
+   * @return
+   *   true if the checkpoint directory exists, false otherwise.
+   */
+  def exists(): Boolean = checkpointManager.exists(checkpointDir)
+
+  /**
+   * Creates a temporary file in the checkpoint directory.
+   *
+   * @return
+   *   An optional FSDataOutputStream for the created temporary file, or None if creation fails.
+   */
+  def createTempFile(): Option[FSDataOutputStream] = {
+    checkpointManager match {
+      case manager: RenameHelperMethods =>
+        val tempFilePath =
+          new Path(
+            checkpointManager.createCheckpointDirectory(), // create all parent folders if needed
+            s"${UUID.randomUUID().toString}.tmp")
+        Some(manager.createTempFile(tempFilePath))
+      case _ =>
+        logInfo(s"Cannot create temp file at checkpoint location: ${checkpointManager.getClass}")
+        None
+    }
+  }
+
+  /**
+   * Deletes the checkpoint directory. This method attempts to delete the checkpoint directory and
+   * captures any exceptions that occur. Exceptions are logged but ignored so as not to disrupt
+   * the caller's workflow.
+   */
+  def delete(): Unit = {
+    try {
+      checkpointManager.delete(checkpointDir)
+      logInfo(s"Checkpoint directory $checkpointDir deleted.")
+    } catch {
+      case e: Exception =>
+        logError(s"Error deleting checkpoint directory $checkpointDir", e)
+    }
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkCheckpointSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkCheckpointSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.FlintSuite
+
+class FlintSparkCheckpointSuite extends FlintSuite with Matchers {
+
+  test("exists") {
+    withCheckpoint { checkpoint =>
+      checkpoint.exists() shouldBe false
+      checkpoint.createDirectory()
+      checkpoint.exists() shouldBe true
+    }
+  }
+
+  test("create directory") {
+    withTempPath { tempDir =>
+      val checkpointDir = new Path(tempDir.getAbsolutePath, "sub/subsub")
+      val checkpoint = new FlintSparkCheckpoint(spark, checkpointDir.toString)
+      checkpoint.createDirectory()
+
+      tempDir.exists() shouldBe true
+    }
+  }
+
+  test("create temp file") {
+    withCheckpoint { checkpoint =>
+      val tempFile = checkpoint.createTempFile()
+      tempFile shouldBe defined
+
+      // Close the stream to ensure the file is flushed
+      tempFile.get.close()
+
+      // Assert that there is a .tmp file
+      listFiles(checkpoint.checkpointLocation)
+        .exists(isTempFile) shouldBe true
+    }
+  }
+
+  test("delete") {
+    withCheckpoint { checkpoint =>
+      checkpoint.createDirectory()
+      checkpoint.delete()
+      checkpoint.exists() shouldBe false
+    }
+  }
+
+  private def withCheckpoint(block: FlintSparkCheckpoint => Unit): Unit = {
+    withTempPath { checkpointDir =>
+      val checkpoint = new FlintSparkCheckpoint(spark, checkpointDir.getAbsolutePath)
+      block(checkpoint)
+    }
+  }
+
+  private def listFiles(dir: String): Array[FileStatus] = {
+    val fs = FileSystem.get(spark.sessionState.newHadoopConf())
+    fs.listStatus(new Path(dir))
+  }
+
+  private def isTempFile(file: FileStatus): Boolean = {
+    file.isFile && file.getPath.getName.endsWith(".tmp")
+  }
+}

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -468,6 +468,34 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
     flint.describeIndex(testFlintIndex) shouldBe empty
   }
 
+  test("vacuum covering index with checkpoint") {
+    withTempDir { checkpointDir =>
+      flint
+        .coveringIndex()
+        .name(testIndex)
+        .onTable(testTable)
+        .addIndexColumns("name", "age")
+        .options(
+          FlintSparkIndexOptions(
+            Map(
+              "auto_refresh" -> "true",
+              "checkpoint_location" -> checkpointDir.getAbsolutePath)),
+          testFlintIndex)
+        .create()
+      flint.refreshIndex(testFlintIndex)
+
+      val job = spark.streams.active.find(_.name == testFlintIndex)
+      awaitStreamingComplete(job.get.id.toString)
+      flint.deleteIndex(testFlintIndex)
+
+      // Checkpoint folder should be removed after vacuum
+      checkpointDir.exists() shouldBe true
+      sql(s"VACUUM INDEX $testIndex ON $testTable")
+      flint.describeIndex(testFlintIndex) shouldBe empty
+      checkpointDir.exists() shouldBe false
+    }
+  }
+
   private def awaitRefreshComplete(query: String): Unit = {
     sql(query)
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -408,5 +408,33 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
     flint.describeIndex(testFlintIndex) shouldBe empty
   }
 
+  test("vacuum materialized view with checkpoint") {
+    withTempDir { checkpointDir =>
+      flint
+        .materializedView()
+        .name(testMvName)
+        .query(testQuery)
+        .options(
+          FlintSparkIndexOptions(
+            Map(
+              "auto_refresh" -> "true",
+              "checkpoint_location" -> checkpointDir.getAbsolutePath,
+              "watermark_delay" -> "1 Second")),
+          testFlintIndex)
+        .create()
+      flint.refreshIndex(testFlintIndex)
+
+      val job = spark.streams.active.find(_.name == testFlintIndex)
+      awaitStreamingComplete(job.get.id.toString)
+      flint.deleteIndex(testFlintIndex)
+
+      // Checkpoint folder should be removed after vacuum
+      checkpointDir.exists() shouldBe true
+      sql(s"VACUUM MATERIALIZED VIEW $testMvName")
+      flint.describeIndex(testFlintIndex) shouldBe empty
+      checkpointDir.exists() shouldBe false
+    }
+  }
+
   private def timestamp(ts: String): Timestamp = Timestamp.valueOf(ts)
 }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -917,7 +917,7 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
     }
   }
 
-  test("should remove checkpoint folder when vacuum") {
+  test("vacuum skipping index with checkpoint") {
     withTempDir { checkpointDir =>
       flint
         .skippingIndex()
@@ -934,10 +934,11 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
 
       val job = spark.streams.active.find(_.name == testIndex)
       awaitStreamingComplete(job.get.id.toString)
-
       flint.deleteIndex(testIndex)
-      flint.vacuumIndex(testIndex)
 
+      // Checkpoint folder should be removed after vacuum
+      checkpointDir.exists() shouldBe true
+      flint.vacuumIndex(testIndex)
       flint.describeIndex(testIndex) shouldBe None
       checkpointDir.exists() shouldBe false
     }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
@@ -580,6 +580,33 @@ class FlintSparkSkippingIndexSqlITSuite extends FlintSparkSuite with ExplainSuit
     flint.describeIndex(testIndex) shouldBe empty
   }
 
+  test("vacuum skipping index with checkpoint") {
+    withTempDir { checkpointDir =>
+      flint
+        .skippingIndex()
+        .onTable(testTable)
+        .addPartitions("year")
+        .options(
+          FlintSparkIndexOptions(
+            Map(
+              "auto_refresh" -> "true",
+              "checkpoint_location" -> checkpointDir.getAbsolutePath)),
+          testIndex)
+        .create()
+      flint.refreshIndex(testIndex)
+
+      val job = spark.streams.active.find(_.name == testIndex)
+      awaitStreamingComplete(job.get.id.toString)
+      flint.deleteIndex(testIndex)
+
+      // Checkpoint folder should be removed after vacuum
+      checkpointDir.exists() shouldBe true
+      sql(s"VACUUM SKIPPING INDEX ON $testTable")
+      flint.describeIndex(testIndex) shouldBe empty
+      checkpointDir.exists() shouldBe false
+    }
+  }
+
   test("analyze skipping index with for supported data types") {
     val result = sql(s"ANALYZE SKIPPING INDEX ON $testTable")
 


### PR DESCRIPTION
### Description

This PR adds functionality to delete the checkpoint folder associated with a Flint index during the vacuuming process. The new `FlintSparkCheckpoint` class wraps Spark's `CheckpointFileManager` and abstracts checkpoint management API.

#### Testing

Prepare for vacuum test:

<pre>
<b># Create a materialized view and cancel refreshing after a while</b>
CREATE MATERIALIZED VIEW glue.default.vacuum_checkpoint_test_2
AS
SELECT clientip
FROM glue.default.http_logs
WITH (
  auto_refresh = true,
  checkpoint_location = 's3://checkpoint/vacuum-checkpoint-test-2');

<b># Drop materialized view and check current status</b>
# Index data
GET _cat/indices?v
green  open   flint_glue_default_vacuum_checkpoint_test_2   5   1   2982743   0    258.6mb   121.2mb

# Index metadata log entry
GET .query_execution_request_glue/_search
      {
        "_index": ".query_execution_request_glue",
        "_id": "ZmxpbnRfZ2x1ZV9kZWZhdWx0X3ZhY3V1bV9jaGVja3BvaW50X3Rlc3RfMg==",
        "_score": 1,
        "_source": {
          "version": "1.0",
          "latestId": "ZmxpbnRfZ2x1ZV9kZWZhdWx0X3ZhY3V1bV9jaGVja3BvaW50X3Rlc3RfMg==",
          "type": "flintindexstate",
          <b>"state": "deleted",</b>
          "applicationId": "XXXXXX",
          "jobId": "YYYYYY",
          "dataSourceName": "glue",
          "jobStartTime": 1725474075924,
          "lastUpdateTime": 1725474672053,
          "error": ""
        }
      }

$ aws s3 ls s3://checkpoint | grep vacuum-checkpoint-test
                           PRE vacuum-checkpoint-test-2/
2024-09-04 11:21:13          0 vacuum-checkpoint-test-2_$folder$
</pre>

Verify checkpoint folder removed after vacuum:

<pre>
VACUUM MATERIALIZED VIEW glue.default.vacuum_checkpoint_test_2;

$ aws s3 ls s3://checkpoint | grep vacuum-checkpoint-test
(empty)

<b># Spark log</b>
FlintSpark: Starting index operation [Vacuum Flint index flint_glue_default_vacuum_checkpoint_test_2] with forceInit=false
...
FlintOpenSearchClient: Deleting Flint index flint_glue_default_vacuum_checkpoint_test_2
...
<b>FlintSparkCheckpoint: Checkpoint directory s3://checkpoint/vacuum-checkpoint-test-2 deleted</b>
FlintOpenSearchMetadataLog: Purging log entry with id ZmxpbnRfZ2x1ZV9kZWZhdWx0X3ZhY3V1bV9jaGVja3BvaW50X3Rlc3RfMg==
FlintOpenSearchMetadataLog: Purged log entry with result DELETED
FlintSpark: Index operation [Vacuum Flint index flint_glue_default_vacuum_checkpoint_test_2] complete
</pre>

### Issues Resolved

- https://github.com/opensearch-project/opensearch-spark/issues/580
- https://github.com/opensearch-project/opensearch-spark/issues/102

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
