### PR TITLE
Translate PPL `join` Command

### DIFF
--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
@@ -36,6 +36,17 @@ KMEANS:                             'KMEANS';
 AD:                                 'AD';
 ML:                                 'ML';
 
+//Native JOIN KEYWORDS
+JOIN:                               'JOIN';
+ON:                                 'ON';
+INNER:                              'INNER';
+OUTER:                              'OUTER';
+FULL:                               'FULL';
+SEMI:                               'SEMI';
+ANTI:                               'ANTI';
+CROSS:                              'CROSS';
+HINT_KEY:                           'HINT.' ID_LITERAL;
+
 //CORRELATION KEYWORDS
 CORRELATE:                          'CORRELATE';
 SELF:                               'SELF';

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -183,13 +183,55 @@ mlArg
 
 // clauses
 fromClause
-   : SOURCE EQUAL tableSourceClause
-   | INDEX EQUAL tableSourceClause
+   : SOURCE EQUAL relation
+   | INDEX EQUAL relation
+   | SOURCE EQUAL tableSourceClause
+   | INDEX EQUAL relation
    ;
 
 tableSourceClause
    : tableSource (COMMA tableSource)*
    ;
+
+// join
+relation
+   : relationPrimary relationExtension
+   ;
+
+// TODO subsearch
+relationPrimary
+   : tableSource (AS alias = qualifiedName)?
+   ;
+
+relationExtension
+   : joinSource
+   ;
+
+joinSource
+   : (joinType) JOIN right = relationPrimary joinHintList? joinCriteria
+   ;
+
+joinType
+   : INNER?
+   | CROSS
+   | LEFT OUTER?
+   | RIGHT OUTER?
+   | FULL OUTER?
+   | LEFT? SEMI
+   | LEFT? ANTI
+   ;
+
+joinCriteria
+   : ON logicalExpression
+   ;
+
+joinHintList
+    : hintPair (COMMA? hintPair)*
+    ;
+
+hintPair
+    : key = HINT_KEY EQUAL value = ident
+    ;
 
 renameClasue
    : orignalField = wcFieldExpression AS renamedField = wcFieldExpression

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -41,6 +41,7 @@ import org.opensearch.sql.ast.tree.Dedupe;
 import org.opensearch.sql.ast.tree.Eval;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Head;
+import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.Limit;
 import org.opensearch.sql.ast.tree.Parse;
@@ -103,7 +104,11 @@ public abstract class AbstractNodeVisitor<T, C> {
   public T visitCorrelationMapping(FieldsMapping node, C context) {
     return visitChildren(node, context);
   }
-  
+
+  public T visitJoin(Join node, C context) {
+    return visitChildren(node, context);
+  }
+
   public T visitProject(Project node, C context) {
     return visitChildren(node, context);
   }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Join.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Join.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+public class Join extends UnresolvedPlan {
+    private final UnresolvedPlan left;
+    private final UnresolvedPlan right;
+    private final JoinType joinType;
+    private final UnresolvedExpression joinCondition;
+    private final JoinHint joinHint;
+
+    public Join(UnresolvedPlan left, UnresolvedPlan right, JoinType joinType, UnresolvedExpression joinCondition, JoinHint joinHint) {
+        this.left = left;
+        this.right = right;
+        this.joinType = joinType;
+        this.joinCondition = joinCondition;
+        this.joinHint = joinHint;
+    }
+
+    @Override
+    public UnresolvedPlan attach(UnresolvedPlan child) {
+        return this;
+    }
+
+    @Override
+    public List<UnresolvedPlan> getChild() {
+        return ImmutableList.of(left, right);
+    }
+
+    @Override
+    public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+        return nodeVisitor.visitJoin(this, context);
+    }
+
+    public enum JoinType {
+        INNER,
+        LEFT,
+        RIGHT,
+        SEMI,
+        ANTI,
+        CROSS,
+        FULL
+    }
+
+    public UnresolvedPlan getLeft() {
+        return left;
+    }
+
+    public UnresolvedPlan getRight() {
+        return right;
+    }
+
+    public JoinType getJoinType() {
+        return joinType;
+    }
+
+    public UnresolvedExpression getJoinCondition() {
+        return joinCondition;
+    }
+
+    public JoinHint getJoinHint() {
+        return joinHint;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Join join = (Join) o;
+        return Objects.equals(left, join.left) && Objects.equals(right, join.right) && joinType == join.joinType && Objects.equals(joinCondition, join.joinCondition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(left, right, joinType, joinCondition);
+    }
+
+    public static class JoinHint {
+        private final Map<String, String> hints;
+
+        public JoinHint() {
+            this.hints = ImmutableMap.of();
+        }
+
+        public JoinHint(Map<String, String> hints) {
+            this.hints = hints;
+        }
+
+        public Map<String, String> getHints() {
+            return hints;
+        }
+    }
+}

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/JoinSpecTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/JoinSpecTransformer.java
@@ -1,9 +1,14 @@
 package org.opensearch.sql.ppl.utils;
 
 import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.plans.Cross$;
 import org.apache.spark.sql.catalyst.plans.FullOuter$;
 import org.apache.spark.sql.catalyst.plans.Inner$;
 import org.apache.spark.sql.catalyst.plans.JoinType;
+import org.apache.spark.sql.catalyst.plans.LeftAnti$;
+import org.apache.spark.sql.catalyst.plans.LeftOuter$;
+import org.apache.spark.sql.catalyst.plans.LeftSemi$;
+import org.apache.spark.sql.catalyst.plans.RightOuter$;
 import org.apache.spark.sql.catalyst.plans.logical.Join;
 import org.apache.spark.sql.catalyst.plans.logical.JoinHint;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -82,4 +87,33 @@ public interface JoinSpecTransformer {
         }
         return Inner$.MODULE$;
     }
