### PR TITLE
Antler syntax extensions related ot signum function.

### DIFF
--- a/ppl-spark-integration/README.md
+++ b/ppl-spark-integration/README.md
@@ -333,6 +333,7 @@ Limitation: Overriding existing field is unsupported, following queries throw ex
  - `source = table | eval a = 10 | fields a,b,c`
  - `source = table | eval a = a * 2 | stats avg(a)`
  - `source = table | eval a = abs(a) | where a > 0`
+ - `source = table | eval a = signum(a) | where a < 0`
 
 **Aggregations**
  - `source = table | stats avg(a) `

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
@@ -259,6 +259,7 @@ POWER:                              'POWER';
 RAND:                               'RAND';
 ROUND:                              'ROUND';
 SIGN:                               'SIGN';
+SIGNUM:                             'SIGNUM';
 SQRT:                               'SQRT';
 TRUNCATE:                           'TRUNCATE';
 

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -558,6 +558,7 @@ mathematicalFunctionName
    | RAND
    | ROUND
    | SIGN
+   | SIGNUM
    | SQRT
    | TRUNCATE
    | trigonometricFunctionName

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanMathFunctionsTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanMathFunctionsTranslatorTestSuite.scala
@@ -191,4 +191,18 @@ class PPLLogicalPlanMathFunctionsTranslatorTestSuite
     val expectedPlan = Project(projectList, evalProject)
     comparePlans(expectedPlan, logPlan, false)
   }
+
+  test("test signum") {
+    val context = new CatalystPlanContext
+    val logPlan = planTransformer.visit(plan(pplParser, "source=t a = signum(b)", false), context)
+
+    val table = UnresolvedRelation(Seq("t"))
+    val filterExpr = EqualTo(
+      UnresolvedAttribute("a"),
+      UnresolvedFunction("signum", seq(UnresolvedAttribute("b")), isDistinct = false))
+    val filterPlan = Filter(filterExpr, table)
+    val projectList = Seq(UnresolvedStar(None))
+    val expectedPlan = Project(projectList, filterPlan)
+    comparePlans(expectedPlan, logPlan, false)
+  }
 }

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanMathFunctionsTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanMathFunctionsTranslatorTestSuite.scala
@@ -194,7 +194,7 @@ class PPLLogicalPlanMathFunctionsTranslatorTestSuite
 
   test("test signum") {
     val context = new CatalystPlanContext
-    val logPlan = planTransformer.visit(plan(pplParser, "source=t a = signum(b)", false), context)
+    val logPlan = planTransformer.visit(plan(pplParser, "source=t a = signum(b)"), context)
 
     val table = UnresolvedRelation(Seq("t"))
     val filterExpr = EqualTo(


### PR DESCRIPTION
### Description
Antler syntax extended so that PPL supports the `signum` function.
### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/467

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
