### PR TITLE
Translate PPL `LOOKUP` Command

### DIFF
--- a/docs/PPL-Lookup-command.md
+++ b/docs/PPL-Lookup-command.md
@@ -1,0 +1,69 @@
+## PPL Lookup Command
+
+## Overview
+Lookup command enriches your search data by adding or replacing data from a lookup index (dimension table).
+You can extend fields of an index with values from a dimension table, append or replace values when lookup condition is matched.
+As an alternative of [Join command](../docs/PPL-Join-command.md), lookup command is more suitable for enriching the source data with a static dataset.
+
+
+### Syntax of Lookup Command
+
+```sql
+SEARCH source=<sourceIndex>
+| <other piped command>
+| LOOKUP <lookupIndex> (<lookupMappingField> [AS <sourceMappingField>])...
+    [(REPLACE | APPEND) (<inputField> [AS <outputField>])...]
+| <other piped command>
+```
+**lookupIndex**
+- Required
+- Description: the name of lookup index (dimension table)
+
+**lookupMappingField**
+- Required
+- Description: A mapping key in \<lookupIndex\>, analogy to a join key from right table. You can specify multiple \<lookupMappingField\> with comma-delimited.
+
+**sourceMappingField**
+- Optional
+- Default: \<lookupMappingField\>
+- Description: A mapping key from source **query**, analogy to a join key from left side. If you don't specify any \<sourceMappingField\>, its default value is \<lookupMappingField\>.
+
+**inputField**
+- Optional
+- Default: All fields of \<lookupIndex\> where matched values are applied to result output if no field is specified.
+- Description: A field in \<lookupIndex\> where matched values are applied to result output. You can specify multiple \<inputField\> with comma-delimited. If you don't specify any \<inputField\>, all fields of \<lookupIndex\> where matched values are applied to result output.
+
+**outputField**
+- Optional
+- Default: \<inputField\>
+- Description:  A field of output. You can specify multiple \<outputField\>. If you specify \<outputField\> with an existing field name in source query, its values will be replaced or appended by matched values from \<inputField\>. If the field specified in \<outputField\> is a new field, an extended new field will be applied to the results.
+
+**REPLACE | APPEND**
+- Optional
+- Default: REPLACE
+- Description: If you specify REPLACE, matched values in \<lookupIndex\> field overwrite the values in result. If you specify APPEND, matched values in \<lookupIndex\> field only append to the missing values in result.
+
+### Usage
+> LOOKUP <lookupIndex> id AS cid REPLACE mail AS email</br>
+> LOOKUP <lookupIndex> name REPLACE mail AS email</br>
+> LOOKUP <lookupIndex> id AS cid, name APPEND address, mail AS email</br>
+> LOOKUP <lookupIndex> id</br>
+
+### Example
+```sql
+SEARCH source=<sourceIndex>
+| WHERE orderType = 'Cancelled'
+| LOOKUP account_list, mkt_id AS mkt_code REPLACE amount, account_name AS name
+| STATS count(mkt_code), avg(amount) BY name
+```
+```sql
+SEARCH source=<sourceIndex>
+| DEDUP market_id
+| EVAL category=replace(category, "-", ".")
+| EVAL category=ltrim(category, "dvp.")
+| LOOKUP bounce_category category AS category APPEND classification
+```
+```sql
+SEARCH source=<sourceIndex>
+| LOOKUP bounce_category category
+```

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -277,15 +277,15 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
          | """.stripMargin)
   }
 
-  protected def createWorkInformationTable(testTable: String): Unit = {
+  protected def createPeopleTable(testTable: String): Unit = {
     sql(s"""
            | CREATE TABLE $testTable
            | (
-           |   firstname STRING,
-           |   department STRING,
-           |   uid INT,
-           |   salary INT,
-           |   newSalary INT
+           |   id INT,
+           |   name STRING,
+           |   occupation STRING,
+           |   country STRING,
+           |   salary INT
            | )
            | USING $tableType $tableOptions
            |""".stripMargin)
@@ -293,11 +293,35 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
     // Insert data into the new table
     sql(s"""
            | INSERT INTO $testTable
-           | VALUES ('Jake', 'IT', 1000 , 100000, 150000),
-           |        ('John', 'HR', 1001, 120000, 170000),
-           |        ('David', 'HR', 1002, 120000, 100000),
-           |        ('Tom', 'SALES', 1003, 0, 200000),
-           |        ('Jane', 'DATA', 1004, 90000, 110000)
+           | VALUES (1000, 'Jake', 'Engineer', 'England' , 100000),
+           |        (1001, 'Hello', 'Artist', 'USA', 70000),
+           |        (1002, 'John', 'Doctor', 'Canada', 120000),
+           |        (1003, 'David', 'Doctor', null, 120000),
+           |        (1004, 'David', null, 'Canada', 0),
+           |        (1005, 'Jane', 'Scientist', 'Canada', 90000)
+           | """.stripMargin)
+  }
+
+  protected def createWorkInformationTable(testTable: String): Unit = {
+    sql(s"""
+           | CREATE TABLE $testTable
+           | (
+           |   uid INT,
+           |   name STRING,
+           |   department STRING,
+           |   occupation STRING
+           | )
+           | USING $tableType $tableOptions
+           |""".stripMargin)
+
+    // Insert data into the new table
+    sql(s"""
+           | INSERT INTO $testTable
+           | VALUES (1000, 'Jake', 'IT', 'Engineer'),
+           |        (1002, 'John', 'DATA', 'Scientist'),
+           |        (1003, 'David', 'HR', 'Doctor'),
+           |        (1005, 'Jane', 'DATA', 'Engineer'),
+           |        (1006, 'Tom', 'SALES', 'Artist')
            | """.stripMargin)
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -277,6 +277,30 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
          | """.stripMargin)
   }
 
