### PR TITLE
Refactor FlintJob with FlintStatement and StatementExecutionManager

### DIFF
--- a/flint-commons/src/main/scala/org/apache/spark/sql/StatementExecutionManager.scala
+++ b/flint-commons/src/main/scala/org/apache/spark/sql/StatementExecutionManager.scala
@@ -38,5 +38,5 @@ trait StatementExecutionManager {
   /**
    * Terminates the statement lifecycle.
    */
-  def terminateStatementsExecution(): Unit
+  def terminateStatementExecution(): Unit
 }

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -211,6 +211,10 @@ object FlintSparkConf {
     FlintConfig("spark.flint.job.query")
       .doc("Flint query for batch and streaming job")
       .createOptional()
+  val QUERY_ID =
+    FlintConfig("spark.flint.job.queryId")
+      .doc("Flint query id for batch and streaming job")
+      .createOptional()
   val JOB_TYPE =
     FlintConfig(s"spark.flint.job.type")
       .doc("Flint job type. Including interactive and streaming")

--- a/integ-test/src/integration/scala/org/apache/spark/sql/FlintJobITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/sql/FlintJobITSuite.scala
@@ -37,6 +37,7 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
   val resultIndex = "query_results2"
   val appId = "00feq82b752mbt0p"
   val dataSourceName = "my_glue1"
+  val queryId = "testQueryId"
   var osClient: OSClient = _
   val threadLocalFuture = new ThreadLocal[Future[Unit]]()
 
@@ -103,9 +104,10 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
           jobRunId,
           spark,
           query,
+          queryId,
           dataSourceName,
           resultIndex,
-          true,
+          "streaming",
           streamingRunningCount)
       job.terminateJVM = false
       job.start()
@@ -144,7 +146,6 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
 
       assert(result.status == "SUCCESS", s"expected status is SUCCESS, but got ${result.status}")
       assert(result.error.isEmpty, s"we don't expect error, but got ${result.error}")
-      assert(result.queryId.isEmpty, s"we don't expect query id, but got ${result.queryId}")
 
       commonAssert(result, jobRunId, query, queryStartTime)
       true
@@ -362,7 +363,9 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
       result.queryRunTime < System.currentTimeMillis() - queryStartTime,
       s"expected query run time ${result.queryRunTime} should be less than ${System
           .currentTimeMillis() - queryStartTime}, but it is not")
