### PR TITLE
Add resultIndex to session manager extension

### DIFF
--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -983,7 +983,8 @@ object FlintREPL extends Logging with FlintJobExecutor {
       resultIndexOption: Option[String]): SessionManager = {
     instantiate(
       new SessionManagerImpl(spark, resultIndexOption),
-      spark.conf.get(FlintSparkConf.CUSTOM_SESSION_MANAGER.key, ""))
+      spark.conf.get(FlintSparkConf.CUSTOM_SESSION_MANAGER.key, ""),
+      resultIndexOption.getOrElse(""))
   }
 
   private def instantiateStatementExecutionManager(

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/QueryResultWriterImpl.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/QueryResultWriterImpl.scala
@@ -9,11 +9,13 @@ import org.opensearch.flint.common.model.FlintStatement
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.FlintJob.writeDataFrameToOpensearch
+import org.apache.spark.sql.flint.config.FlintSparkConf
 
 class QueryResultWriterImpl(context: Map[String, Any]) extends QueryResultWriter with Logging {
 
   private val resultIndex = context("resultIndex").asInstanceOf[String]
-  private val osClient = context("osClient").asInstanceOf[OSClient]
+  // Initialize OSClient with Flint options because custom session manager implementation should not have it in the context
+  private val osClient = new OSClient(FlintSparkConf().flintOptions())
 
   override def writeDataFrame(dataFrame: DataFrame, flintStatement: FlintStatement): Unit = {
     writeDataFrameToOpensearch(dataFrame, resultIndex, osClient)


### PR DESCRIPTION
### Description
Add resultIndex to session manager extension constructor. In this case custom session manager can work with default QueryResultWriter to persist result to OpenSearch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