+
+    // +----------------------------------------------------------------------------+
+    // | Native Join Syntax (https://github.com/opensearch-project/sql/issues/2913) |
+    // +----------------------------------------------------------------------------+
+
+    static LogicalPlan join(LogicalPlan left, LogicalPlan right, org.opensearch.sql.ast.tree.Join.JoinType joinType, Expression joinCondition, org.opensearch.sql.ast.tree.Join.JoinHint joinHint) {
+        return new Join(left, right, getType(joinType), Option.apply(joinCondition), JoinHint.NONE());
+    }
+
+    static JoinType getType(org.opensearch.sql.ast.tree.Join.JoinType joinType) {
+        switch (joinType) {
+            case INNER:
+                return Inner$.MODULE$;
+            case LEFT:
+                return LeftOuter$.MODULE$;
+            case RIGHT:
+                return RightOuter$.MODULE$;
+            case FULL:
+                return FullOuter$.MODULE$;
+            case SEMI:
+                return LeftSemi$.MODULE$;
+            case ANTI:
+                return LeftAnti$.MODULE$;
+            case CROSS:
+                return Cross$.MODULE$;
+        }
+        return Inner$.MODULE$;
+    }
+
 }

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanJoinTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanJoinTranslatorTestSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.ppl
+
+import org.opensearch.flint.spark.ppl.PlaneUtils.plan
+import org.opensearch.sql.ppl.{CatalystPlanContext, CatalystQueryPlanVisitor}
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation, UnresolvedStar}
+import org.apache.spark.sql.catalyst.expressions.{EqualTo, IsNotNull, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{Deduplicate, Filter, Join, JoinHint, Project}
+
+class PPLLogicalPlanJoinTranslatorTestSuite
+    extends SparkFunSuite
+    with PlanTest
+    with LogicalPlanTestUtils
+    with Matchers {
+
+  private val planTransformer = new CatalystQueryPlanVisitor()
+  private val pplParser = new PPLSyntaxParser()
+
+  /** Test table and index name */
+  private val testTable1 = "spark_catalog.default.flint_ppl_test1"
+  private val testTable2 = "spark_catalog.default.flint_ppl_test2"
+
+  test("test simple join") {
+    val context = new CatalystPlanContext
+//    val logicalPlan =
+//      planTransformer.visit(
+//        plan(
+//          pplParser,
+//          s"""
+//           | source = $testTable1 | JOIN $testTable2 ON $testTable1.id = $testTable2.id
+//           | """.stripMargin,
+//          isExplain = false),
+//        context)
+
+    val stat = plan(
+      pplParser,
+      s"source = $testTable1 JOIN $testTable2 ON $testTable1.id = $testTable2.id",
+      isExplain = false)
+    val logicalPlan = planTransformer.visit(stat, context)
+    val table1 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test1"))
+    val table2 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test2"))
+
+    val joinCondition =
+      EqualTo(UnresolvedAttribute(s"$testTable1.id"), UnresolvedAttribute(s"$testTable2.id"))
+    val joinPlan = Join(table1, table2, Inner, Some(joinCondition), JoinHint.NONE)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), joinPlan)
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
+
+}


### PR DESCRIPTION
### Description

__Syntax__
```
leftRelation [AS leftAlias]
| [joinType] JOIN rightRelation [AS rightAlias] [hint.key1=value1 [, hint.key2=value2]...] ON joinCriteria
```
**joinType**: `INNER | LEFT [OUTER] | [LEFT] SEMI | [LEFT] ANTI | FULL [OUTER] | CROSS | ...`
**relation**: `indexName | subquery`
**joinCriteria**: `[leftAlias | leftIndexName].leftField = [rightAlias | rightIndexName].rightField [ AND [leftAlias | leftIndexName].leftField = [rightAlias | rightIndexName].rightField ]...`


### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-spark/issues/619

### Check List
- [ ] Updated documentation (ppl-spark-integration/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