-    assert(result.queryId.isEmpty, s"we don't expect query id, but got ${result.queryId}")
+    assert(
+      result.queryId == queryId,
+      s"expected query id is ${queryId}, but got ${result.queryId}")
   }
 
   def pollForResultAndAssert(expected: REPLResult => Boolean, jobId: String): Unit = {

--- a/integ-test/src/integration/scala/org/apache/spark/sql/FlintJobITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/sql/FlintJobITSuite.scala
@@ -92,7 +92,7 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
        * all Spark conf required by Flint code underlying manually.
        */
       spark.conf.set(DATA_SOURCE_NAME.key, dataSourceName)
-      spark.conf.set(JOB_TYPE.key, "streaming")
+      spark.conf.set(JOB_TYPE.key, FlintJobType.STREAMING)
 
       /**
        * FlintJob.main() is not called because we need to manually set these variables within a
@@ -107,7 +107,7 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
           queryId,
           dataSourceName,
           resultIndex,
-          "streaming",
+          FlintJobType.STREAMING,
           streamingRunningCount)
       job.terminateJVM = false
       job.start()

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/CommandContext.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/CommandContext.scala
@@ -15,6 +15,7 @@ case class CommandContext(
     jobId: String,
     spark: SparkSession,
     dataSource: String,
+    jobType: String,
     sessionId: String,
     sessionManager: SessionManager,
     queryResultWriter: QueryResultWriter,

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
@@ -11,11 +11,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.opensearch.flint.core.logging.CustomLogging
 import org.opensearch.flint.core.metrics.MetricConstants
 import org.opensearch.flint.core.metrics.MetricsUtil.registerGauge
-import play.api.libs.json._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.flint.config.FlintSparkConf
-import org.apache.spark.sql.types._
 
 /**
  * Spark SQL Application entrypoint
@@ -41,6 +39,8 @@ object FlintJob extends Logging with FlintJobExecutor {
     if (query.isEmpty) {
       logAndThrow(s"Query undefined for the ${jobType} job.")
     }
+    val queryId = conf.get(FlintSparkConf.QUERY_ID.key, "")
+
     if (resultIndexOption.isEmpty) {
       logAndThrow("resultIndex is not set")
     }
@@ -66,9 +66,10 @@ object FlintJob extends Logging with FlintJobExecutor {
         jobId,
         createSparkSession(conf),
         query,
+        queryId,
         dataSource,
         resultIndexOption.get,
-        jobType.equalsIgnoreCase("streaming"),
+        jobType,
         streamingRunningCount)
     registerGauge(MetricConstants.STREAMING_RUNNING_METRIC, streamingRunningCount)
     jobOperator.start()

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
@@ -30,7 +30,7 @@ object FlintJob extends Logging with FlintJobExecutor {
     val (queryOption, resultIndexOption) = parseArgs(args)
 
     val conf = createSparkConf()
-    val jobType = conf.get("spark.flint.job.type", "batch")
+    val jobType = conf.get("spark.flint.job.type", FlintJobType.BATCH)
     CustomLogging.logInfo(s"""Job type is: ${jobType}""")
     conf.set(FlintSparkConf.JOB_TYPE.key, jobType)
 

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -34,6 +34,12 @@ object SparkConfConstants {
     "org.opensearch.flint.spark.FlintPPLSparkExtensions,org.opensearch.flint.spark.FlintSparkExtensions"
 }
 
+object FlintJobType {
+  val INTERACTIVE = "interactive"
+  val BATCH = "batch"
+  val STREAMING = "streaming"
+}
+
 trait FlintJobExecutor {
   this: Logging =>
 
@@ -132,7 +138,7 @@ trait FlintJobExecutor {
    * https://github.com/opensearch-project/opensearch-spark/issues/324
    */
   def configDYNMaxExecutors(conf: SparkConf, jobType: String): Unit = {
-    if (jobType.equalsIgnoreCase("streaming")) {
+    if (jobType.equalsIgnoreCase(FlintJobType.STREAMING)) {
       conf.set(
         "spark.dynamicAllocation.maxExecutors",
         conf

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -89,7 +89,7 @@ object FlintREPL extends Logging with FlintJobExecutor {
     val query = getQuery(queryOption, jobType, conf)
     val queryId = conf.get(FlintSparkConf.QUERY_ID.key, "")
 
-    if (jobType.equalsIgnoreCase("streaming")) {
+    if (jobType.equalsIgnoreCase(FlintJobType.STREAMING)) {
       if (resultIndexOption.isEmpty) {
         logAndThrow("resultIndex is not set")
       }
@@ -223,7 +223,7 @@ object FlintREPL extends Logging with FlintJobExecutor {
 
   def getQuery(queryOption: Option[String], jobType: String, conf: SparkConf): String = {
     queryOption.getOrElse {
-      if (jobType.equalsIgnoreCase("streaming")) {
+      if (jobType.equalsIgnoreCase(FlintJobType.STREAMING)) {
         val defaultQuery = conf.get(FlintSparkConf.QUERY.key, "")
         if (defaultQuery.isEmpty) {
           logAndThrow("Query undefined for the streaming job.")

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/SingleStatementExecutionManagerImpl.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/SingleStatementExecutionManagerImpl.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql
+
+import org.opensearch.flint.common.model.FlintStatement
+import org.opensearch.flint.core.storage.OpenSearchUpdater
+import org.opensearch.search.sort.SortOrder
+
+import org.apache.spark.internal.Logging
+
+/**
+ * SingleStatementExecutionManager is an implementation of StatementExecutionManager interface to
+ * run single statement
+ * @param commandContext
+ */
+class SingleStatementExecutionManager(
+    commandContext: CommandContext,
+    resultIndex: String,
+    osClient: OSClient)
+    extends StatementExecutionManager
+    with FlintJobExecutor
+    with Logging {
+
+  override def prepareStatementExecution(): Either[String, Unit] = {
+    checkAndCreateIndex(osClient, resultIndex)
+  }
+
+  override def updateStatement(statement: FlintStatement): Unit = {
+    // TODO: Update FlintJob to Support All Query Types. Track on https://github.com/opensearch-project/opensearch-spark/issues/633
+  }
+
+  override def terminateStatementExecution(): Unit = {
+    // TODO: Update FlintJob to Support All Query Types. Track on https://github.com/opensearch-project/opensearch-spark/issues/633
+  }
+
+  override def getNextStatement(): Option[FlintStatement] = {
+    // TODO: Update FlintJob to Support All Query Types. Track on https://github.com/opensearch-project/opensearch-spark/issues/633
+    None
+  }
+
+  override def executeStatement(statement: FlintStatement): DataFrame = {
+    import commandContext._
+    val isStreaming = jobType.equalsIgnoreCase("streaming")
+    executeQuery(
+      applicationId,
+      jobId,
+      spark,
+      statement.query,
+      dataSource,
+      statement.queryId,
+      sessionId,
+      isStreaming)
+  }
+}

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/SingleStatementExecutionManagerImpl.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/SingleStatementExecutionManagerImpl.scala
@@ -43,7 +43,7 @@ class SingleStatementExecutionManager(
 
   override def executeStatement(statement: FlintStatement): DataFrame = {
     import commandContext._
-    val isStreaming = jobType.equalsIgnoreCase("streaming")
+    val isStreaming = jobType.equalsIgnoreCase(FlintJobType.STREAMING)
     executeQuery(
       applicationId,
       jobId,

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/StatementExecutionManagerImpl.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/StatementExecutionManagerImpl.scala
@@ -38,7 +38,7 @@ class StatementExecutionManagerImpl(commandContext: CommandContext)
   override def updateStatement(statement: FlintStatement): Unit = {
     flintSessionIndexUpdater.update(statement.statementId, FlintStatement.serialize(statement))
   }
-  override def terminateStatementsExecution(): Unit = {
+  override def terminateStatementExecution(): Unit = {
     flintReader.close()
   }
 

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -50,6 +50,7 @@ class FlintREPLTest
 
   private val jobId = "testJobId"
   private val applicationId = "testApplicationId"
+  private val INTERACTIVE_JOB_TYPE = "interactive"
 
   test("parseArgs with no arguments should return (None, None)") {
     val args = Array.empty[String]
@@ -669,6 +670,7 @@ class FlintREPLTest
         jobId,
         spark,
         dataSource,
+        INTERACTIVE_JOB_TYPE,
         sessionId,
         sessionManager,
         queryResultWriter,
@@ -734,6 +736,7 @@ class FlintREPLTest
         jobId,
         mockSparkSession,
         dataSource,
+        INTERACTIVE_JOB_TYPE,
         sessionId,
         sessionManager,
         queryResultWriter,
@@ -808,6 +811,7 @@ class FlintREPLTest
         jobId,
         mockSparkSession,
         dataSource,
+        INTERACTIVE_JOB_TYPE,
         sessionId,
         sessionManager,
         queryResultWriter,
@@ -1059,6 +1063,7 @@ class FlintREPLTest
       jobId,
       spark,
       dataSource,
+      INTERACTIVE_JOB_TYPE,
       sessionId,
       sessionManager,
       queryResultWriter,
@@ -1128,6 +1133,7 @@ class FlintREPLTest
       jobId,
       spark,
       dataSource,
+      INTERACTIVE_JOB_TYPE,
       sessionId,
       sessionManager,
       queryResultWriter,
@@ -1193,6 +1199,7 @@ class FlintREPLTest
       jobId,
       spark,
       dataSource,
+      INTERACTIVE_JOB_TYPE,
       sessionId,
       sessionManager,
       queryResultWriter,
@@ -1263,6 +1270,7 @@ class FlintREPLTest
       jobId,
       spark,
       dataSource,
+      INTERACTIVE_JOB_TYPE,
       sessionId,
       sessionManager,
       queryResultWriter,
@@ -1355,6 +1363,7 @@ class FlintREPLTest
       jobId,
       mockSparkSession,
       dataSource,
+      INTERACTIVE_JOB_TYPE,
       sessionId,
       sessionManager,
       queryResultWriter,
@@ -1430,6 +1439,7 @@ class FlintREPLTest
         jobId,
         spark,
         dataSource,
+        INTERACTIVE_JOB_TYPE,
         sessionId,
         sessionManager,
         queryResultWriter,


### PR DESCRIPTION
### Description

1. Batch and Streaming query will take `queryId` from spark conf `spark.flint.job.queryId`
2.  Refactor `FlintJob` using the `FlintStatement` data model and the `StatementExecutionManager` interface, and provide `SingleStatementExecutionManager` as the `StatementExecutionManager` implementation. With this enhancement, `FlintJob` may manage the query lifecycle using these extension points. FlintJob's default behavior remains unchanged.

### Future task 
https://github.com/opensearch-project/opensearch-spark/issues/633

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/602

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