+  protected def createWorkInformationTable(testTable: String): Unit = {
+    sql(s"""
+           | CREATE TABLE $testTable
+           | (
+           |   firstname STRING,
+           |   department STRING,
+           |   uid INT,
+           |   salary INT,
+           |   newSalary INT
+           | )
+           | USING $tableType $tableOptions
+           |""".stripMargin)
+
+    // Insert data into the new table
+    sql(s"""
+           | INSERT INTO $testTable
+           | VALUES ('Jake', 'IT', 1000 , 100000, 150000),
+           |        ('John', 'HR', 1001, 120000, 170000),
+           |        ('David', 'HR', 1002, 120000, 100000),
+           |        ('Tom', 'SALES', 1003, 0, 200000),
+           |        ('Jane', 'DATA', 1004, 90000, 110000)
+           | """.stripMargin)
+  }
+
   protected def createOccupationTopRareTable(testTable: String): Unit = {
     sql(s"""
       | CREATE TABLE $testTable

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.ppl
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.streaming.StreamTest
+
+class FlintSparkPPLLookupITSuite
+    extends QueryTest
+    with LogicalPlanTestUtils
+    with FlintPPLSuite
+    with StreamTest {
+
+  /** Test table and index name */
+  private val testTable1 = "spark_catalog.default.flint_ppl_test1"
+  private val testTable2 = "spark_catalog.default.flint_ppl_test2"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    createOccupationTable(testTable1)
+    createWorkInformationTable(testTable2)
+  }
+
+  protected override def afterEach(): Unit = {
+    super.afterEach()
+    // Stop all streaming jobs if any
+    spark.streams.active.foreach { job =>
+      job.stop()
+      job.awaitTermination()
+    }
+  }
+
+  test(
+    "test LookupCriteria -> ON, Single Condition, OutputStrategy -> REPLACE, Single OutputField") {
+    val frame = sql(s"""
+                       | source = $testTable1 | LOOKUP $testTable2 firstname AS name REPLACE newSalary AS salary
+                       | """.stripMargin)
+    val results: Array[Row] = frame.collect()
+    results.foreach(println(_))
+  }
+
+  test(
+    "test LookupCriteria -> ON, Multiple Conditions, OutputStrategy -> REPLACE, Single OutputField") {
+    val frame = sql(s"""
+                       | source = $testTable1 | LOOKUP $testTable2 ON name = firstname AND $testTable1.salary = $testTable2.salary REPLACE newSalary AS salary
+                       | """.stripMargin)
+    val results: Array[Row] = frame.collect()
+    results.foreach(println(_))
+  }
+
+  test("test jon") {
+    val frame = sql(s"""
+                       | source = $testTable1 | join left=l right=r ON name = firstname AND l.salary = r.salary $testTable2
+                       | """.stripMargin)
+    val results: Array[Row] = frame.collect()
+    results.foreach(println(_))
+  }
+}

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
@@ -200,7 +200,8 @@ class FlintSparkPPLLookupITSuite
   }
 
   test("test LOOKUP lookupTable uid AS id, name REPLACE department") {
-    val frame = sql(s"source = $testTable1| LOOKUP $testTable2 uID AS id, name REPLACE department")
+    val frame =
+      sql(s"source = $testTable1| LOOKUP $testTable2 uID AS id, name REPLACE department")
     // frame.show()
     // frame.explain(true)
     val results: Array[Row] = frame.collect()
@@ -215,12 +216,18 @@ class FlintSparkPPLLookupITSuite
     implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, Integer](_.getAs[Integer](0))
     assert(results.sorted.sameElements(expectedResults.sorted))
     val lookupProject =
-      Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uID"), UnresolvedAttribute("name")), lookupAlias)
+      Project(
+        Seq(
+          UnresolvedAttribute("department"),
+          UnresolvedAttribute("uID"),
+          UnresolvedAttribute("name")),
+        lookupAlias)
     val joinCondition =
       And(
         EqualTo(UnresolvedAttribute("uID"), UnresolvedAttribute("id")),
-        EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.name"), UnresolvedAttribute("__auto_generated_subquery_name_s.name"))
-      )
+        EqualTo(
+          UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
+          UnresolvedAttribute("__auto_generated_subquery_name_s.name")))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
     val coalesceForSafeExpr =
       Coalesce(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("department")))
@@ -258,12 +265,18 @@ class FlintSparkPPLLookupITSuite
     assert(results.sorted.sameElements(expectedResults.sorted))
 
     val lookupProject =
-      Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid"), UnresolvedAttribute("name")), lookupAlias)
+      Project(
+        Seq(
+          UnresolvedAttribute("department"),
+          UnresolvedAttribute("uid"),
+          UnresolvedAttribute("name")),
+        lookupAlias)
     val joinCondition =
       And(
         EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("ID")),
-        EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.name"), UnresolvedAttribute("__auto_generated_subquery_name_s.name"))
-      )
+        EqualTo(
+          UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
+          UnresolvedAttribute("__auto_generated_subquery_name_s.name")))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
     val coalesceExpr =
       Coalesce(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("department")))
@@ -304,20 +317,21 @@ class FlintSparkPPLLookupITSuite
 
   ignore("test LOOKUP lookupTable name REPLACE occupation") {
     val frame =
-      sql(s"source = $testTable1 | eval major = occupation | fields id, name, major, country, salary | LOOKUP $testTable2 name REPLACE occupation AS major")
+      sql(
+        s"source = $testTable1 | eval major = occupation | fields id, name, major, country, salary | LOOKUP $testTable2 name REPLACE occupation AS major")
     frame.show()
     frame.explain(true)
     val results: Array[Row] = frame.collect()
-    //+----+-----+-------+------+---------+
-    //|  id| name|country|salary|    major|
-    //+----+-----+-------+------+---------+
-    //|1000| Jake|England|100000| Engineer|
-    //|1001|Hello|    USA| 70000|   Artist|
-    //|1002| John| Canada|120000|Scientist|
-    //|1003|David|   NULL|120000|   Doctor|
-    //|1004|David| Canada|     0|   Doctor|  --> null
-    //|1005| Jane| Canada| 90000| Engineer|
-    //+----+-----+-------+------+---------+
+    // +----+-----+-------+------+---------+
+    // |  id| name|country|salary|    major|
+    // +----+-----+-------+------+---------+
+    // |1000| Jake|England|100000| Engineer|
+    // |1001|Hello|    USA| 70000|   Artist|
+    // |1002| John| Canada|120000|Scientist|
+    // |1003|David|   NULL|120000|   Doctor|
+    // |1004|David| Canada|     0|   Doctor|  --> null
+    // |1005| Jane| Canada| 90000| Engineer|
+    // +----+-----+-------+------+---------+
     val expectedResults: Array[Row] = Array(
       Row(1000, "Jake", "England", 100000, "Engineer"),
       Row(1001, "Hello", "USA", 70000, "Artist"),
@@ -353,20 +367,21 @@ class FlintSparkPPLLookupITSuite
 
   ignore("test LOOKUP lookupTable name APPEND occupation") {
     val frame =
-      sql(s"source = $testTable1 | eval major = occupation | fields id, name, major, country, salary | LOOKUP $testTable2 name APPEND occupation AS major")
+      sql(
+        s"source = $testTable1 | eval major = occupation | fields id, name, major, country, salary | LOOKUP $testTable2 name APPEND occupation AS major")
     frame.show()
     frame.explain(true)
     val results: Array[Row] = frame.collect()
-    //+----+-----+-------+------+---------+
-    //|  id| name|country|salary|    major|
-    //+----+-----+-------+------+---------+
-    //|1000| Jake|England|100000| Engineer|
-    //|1001|Hello|    USA| 70000|   Artist|
-    //|1002| John| Canada|120000|   Doctor|
-    //|1003|David|   NULL|120000|   Doctor|
-    //|1004|David| Canada|     0|   Doctor| --> null
-    //|1005| Jane| Canada| 90000|Scientist|
-    //+----+-----+-------+------+---------+
+    // +----+-----+-------+------+---------+
+    // |  id| name|country|salary|    major|
+    // +----+-----+-------+------+---------+
+    // |1000| Jake|England|100000| Engineer|
+    // |1001|Hello|    USA| 70000|   Artist|
+    // |1002| John| Canada|120000|   Doctor|
+    // |1003|David|   NULL|120000|   Doctor|
+    // |1004|David| Canada|     0|   Doctor| --> null
+    // |1005| Jane| Canada| 90000|Scientist|
+    // +----+-----+-------+------+---------+
     val expectedResults: Array[Row] = Array(
       Row(1000, "Jake", "England", 100000, "Engineer"),
       Row(1001, "Hello", "USA", 70000, "Artist"),

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
@@ -6,6 +6,10 @@
 package org.opensearch.flint.spark.ppl
 
 import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation, UnresolvedStar}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Coalesce, EqualTo}
+import org.apache.spark.sql.catalyst.plans.LeftOuter
+import org.apache.spark.sql.catalyst.plans.logical.{DataFrameDropColumns, Join, JoinHint, LogicalPlan, Project, SubqueryAlias}
 import org.apache.spark.sql.streaming.StreamTest
 
 class FlintSparkPPLLookupITSuite
@@ -20,7 +24,7 @@ class FlintSparkPPLLookupITSuite
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    createOccupationTable(testTable1)
+    createPeopleTable(testTable1)
     createWorkInformationTable(testTable2)
   }
 
@@ -33,29 +37,364 @@ class FlintSparkPPLLookupITSuite
     }
   }
 
-  test(
-    "test LookupCriteria -> ON, Single Condition, OutputStrategy -> REPLACE, Single OutputField") {
-    val frame = sql(s"""
-                       | source = $testTable1 | LOOKUP $testTable2 firstname AS name REPLACE newSalary AS salary
-                       | """.stripMargin)
-    val results: Array[Row] = frame.collect()
-    results.foreach(println(_))
+  private def sourceAlias: LogicalPlan = {
+    val tbl = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test1"))
+    SubqueryAlias("__auto_generated_subquery_name_s", tbl)
   }
 
-  test(
-    "test LookupCriteria -> ON, Multiple Conditions, OutputStrategy -> REPLACE, Single OutputField") {
-    val frame = sql(s"""
-                       | source = $testTable1 | LOOKUP $testTable2 ON name = firstname AND $testTable1.salary = $testTable2.salary REPLACE newSalary AS salary
-                       | """.stripMargin)
-    val results: Array[Row] = frame.collect()
-    results.foreach(println(_))
+  private def lookupAlias: LogicalPlan = {
+    val tbl = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test2"))
+    SubqueryAlias("__auto_generated_subquery_name_l", tbl)
   }
 
-  test("test jon") {
-    val frame = sql(s"""
-                       | source = $testTable1 | join left=l right=r ON name = firstname AND l.salary = r.salary $testTable2
-                       | """.stripMargin)
+  test("test LOOKUP lookupTable uid AS id REPLACE department") {
+    val frame = sql(s"source = $testTable1| LOOKUP $testTable2 uid AS id REPLACE department")
+    // frame.show()
+    // frame.explain(true)
     val results: Array[Row] = frame.collect()
-    results.foreach(println(_))
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "Engineer", "England", 100000, "IT"),
+      Row(1001, "Hello", "Artist", "USA", 70000, null),
+      Row(1002, "John", "Doctor", "Canada", 120000, "DATA"),
+      Row(1003, "David", "Doctor", null, 120000, "HR"),
+      Row(1004, "David", null, "Canada", 0, null),
+      Row(1005, "Jane", "Scientist", "Canada", 90000, "DATA"))
+
+    implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, Integer](_.getAs[Integer](0))
+    assert(results.sorted.sameElements(expectedResults.sorted))
+    val lookupProject =
+      Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
+    val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
+    val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
+    val coalesceForSafeExpr =
+      Coalesce(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("department")))
+    val projectAfterJoin = Project(
+      Seq(
+        UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
+        Alias(coalesceForSafeExpr, "department")()),
+      joinPlan)
+    val dropColumns = DataFrameDropColumns(
+      Seq(
+        UnresolvedAttribute("uid"),
+        UnresolvedAttribute("__auto_generated_subquery_name_s.department")),
+      projectAfterJoin)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropColumns)
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
+
+  test("test LOOKUP lookupTable uid AS id APPEND department") {
+    val frame = sql(s"source = $testTable1| LOOKUP $testTable2 uid AS id APPEND department")
+    // frame.show()
+    // frame.explain(true)
+    val results: Array[Row] = frame.collect()
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "Engineer", "England", 100000, "IT"),
+      Row(1001, "Hello", "Artist", "USA", 70000, null),
+      Row(1002, "John", "Doctor", "Canada", 120000, "DATA"),
+      Row(1003, "David", "Doctor", null, 120000, "HR"),
+      Row(1004, "David", null, "Canada", 0, null),
+      Row(1005, "Jane", "Scientist", "Canada", 90000, "DATA"))
+
+    implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, Integer](_.getAs[Integer](0))
+    assert(results.sorted.sameElements(expectedResults.sorted))
+
+    val lookupProject =
+      Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
+    val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
+    val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
+    val coalesceExpr =
+      Coalesce(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("department")))
+    val coalesceForSafeExpr = Coalesce(Seq(coalesceExpr, UnresolvedAttribute("department")))
+    val projectAfterJoin = Project(
+      Seq(
+        UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
+        Alias(coalesceForSafeExpr, "department")()),
+      joinPlan)
+    val dropColumns = DataFrameDropColumns(
+      Seq(
+        UnresolvedAttribute("uid"),
+        UnresolvedAttribute("__auto_generated_subquery_name_s.department")),
+      projectAfterJoin)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropColumns)
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
+
+  test("test LOOKUP lookupTable uid AS id REPLACE department AS country") {
+    val frame =
+      sql(s"source = $testTable1| LOOKUP $testTable2 uid AS id REPLACE department AS country")
+    // frame.show()
+    frame.explain(true)
+    val results: Array[Row] = frame.collect()
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "Engineer", 100000, "IT"),
+      Row(1001, "Hello", "Artist", 70000, "USA"),
+      Row(1002, "John", "Doctor", 120000, "DATA"),
+      Row(1003, "David", "Doctor", 120000, "HR"),
+      Row(1004, "David", null, 0, "Canada"),
+      Row(1005, "Jane", "Scientist", 90000, "DATA"))
+
+    implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, Integer](_.getAs[Integer](0))
+    assert(results.sorted.sameElements(expectedResults.sorted))
+
+    val lookupProject =
+      Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
+    val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
+    val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
+    val coalesceForSafeExpr =
+      Coalesce(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("country")))
+    val projectAfterJoin = Project(
+      Seq(
+        UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
+        Alias(coalesceForSafeExpr, "country")()),
+      joinPlan)
+    val dropColumns = DataFrameDropColumns(
+      Seq(
+        UnresolvedAttribute("uid"),
+        UnresolvedAttribute("__auto_generated_subquery_name_s.country")),
+      projectAfterJoin)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropColumns)
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
+
+  test("test LOOKUP lookupTable uid AS id APPEND department AS country") {
+    val frame =
+      sql(s"source = $testTable1| LOOKUP $testTable2 uid AS id APPEND department AS country")
+    // frame.show()
+    frame.explain(true)
+    val results: Array[Row] = frame.collect()
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "Engineer", 100000, "England"),
+      Row(1001, "Hello", "Artist", 70000, "USA"),
+      Row(1002, "John", "Doctor", 120000, "Canada"),
+      Row(1003, "David", "Doctor", 120000, "HR"),
+      Row(1004, "David", null, 0, "Canada"),
+      Row(1005, "Jane", "Scientist", 90000, "Canada"))
+
+    val lookupProject =
+      Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
+    val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
+    val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
+    val coalesceExpr =
+      Coalesce(Seq(UnresolvedAttribute("country"), UnresolvedAttribute("department")))
+    val coalesceForSafeExpr = Coalesce(Seq(coalesceExpr, UnresolvedAttribute("country")))
+    val projectAfterJoin = Project(
+      Seq(
+        UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
+        Alias(coalesceForSafeExpr, "country")()),
+      joinPlan)
+    val dropColumns = DataFrameDropColumns(
+      Seq(
+        UnresolvedAttribute("uid"),
+        UnresolvedAttribute("__auto_generated_subquery_name_s.country")),
+      projectAfterJoin)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropColumns)
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
+
+  test("test LOOKUP lookupTable uid AS id, name REPLACE department") {
+    val frame = sql(s"source = $testTable1| LOOKUP $testTable2 uID AS id, name REPLACE department")
+    // frame.show()
+    // frame.explain(true)
+    val results: Array[Row] = frame.collect()
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "Engineer", "England", 100000, "IT"),
+      Row(1001, "Hello", "Artist", "USA", 70000, null),
+      Row(1002, "John", "Doctor", "Canada", 120000, "DATA"),
+      Row(1003, "David", "Doctor", null, 120000, "HR"),
+      Row(1004, "David", null, "Canada", 0, null),
+      Row(1005, "Jane", "Scientist", "Canada", 90000, "DATA"))
+
+    implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, Integer](_.getAs[Integer](0))
+    assert(results.sorted.sameElements(expectedResults.sorted))
+    val lookupProject =
+      Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uID"), UnresolvedAttribute("name")), lookupAlias)
+    val joinCondition =
+      And(
+        EqualTo(UnresolvedAttribute("uID"), UnresolvedAttribute("id")),
+        EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.name"), UnresolvedAttribute("__auto_generated_subquery_name_s.name"))
+      )
+    val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
+    val coalesceForSafeExpr =
+      Coalesce(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("department")))
+    val projectAfterJoin = Project(
+      Seq(
+        UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
+        Alias(coalesceForSafeExpr, "department")()),
+      joinPlan)
+    val dropColumns = DataFrameDropColumns(
+      Seq(
+        UnresolvedAttribute("uID"),
+        UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
+        UnresolvedAttribute("__auto_generated_subquery_name_s.department")),
+      projectAfterJoin)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropColumns)
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
+
+  test("test LOOKUP lookupTable uid AS id, name APPEND department") {
+    val frame = sql(s"source = $testTable1| LOOKUP $testTable2 uid AS ID, name APPEND department")
+    // frame.show()
+    // frame.explain(true)
+    val results: Array[Row] = frame.collect()
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "Engineer", "England", 100000, "IT"),
+      Row(1001, "Hello", "Artist", "USA", 70000, null),
+      Row(1002, "John", "Doctor", "Canada", 120000, "DATA"),
+      Row(1003, "David", "Doctor", null, 120000, "HR"),
+      Row(1004, "David", null, "Canada", 0, null),
+      Row(1005, "Jane", "Scientist", "Canada", 90000, "DATA"))
+
+    implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, Integer](_.getAs[Integer](0))
+    assert(results.sorted.sameElements(expectedResults.sorted))
+
+    val lookupProject =
+      Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid"), UnresolvedAttribute("name")), lookupAlias)
+    val joinCondition =
+      And(
+        EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("ID")),
+        EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.name"), UnresolvedAttribute("__auto_generated_subquery_name_s.name"))
+      )
+    val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
+    val coalesceExpr =
+      Coalesce(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("department")))
+    val coalesceForSafeExpr = Coalesce(Seq(coalesceExpr, UnresolvedAttribute("department")))
+    val projectAfterJoin = Project(
+      Seq(
+        UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
+        Alias(coalesceForSafeExpr, "department")()),
+      joinPlan)
+    val dropColumns = DataFrameDropColumns(
+      Seq(
+        UnresolvedAttribute("uid"),
+        UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
+        UnresolvedAttribute("__auto_generated_subquery_name_s.department")),
+      projectAfterJoin)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropColumns)
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
+
+  test("test LOOKUP lookupTable uid AS id, name") {
+    val frame = sql(s"source = $testTable1| LOOKUP $testTable2 uID AS id, name")
+    frame.show()
+    frame.explain(true)
+    val results: Array[Row] = frame.collect()
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "Engineer", "England", 100000, 1000, "Jake", "IT", "Engineer"),
+      Row(1001, "Hello", "Artist", "USA", 70000, null, null, null, null),
+      Row(1002, "John", "Doctor", "Canada", 120000, 1002, "John", "DATA", "Scientist"),
+      Row(1003, "David", "Doctor", null, 120000, 1003, "David", "HR", "Doctor"),
+      Row(1004, "David", null, "Canada", 0, null, null, null, null),
+      Row(1005, "Jane", "Scientist", "Canada", 90000, 1005, "Jane", "DATA", "Engineer"))
+
+    implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, Integer](_.getAs[Integer](0))
+    assert(results.sorted.sameElements(expectedResults.sorted))
+  }
+
+  ignore("test LOOKUP lookupTable name REPLACE occupation") {
+    val frame =
+      sql(s"source = $testTable1 | eval major = occupation | fields id, name, major, country, salary | LOOKUP $testTable2 name REPLACE occupation AS major")
+    frame.show()
+    frame.explain(true)
+    val results: Array[Row] = frame.collect()
+    //+----+-----+-------+------+---------+
+    //|  id| name|country|salary|    major|
+    //+----+-----+-------+------+---------+
+    //|1000| Jake|England|100000| Engineer|
+    //|1001|Hello|    USA| 70000|   Artist|
+    //|1002| John| Canada|120000|Scientist|
+    //|1003|David|   NULL|120000|   Doctor|
+    //|1004|David| Canada|     0|   Doctor|  --> null
+    //|1005| Jane| Canada| 90000| Engineer|
+    //+----+-----+-------+------+---------+
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "England", 100000, "Engineer"),
+      Row(1001, "Hello", "USA", 70000, "Artist"),
+      Row(1002, "John", "Canada", 120000, "Scientist"),
+      Row(1003, "David", null, 120000, "Doctor"),
+      Row(1004, "David", "Canada", 0, "Doctor"), // -> null
+      Row(1005, "Jane", "Canada", 90000, "Engineer"))
+
+    implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, Integer](_.getAs[Integer](0))
+    assert(results.sorted.sameElements(expectedResults.sorted))
+
+    val lookupProject =
+      Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
+    val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
+    val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
+    val coalesceForSafeExpr =
+      Coalesce(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("country")))
+    val projectAfterJoin = Project(
+      Seq(
+        UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
+        Alias(coalesceForSafeExpr, "country")()),
+      joinPlan)
+    val dropColumns = DataFrameDropColumns(
+      Seq(
+        UnresolvedAttribute("uid"),
+        UnresolvedAttribute("__auto_generated_subquery_name_s.country")),
+      projectAfterJoin)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropColumns)
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
+
+  ignore("test LOOKUP lookupTable name APPEND occupation") {
+    val frame =
+      sql(s"source = $testTable1 | eval major = occupation | fields id, name, major, country, salary | LOOKUP $testTable2 name APPEND occupation AS major")
+    frame.show()
+    frame.explain(true)
+    val results: Array[Row] = frame.collect()
+    //+----+-----+-------+------+---------+
+    //|  id| name|country|salary|    major|
+    //+----+-----+-------+------+---------+
+    //|1000| Jake|England|100000| Engineer|
+    //|1001|Hello|    USA| 70000|   Artist|
+    //|1002| John| Canada|120000|   Doctor|
+    //|1003|David|   NULL|120000|   Doctor|
+    //|1004|David| Canada|     0|   Doctor| --> null
+    //|1005| Jane| Canada| 90000|Scientist|
+    //+----+-----+-------+------+---------+
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "England", 100000, "Engineer"),
+      Row(1001, "Hello", "USA", 70000, "Artist"),
+      Row(1002, "John", "Canada", 120000, "Doctor"),
+      Row(1003, "David", null, 120000, "Doctor"),
+      Row(1004, "David", "Canada", 0, "Doctor"),
+      Row(1005, "Jane", "Canada", 90000, "Scientist"))
+
+    val lookupProject =
+      Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
+    val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
+    val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
+    val coalesceExpr =
+      Coalesce(Seq(UnresolvedAttribute("country"), UnresolvedAttribute("department")))
+    val coalesceForSafeExpr = Coalesce(Seq(coalesceExpr, UnresolvedAttribute("country")))
+    val projectAfterJoin = Project(
+      Seq(
+        UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
+        Alias(coalesceForSafeExpr, "country")()),
+      joinPlan)
+    val dropColumns = DataFrameDropColumns(
+      Seq(
+        UnresolvedAttribute("uid"),
+        UnresolvedAttribute("__auto_generated_subquery_name_s.country")),
+      projectAfterJoin)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropColumns)
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
   }
 }

--- a/ppl-spark-integration/README.md
+++ b/ppl-spark-integration/README.md
@@ -357,6 +357,20 @@ _- **Limitation: sub-searches is unsupported in join right side now**_
 
 Details of Join command, see [PPL-Join-Command](../docs/PPL-Join-command.md)
 
+**Lookup**
+- `source = table1 | lookup table2 id`
+- `source = table1 | lookup table2 id, name`
+- `source = table1 | lookup table2 id as cid, name`
+- `source = table1 | lookup table2 id as cid, name replace dept as department`
+- `source = table1 | lookup table2 id as cid, name replace dept as department, city as location`
+- `source = table1 | lookup table2 id as cid, name append dept as department`
+- `source = table1 | lookup table2 id as cid, name append dept as department, city as location`
+- `source = table1 | lookup table2 id as cid, name replace dept` (dept without "as" is unsupported)
+
+_- **Limitation: "REPLACE" or "APPEND" clause must contain "AS"**_
+
+Details of Lookup command syntax, see [PPL-Lookup-Command](../docs/PPL-Lookup-command.md)
+
 ---
 #### Experimental Commands:
 - `correlation` - [See details](../docs/PPL-Correlation-command.md)

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
@@ -95,6 +95,7 @@ TIME_FIELD:                         'TIME_FIELD';
 TIME_ZONE:                          'TIME_ZONE';
 TRAINING_DATA_SIZE:                 'TRAINING_DATA_SIZE';
 ANOMALY_SCORE_THRESHOLD:            'ANOMALY_SCORE_THRESHOLD';
+APPEND:                             'APPEND';
 
 // COMPARISON FUNCTION KEYWORDS
 CASE:                               'CASE';

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -45,6 +45,7 @@ commands
    | grokCommand
    | parseCommand
    | patternsCommand
+   | lookupCommand
    ;
 
 searchCommand
@@ -143,6 +144,26 @@ patternsParameter
 patternsMethod
    : PUNCT
    | REGEX
+   ;
+
+// lookup
+lookupCommand
+   : LOOKUP tableSource lookupMappingList ((APPEND | REPLACE) outputCandidateList)?
+   ;
+
+lookupMappingList
+   : lookupPair (COMMA lookupPair)*
+   ;
+
+outputCandidateList
+   : lookupPair (COMMA lookupPair)*
+   ;
+
+ // The lookup pair will generate a K-V pair. For example:
+ // 1. When lookupPair is "name AS cName", the key will be Alias(cName, Field(name)), the value will be Field(cName)
+ // 2. When lookupPair is "dept", the key is Alias(dept, Field(dept)), value is Field(dept)
+lookupPair
+   : lookupField = fieldExpression (AS searchField = fieldExpression)?
    ;
 
 kmeansCommand

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -159,11 +159,12 @@ outputCandidateList
    : lookupPair (COMMA lookupPair)*
    ;
 
- // The lookup pair will generate a K-V pair. For example:
+ // The lookup pair will generate a K-V pair.
+ // The format is Key -> Alias(outputFieldName, inputField), Value -> outputField. For example:
  // 1. When lookupPair is "name AS cName", the key will be Alias(cName, Field(name)), the value will be Field(cName)
  // 2. When lookupPair is "dept", the key is Alias(dept, Field(dept)), value is Field(dept)
 lookupPair
-   : lookupField = fieldExpression (AS searchField = fieldExpression)?
+   : inputField = fieldExpression (AS outputField = fieldExpression)?
    ;
 
 kmeansCommand

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -45,6 +45,7 @@ import org.opensearch.sql.ast.tree.Head;
 import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.Limit;
+import org.opensearch.sql.ast.tree.Lookup;
 import org.opensearch.sql.ast.tree.Parse;
 import org.opensearch.sql.ast.tree.Project;
 import org.opensearch.sql.ast.tree.RareTopN;
@@ -96,6 +97,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitFilter(Filter node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitLookup(Lookup node, C context) {
     return visitChildren(node, context);
   }
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Alias.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Alias.java
@@ -33,7 +33,6 @@ public class Alias extends UnresolvedExpression {
   public Alias(String name, UnresolvedExpression delegated) {
     this.name = name;
     this.delegated = delegated;
-    this.alias = name; // alias should equal name if no specific alias assigned
   }
 
   public String getName() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Alias.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Alias.java
@@ -33,6 +33,7 @@ public class Alias extends UnresolvedExpression {
   public Alias(String name, UnresolvedExpression delegated) {
     this.name = name;
     this.delegated = delegated;
+    this.alias = name; // alias should equal name if no specific alias assigned
   }
 
   public String getName() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/BinaryExpression.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/BinaryExpression.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.ast.expression;
 
 import java.util.Arrays;

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/QualifiedName.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/QualifiedName.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
 
@@ -106,5 +107,18 @@ public class QualifiedName extends UnresolvedExpression {
   @Override
   public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
     return nodeVisitor.visitQualifiedName(this, context);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    QualifiedName that = (QualifiedName) o;
+    return Objects.equals(parts, that.parts);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(parts);
   }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Lookup.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Lookup.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.Node;
+import org.opensearch.sql.ast.expression.Alias;
+import org.opensearch.sql.ast.expression.Field;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** AST node represent Lookup operation. */
+public class Lookup extends UnresolvedPlan {
+    private UnresolvedPlan child;
+    private final Relation lookupRelation;
+    private final Map<Alias, Field> lookupMappingMap;
+    private final OutputStrategy outputStrategy;
+    private final Map<Alias, Field> outputCandidateMap;
+
+    public Lookup(
+        Relation lookupRelation,
+        Map<Alias, Field> lookupMappingMap,
+        OutputStrategy outputStrategy,
+        Map<Alias, Field> outputCandidateMap) {
+        this.lookupRelation = lookupRelation;
+        this.lookupMappingMap = lookupMappingMap;
+        this.outputStrategy = outputStrategy;
+        this.outputCandidateMap = outputCandidateMap;
+    }
+
+    @Override
+    public UnresolvedPlan attach(UnresolvedPlan child) {
+        this.child = new SubqueryAlias(child, "_s"); // add a auto generated alias name
+//        this.child = child;
+        return this;
+    }
+
+    @Override
+    public List<? extends Node> getChild() {
+        return ImmutableList.of(child);
+    }
+
+    @Override
+    public <T, C> T accept(AbstractNodeVisitor<T, C> visitor, C context) {
+        return visitor.visitLookup(this, context);
+    }
+
+    public enum OutputStrategy {
+        APPEND,
+        REPLACE
+    }
+
+    public Relation getLookupRelation() {
+        return lookupRelation;
+    }
+
+    /**
+     * Lookup mapping field map. For example:
+     *  1. When mapping is "name AS cName",
+     *     the original key will be Alias(cName, Field(name)), the original value will be Field(cName).
+     *     Returns a map which left join key is Field(name), right join key is Field(cName)
+     *  2. When mapping is "dept",
+     *     the original key is Alias(dept, Field(dept)), the original value is Field(dept).
+     *     Returns a map which left join key is Field(dept), the right join key is Field(dept) too.
+     */
+    public Map<Field, Field> getLookupMappingMap() {
+        return lookupMappingMap.entrySet().stream()
+            .collect(Collectors.toMap(entry -> (Field) (entry.getKey()).getDelegated(), Map.Entry::getValue));
+    }
+
+    public OutputStrategy getOutputStrategy() {
+        return outputStrategy;
+    }
+
+    /**
+     * Output candidate field map. For example:
+     *  1. When output candidate is "name AS cName", the key will be Alias(cName, Field(name)), the value will be Field(cName)
+     *  2. When output candidate is "dept", the key is Alias(dept, Field(dept)), value is Field(dept)
+     */
+    public Map<Alias, Field> getOutputCandidateMap() {
+        return outputCandidateMap;
+    }
+
+    /** Return the lookup output Field list instead of Alias list */
+    public List<Field> getLookupOutputFieldList() {
+        return outputCandidateMap.keySet().stream().map(alias -> (Field) alias.getDelegated()).collect(Collectors.toList());
+    }
+
+    public boolean allFieldsShouldAppliedToOutputList() {
+        return getOutputCandidateMap().isEmpty();
+    }
+
+}

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Lookup.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Lookup.java
@@ -92,23 +92,26 @@ public class Lookup extends UnresolvedPlan {
     }
 
     /**
-     * Output candidate field map. For example:
-     *  1. When output candidate is "name AS cName", the key will be Alias(cName, Field(name)), the value will be Field(cName)
-     *  2. When output candidate is "dept", the key is Alias(dept, Field(dept)), value is Field(dept)
+     * Output candidate field map.
+     *  Format: Key -> Alias(outputFieldName, inputField), Value -> Field(outputField). For example:
+     *  1. When output candidate is "name AS cName", the key will be Alias("cName", Field(name)), the value will be Field(cName)
+     *  2. When output candidate is "dept", the key is Alias("dept", Field(dept)), value is Field(dept)
      */
     public Map<Alias, Field> getOutputCandidateMap() {
         return outputCandidateMap;
     }
 
-    public List<Field> getSourceOutputFieldListWithSubqueryAlias() {
-        return outputCandidateMap.values().stream().map(f ->
+    /** Return a new input field list with source side SubqueryAlias */
+    public List<Field> getFieldListWithSourceSubqueryAlias() {
+        return getOutputCandidateMap().values().stream().map(f ->
             new Field(QualifiedName.of(getSourceSubqueryAliasName(), f.getField().toString()), f.getFieldArgs()))
             .collect(Collectors.toList());
     }
 
-    /** Return the lookup output Field list instead of Alias list */
-    public List<Field> getLookupOutputFieldList() {
-        return outputCandidateMap.keySet().stream().map(alias -> (Field) alias.getDelegated()).collect(Collectors.toList());
+    /** Return the input field list instead of Alias list */
+    public List<Field> getInputFieldList() {
+        return getOutputCandidateMap().keySet().stream()
+            .map(alias -> (Field) alias.getDelegated()).collect(Collectors.toList());
     }
 
     public boolean allFieldsShouldAppliedToOutputList() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/SubqueryAlias.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/SubqueryAlias.java
@@ -20,6 +20,14 @@ public class SubqueryAlias extends UnresolvedPlan {
         this.child = child;
     }
 
+    /**
+     * Create an alias (SubqueryAlias) for a sub-query with a default alias name
+     */
+    public SubqueryAlias(UnresolvedPlan child, String suffix) {
+        this.alias = "__auto_generated_subquery_name" + suffix;
+        this.child = child;
+    }
+
     public String getAlias() {
         return alias;
     }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -347,16 +347,15 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
         ctx.APPEND() != null ? Lookup.OutputStrategy.APPEND : Lookup.OutputStrategy.REPLACE;
     java.util.Map<Alias, Field> lookupMappingList = buildLookupPair(ctx.lookupMappingList().lookupPair());
     java.util.Map<Alias, Field> outputCandidateList =
-        ctx.APPEND() == null && ctx.REPLACE() == null ? emptyMap()
-            : buildLookupPair(ctx.outputCandidateList().lookupPair());
-    return new Lookup(lookupRelation, lookupMappingList, strategy, outputCandidateList);
+        ctx.APPEND() == null && ctx.REPLACE() == null ? emptyMap() : buildLookupPair(ctx.outputCandidateList().lookupPair());
+    return new Lookup(new SubqueryAlias(lookupRelation, "_l"), lookupMappingList, strategy, outputCandidateList);
   }
 
   private java.util.Map<Alias, Field> buildLookupPair(List<OpenSearchPPLParser.LookupPairContext> ctx) {
     return ctx.stream()
       .map(of -> expressionBuilder.visitLookupPair(of))
       .map(And.class::cast)
-      .collect(Collectors.toMap(and -> (Alias) and.getLeft(), and -> (Field) and.getRight()));
+      .collect(Collectors.toMap(and -> (Alias) and.getLeft(), and -> (Field) and.getRight(), (x, y) -> y, LinkedHashMap::new));
   }
 
   /** Top command. */

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -14,6 +14,7 @@ import org.opensearch.flint.spark.ppl.OpenSearchPPLParser;
 import org.opensearch.flint.spark.ppl.OpenSearchPPLParserBaseVisitor;
 import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.ast.expression.Alias;
+import org.opensearch.sql.ast.expression.And;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.EqualTo;
@@ -37,10 +38,10 @@ import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Head;
 import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Kmeans;
+import org.opensearch.sql.ast.tree.Lookup;
 import org.opensearch.sql.ast.tree.Parse;
 import org.opensearch.sql.ast.tree.Project;
 import org.opensearch.sql.ast.tree.RareAggregation;
-import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
@@ -48,7 +49,6 @@ import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.TopAggregation;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
-import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.ppl.utils.ArgumentFactory;
 
 import java.util.ArrayList;
@@ -60,6 +60,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 
 
 /** Class of building the AST. Refines the visit path and build the AST nodes */
@@ -336,6 +337,26 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     Literal pattern = arguments.getOrDefault("pattern", new Literal("", DataType.STRING));
 
     return new Parse(ParseMethod.PATTERNS, sourceField, pattern, arguments);
+  }
+
+  /** Lookup command */
+  @Override
+  public UnresolvedPlan visitLookupCommand(OpenSearchPPLParser.LookupCommandContext ctx) {
+    Relation lookupRelation = new Relation(this.internalVisitExpression(ctx.tableSource()));
+    Lookup.OutputStrategy strategy =
+        ctx.APPEND() != null ? Lookup.OutputStrategy.APPEND : Lookup.OutputStrategy.REPLACE;
+    java.util.Map<Alias, Field> lookupMappingList = buildLookupPair(ctx.lookupMappingList().lookupPair());
+    java.util.Map<Alias, Field> outputCandidateList =
+        ctx.APPEND() == null && ctx.REPLACE() == null ? emptyMap()
+            : buildLookupPair(ctx.outputCandidateList().lookupPair());
+    return new Lookup(lookupRelation, lookupMappingList, strategy, outputCandidateList);
+  }
+
+  private java.util.Map<Alias, Field> buildLookupPair(List<OpenSearchPPLParser.LookupPairContext> ctx) {
+    return ctx.stream()
+      .map(of -> expressionBuilder.visitLookupPair(of))
+      .map(And.class::cast)
+      .collect(Collectors.toMap(and -> (Alias) and.getLeft(), and -> (Field) and.getRight()));
   }
 
   /** Top command. */

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -87,8 +87,8 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     @Override
     public UnresolvedExpression visitLookupPair(OpenSearchPPLParser.LookupPairContext ctx) {
         Field lookupField = (Field) visitFieldExpression(ctx.lookupField);
-        Field searchField = (Field) visitFieldExpression(ctx.searchField);
         if (ctx.AS() != null) {
+            Field searchField = (Field) visitFieldExpression(ctx.searchField);
             return new And(new Alias(ctx.searchField.getText(), lookupField), searchField);
         } else {
             return new And(new Alias(ctx.lookupField.getText(), lookupField), lookupField);

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -86,12 +86,12 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
      */
     @Override
     public UnresolvedExpression visitLookupPair(OpenSearchPPLParser.LookupPairContext ctx) {
-        Field lookupField = (Field) visitFieldExpression(ctx.lookupField);
+        Field inputField = (Field) visitFieldExpression(ctx.inputField);
         if (ctx.AS() != null) {
-            Field searchField = (Field) visitFieldExpression(ctx.searchField);
-            return new And(new Alias(ctx.searchField.getText(), lookupField), searchField);
+            Field outputField = (Field) visitFieldExpression(ctx.outputField);
+            return new And(new Alias(ctx.outputField.getText(), inputField), outputField);
         } else {
-            return new And(new Alias(ctx.lookupField.getText(), lookupField), lookupField);
+            return new And(new Alias(ctx.inputField.getText(), inputField), inputField);
         }
     }
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -82,6 +82,20 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     }
 
     /**
+     * Lookup.
+     */
+    @Override
+    public UnresolvedExpression visitLookupPair(OpenSearchPPLParser.LookupPairContext ctx) {
+        Field lookupField = (Field) visitFieldExpression(ctx.lookupField);
+        Field searchField = (Field) visitFieldExpression(ctx.searchField);
+        if (ctx.AS() != null) {
+            return new And(new Alias(ctx.searchField.getText(), lookupField), searchField);
+        } else {
+            return new And(new Alias(ctx.lookupField.getText(), lookupField), lookupField);
+        }
+    }
+
+    /**
      * Eval clause.
      */
     @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.utils;
+
+import org.apache.spark.sql.catalyst.analysis.UnresolvedStar;
+import org.apache.spark.sql.catalyst.expressions.Alias$;
+import org.apache.spark.sql.catalyst.expressions.Coalesce$;
+import org.apache.spark.sql.catalyst.expressions.EqualTo$;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.opensearch.sql.ast.expression.Alias;
+import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.tree.Lookup;
+import org.opensearch.sql.ppl.CatalystPlanContext;
+import org.opensearch.sql.ppl.CatalystQueryPlanVisitor;
+import scala.Option;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.opensearch.sql.ppl.utils.DataTypeTransformer.seq;
+
+public interface LookupTransformer {
+
+    /** lookup fields (left side join keys) + replace fields in lookup relation */
+    static List<NamedExpression> buildLookupRelationProjectList(
+        Lookup node,
+        CatalystQueryPlanVisitor.ExpressionAnalyzer expressionAnalyzer,
+        CatalystPlanContext context) {
+        List<Field> lookupOutputFields = new ArrayList<>(node.getLookupOutputFieldList());
+        if (lookupOutputFields.isEmpty()) {
+            // All fields will be applied to the output if no lookup output field is specified.
+            return Collections.singletonList(new UnresolvedStar(Option.empty()));
+        }
+        lookupOutputFields.addAll(node.getLookupMappingMap().keySet());
+        return buildProjectListFromFields(lookupOutputFields, expressionAnalyzer, context);
+    }
+
+    static List<NamedExpression> buildProjectListFromFields(
+        List<Field> fields,
+        CatalystQueryPlanVisitor.ExpressionAnalyzer expressionAnalyzer,
+        CatalystPlanContext context) {
+        return fields.stream().map(field -> expressionAnalyzer.visitField(field, context))
+            .map(NamedExpression.class::cast)
+            .collect(Collectors.toList());
+    }
+
+    static Expression buildLookupMappingCondition(
+        Lookup node,
+        CatalystQueryPlanVisitor.ExpressionAnalyzer expressionAnalyzer,
+        CatalystPlanContext context) {
+        // only equi-join conditions are accepted in lookup command
+        List<Expression> equiConditions = new ArrayList<>();
+        for (Map.Entry<Field, Field> entry : node.getLookupMappingMap().entrySet()) {
+            Expression lookupNamedExpression;
+            Expression sourceNamedExpression;
+            if (entry.getKey().getField() == entry.getValue().getField()) {
+                Field lookupWithAlias = buildFieldWithLookupSubqueryAlias(node, entry.getKey());
+                Field sourceWithAlias = buildFieldWithSourceSubqueryAlias(node, entry.getValue());
+                lookupNamedExpression = expressionAnalyzer.visitField(lookupWithAlias, context);
+                sourceNamedExpression = expressionAnalyzer.visitField(sourceWithAlias, context);
+            } else {
+                lookupNamedExpression = expressionAnalyzer.visitField(entry.getKey(), context);
+                sourceNamedExpression = expressionAnalyzer.visitField(entry.getValue(), context);
+            }
+
+            Expression equalTo = EqualTo$.MODULE$.apply(lookupNamedExpression, sourceNamedExpression);
+            equiConditions.add(equalTo);
+        }
+        context.retainAllNamedParseExpressions(e -> e);
+        return equiConditions.stream().reduce(org.apache.spark.sql.catalyst.expressions.And::new).orElse(null);
+    }
+
+    static List<NamedExpression> buildOutputProjectList(
+        Lookup node,
+        Lookup.OutputStrategy strategy,
+        CatalystQueryPlanVisitor.ExpressionAnalyzer expressionAnalyzer,
+        CatalystPlanContext context) {
+        List<NamedExpression> outputProjectList = new ArrayList<>();
+        for (Map.Entry<Alias, Field> entry : node.getOutputCandidateMap().entrySet()) {
+            Alias lookupOutputFieldWithAlias = entry.getKey();
+            Field lookupOutputField = (Field) lookupOutputFieldWithAlias.getDelegated();
+            Field sourceOutputField = entry.getValue();
+            Expression lookupOutputCol = expressionAnalyzer.visitField(lookupOutputField, context);
+            Expression sourceOutputCol = expressionAnalyzer.visitField(sourceOutputField, context);
+//            Expression lookupOutputCol;
+//            Expression sourceOutputCol;
+//            if (lookupOutputField.getField() == sourceOutputField.getField()) {
+//                Field sourceWithAlias = buildFieldWithSourceSubqueryAlias(node, sourceOutputField);
+//                Field lookupWithAlias = buildFieldWithLookupSubqueryAlias(node, lookupOutputField);
+//                sourceOutputCol = expressionAnalyzer.visitField(sourceWithAlias, context);
+//                lookupOutputCol = expressionAnalyzer.visitField(lookupWithAlias, context);
+//            } else {
+//                lookupOutputCol = expressionAnalyzer.visitField(lookupOutputField, context);
+//                sourceOutputCol = expressionAnalyzer.visitField(sourceOutputField, context);
+//            }
+
+            Expression child;
+            if (strategy == Lookup.OutputStrategy.APPEND) {
+                child = Coalesce$.MODULE$.apply(seq(sourceOutputCol, lookupOutputCol));
+            } else {
+                child = lookupOutputCol;
+            }
+            // The result output project list we build here is used to replace the source output,
+            // for the unmatched rows of left outer join, the outputs are null, so fall back to source output.
+            Expression nullSafeOutput = Coalesce$.MODULE$.apply(seq(child, sourceOutputCol));
+            NamedExpression nullSafeOutputCol = Alias$.MODULE$.apply(nullSafeOutput,
+                lookupOutputFieldWithAlias.getAlias(),
+                NamedExpression.newExprId(),
+                seq(new java.util.ArrayList<String>()),
+                Option.empty(),
+                seq(new java.util.ArrayList<String>()));
+            outputProjectList.add(nullSafeOutputCol);
+        }
+        context.retainAllNamedParseExpressions(p -> p);
+        return outputProjectList;
+    }
+
+    static Field buildFieldWithLookupSubqueryAlias(Lookup node, Field field) {
+        return new Field(QualifiedName.of(node.getLookupSubqueryAliasName(), field.getField().toString()));
+    }
+
+    static Field buildFieldWithSourceSubqueryAlias(Lookup node, Field field) {
+        return new Field(QualifiedName.of(node.getSourceSubqueryAliasName(), field.getField().toString()));
+    }
+}

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
@@ -112,7 +112,7 @@ public interface LookupTransformer {
             // for the unmatched rows of left outer join, the outputs are null, so fall back to source output.
             Expression nullSafeOutput = Coalesce$.MODULE$.apply(seq(child, sourceOutputCol));
             NamedExpression nullSafeOutputCol = Alias$.MODULE$.apply(nullSafeOutput,
-                lookupOutputFieldWithAlias.getAlias(),
+                lookupOutputFieldWithAlias.getName(),
                 NamedExpression.newExprId(),
                 seq(new java.util.ArrayList<String>()),
                 Option.empty(),


### PR DESCRIPTION
### Description
__Syntax__
```sql
| LOOKUP <lookupIndex> (<lookupMappingField> [AS <sourceMappingField>])...
    [(REPLACE | APPEND) (<inputField> [AS <outputField>])...]
```

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-spark/issues/620 and parent issue https://github.com/opensearch-project/sql/issues/2651

### Check List
- [x] Updated documentation (ppl-spark-integration/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [x] Commits are signed per the DCO using --signoff 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
