### PR TITLE
Optional support for getAllIndexMetadata by index pattern

### DIFF
--- a/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/FlintIndexMetadataService.java
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/metadata/FlintIndexMetadataService.java
@@ -26,13 +26,21 @@ public interface FlintIndexMetadataService {
   FlintMetadata getIndexMetadata(String indexName);
 
   /**
-   * Retrieve all metadata for Flint index whose name matches the given pattern.
+   * Whether the service supports retrieving metadata for Flint indexes by index pattern.
    *
-   * @param indexNamePattern index name pattern
-   * @return map where the keys are the matched index names, and the values are
+   * @return true if supported, otherwise false
+   */
+  boolean supportsGetByIndexPattern();
+
+  /**
+   * Retrieve all metadata for Flint index whose name matches the given pattern.
+   * If get by index pattern is not supported, then the provided names must be full index names.
+   *
+   * @param indexNamePatterns index full names or patterns
+   * @return map where the keys are the (matched) index names, and the values are
    *         corresponding index metadata
    */
-  Map<String, FlintMetadata> getAllIndexMetadata(String... indexNamePattern);
+  Map<String, FlintMetadata> getAllIndexMetadata(String... indexNamePatterns);
 
   /**
    * Update metadata for a Flint index.

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintClient.java
@@ -8,6 +8,8 @@ package org.opensearch.flint.core;
 import org.opensearch.flint.common.metadata.FlintMetadata;
 import org.opensearch.flint.core.storage.FlintWriter;
 
+import java.util.List;
+
 /**
  * Flint index client that provides API for metadata and data operations
  * on a Flint index regardless of concrete storage.
@@ -29,6 +31,14 @@ public interface FlintClient {
    * @return true if the index exists, otherwise false
    */
   boolean exists(String indexName);
+
+  /**
+   * Get all index names that match the given pattern.
+   *
+   * @param indexNamePatterns index name patterns
+   * @return list of index names
+   */
+  List<String> getIndexNames(String... indexNamePatterns);
 
   /**
    * Delete a Flint index.

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchIndexMetadataService.scala
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchIndexMetadataService.scala
@@ -46,9 +46,12 @@ class FlintOpenSearchIndexMetadataService(options: FlintOptions)
       }
   }
 
-  override def getAllIndexMetadata(indexNamePattern: String*): util.Map[String, FlintMetadata] = {
-    logInfo(s"Fetching all Flint index metadata for pattern ${indexNamePattern.mkString(",")}");
-    val indexNames = indexNamePattern.map(OpenSearchClientUtils.sanitizeIndexName)
+  override def supportsGetByIndexPattern(): Boolean = true
+
+  override def getAllIndexMetadata(
+      indexNamePatterns: String*): util.Map[String, FlintMetadata] = {
+    logInfo(s"Fetching all Flint index metadata for pattern ${indexNamePatterns.mkString(",")}");
+    val indexNames = indexNamePatterns.map(OpenSearchClientUtils.sanitizeIndexName)
     var client: IRestHighLevelClient = null
     try {
       client = OpenSearchClientUtils.createClient(options)

--- a/integ-test/src/integration/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
@@ -65,6 +65,17 @@ class FlintOpenSearchClientSuite extends AnyFlatSpec with OpenSearchSuite with M
     (settings \ "index.number_of_replicas").extract[String] shouldBe "2"
   }
 
+  it should "get all index names with the given index name pattern" in {
+    val metadata = FlintOpenSearchIndexMetadataService.deserialize(
+      """{"properties": {"test": { "type": "integer" } } }""")
+    flintClient.createIndex("flint_test_1_index", metadata)
+    flintClient.createIndex("flint_test_2_index", metadata)
+
+    val indexNames = flintClient.getIndexNames("flint_*_index")
+    indexNames should have size 2
+    indexNames should contain allOf ("flint_test_1_index", "flint_test_2_index")
+  }
+
   it should "convert index name to all lowercase" in {
     val indexName = "flint_ELB_logs_index"
     flintClient.createIndex(

--- a/integ-test/src/integration/scala/org/opensearch/flint/core/FlintOpenSearchIndexMetadataServiceITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/core/FlintOpenSearchIndexMetadataServiceITSuite.scala
@@ -108,13 +108,12 @@ class FlintOpenSearchIndexMetadataServiceITSuite
 }
 
 class TestIndexMetadataService extends FlintIndexMetadataService {
-  override def getIndexMetadata(indexName: String): FlintMetadata = {
-    null
-  }
+  override def getIndexMetadata(indexName: String): FlintMetadata = null
 
-  override def getAllIndexMetadata(indexNamePattern: String*): util.Map[String, FlintMetadata] = {
+  override def supportsGetByIndexPattern(): Boolean = true
+
+  override def getAllIndexMetadata(indexNamePattern: String*): util.Map[String, FlintMetadata] =
     null
-  }
 
   override def updateIndexMetadata(indexName: String, metadata: FlintMetadata): Unit = {}
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexDescribeITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkIndexDescribeITSuite.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import java.util
+
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
+import org.opensearch.flint.common.metadata.{FlintIndexMetadataService, FlintMetadata}
+import org.opensearch.flint.core.storage.FlintOpenSearchIndexMetadataService
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.flint.config.FlintSparkConf
+
+class FlintSparkIndexDescribeITSuite extends FlintSparkSuite with Matchers {
+
+  /** Test table and index name */
+  private val testTable = "spark_catalog.default.covering_sql_test"
+  private val testIndexMatch1 = "name_and_age_1"
+  private val testIndexMatch2 = "name_and_age_2"
+  private val testIndexOther = "address"
+  private val testFlintIndexMatch1 =
+    FlintSparkCoveringIndex.getFlintIndexName(testIndexMatch1, testTable)
+  private val testFlintIndexMatch2 =
+    FlintSparkCoveringIndex.getFlintIndexName(testIndexMatch2, testTable)
+  private val testFlintIndexOther =
+    FlintSparkCoveringIndex.getFlintIndexName(testIndexOther, testTable)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    createPartitionedAddressTable(testTable)
+
+    flint
+      .coveringIndex()
+      .name(testIndexMatch1)
+      .onTable(testTable)
+      .addIndexColumns("name", "age")
+      .create()
+
+    flint
+      .coveringIndex()
+      .name(testIndexMatch2)
+      .onTable(testTable)
+      .addIndexColumns("name", "age")
+      .create()
+
+    flint
+      .coveringIndex()
+      .name(testIndexOther)
+      .onTable(testTable)
+      .addIndexColumns("address")
+      .create()
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+
+    // Delete all test indices
+    deleteTestIndex(testFlintIndexMatch1, testFlintIndexMatch2, testFlintIndexOther)
+    sql(s"DROP TABLE $testTable")
+  }
+
+  test("describe all indexes matching a pattern") {
+    val indexNamePattern = FlintSparkCoveringIndex.getFlintIndexName("name_and_age_*", testTable)
+    val indexes = flint.describeIndexes(indexNamePattern)
+    indexes should have size 2
+    indexes.map(_.name) should contain allOf (testFlintIndexMatch1, testFlintIndexMatch2)
+  }
+
+  test(
+    "describe all indexes matching a pattern with custom index metadata service implementation without get-by-pattern support") {
+    setFlintSparkConf(
+      FlintSparkConf.CUSTOM_FLINT_INDEX_METADATA_SERVICE_CLASS,
+      classOf[NoGetByPatternSupportIndexMetadataService].getName)
+    val testFlint = new FlintSpark(spark)
+    val indexNamePattern = FlintSparkCoveringIndex.getFlintIndexName("name_and_age_*", testTable)
+    val indexes = testFlint.describeIndexes(indexNamePattern)
+    indexes should have size 2
+    indexes.map(_.name) should contain allOf (testFlintIndexMatch1, testFlintIndexMatch2)
+  }
+}
+
+class NoGetByPatternSupportIndexMetadataService extends FlintIndexMetadataService with Logging {
+
+  /**
+   * Cannot directly extend FlintOpenSearchIndexMetadataService because
+   * FlintIndexMetadataServiceBuilder expects custom implementation takes no arguments in its
+   * constructor
+   */
+  private val indexMetadataService = new FlintOpenSearchIndexMetadataService(
+    FlintSparkConf().flintOptions())
+
+  override def supportsGetByIndexPattern(): Boolean = false
+
+  /**
+   * Does not match index names by pattern. The input is expected to be a list of full index names
+   */
+  override def getAllIndexMetadata(indexNames: String*): util.Map[String, FlintMetadata] = {
+    logInfo(s"Fetching all Flint index metadata for indexes ${indexNames.mkString(",")}");
+    indexNames
+      .map(index => index -> getIndexMetadata(index))
+      .toMap
+      .asJava
+  }
+
+  override def getIndexMetadata(indexName: String): FlintMetadata =
+    indexMetadataService.getIndexMetadata(indexName)
+
+  override def updateIndexMetadata(indexName: String, metadata: FlintMetadata): Unit =
+    indexMetadataService.updateIndexMetadata(indexName, metadata)
+
+  override def deleteIndexMetadata(indexName: String): Unit =
+    indexMetadataService.deleteIndexMetadata(indexName)
+}


### PR DESCRIPTION
### Description
`FlintIndexMetadataService` used to use index pattern (using wildcard character `*`) to fetch index metadata for indexes matching the pattern. This change makes supporting getting by pattern optional. Instead, the service could fetch index metadata for full index names.

This does not change the `FlintSpark.describeIndexes` api, which still takes an index pattern as argument.

#### Alternative Considered
Alternative is to not use index pattern in `FlintIndexMetadataService.getAllIndexMetadata` at all, and instead always take full index names. However, this adds number of requests overhead for services that do allow for pattern matching, e.g. OpenSearch implementation `FlintOpenSearchIndexMetadataService`. Instead of making 1 request, a pattern that matches to N indexes would require N requests to fetch their metadata, if getting by pattern is removed completely.

### Issues Resolved
* #371 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
