### PR TITLE
Import Lombok and override the equals and hashCode methods for expression and plan nodes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -151,7 +151,9 @@ lazy val pplSparkIntegration = (project in file("ppl-spark-integration"))
       "org.scalatest" %% "scalatest-flatspec" % "3.2.15" % "test",
       "org.scalatestplus" %% "mockito-4-6" % "3.2.15.0" % "test",
       "com.stephenn" %% "scalatest-json-jsonassert" % "0.2.5" % "test",
-      "com.github.sbt" % "junit-interface" % "0.13.3" % "test"),
+      "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
+      "org.projectlombok" % "lombok" % "1.18.30",
+    ),
     libraryDependencies ++= deps(sparkVersion),
     // ANTLR settings
     Antlr4 / antlr4Version := "4.8",

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/Node.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/Node.java
@@ -5,9 +5,14 @@
 
 package org.opensearch.sql.ast;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.util.List;
 
 /** AST node. */
+@EqualsAndHashCode
+@ToString
 public abstract class Node {
 
   public <R, C> R accept(AbstractNodeVisitor<R, C> visitor, C context) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/AggregateFunction.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/AggregateFunction.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Collections;
@@ -16,6 +19,9 @@ import static java.lang.String.format;
  * Expression node of aggregate functions. Params include aggregate function name (AVG, SUM, MAX
  * etc.) and the field to aggregate.
  */
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class AggregateFunction extends UnresolvedExpression {
   private final String funcName;
   private final UnresolvedExpression field;
@@ -51,35 +57,9 @@ public class AggregateFunction extends UnresolvedExpression {
     this.distinct = distinct;
   }
 
-  public AggregateFunction(String funcName, UnresolvedExpression field, List<UnresolvedExpression> argList) {
-    this.funcName = funcName;
-    this.field = field;
-    this.argList = argList;
-  }
-
   @Override
   public List<UnresolvedExpression> getChild() {
     return Collections.singletonList(field);
-  }
-
-  public String getFuncName() {
-    return funcName;
-  }
-
-  public UnresolvedExpression getField() {
-    return field;
-  }
-
-  public List<UnresolvedExpression> getArgList() {
-    return argList;
-  }
-
-  public UnresolvedExpression getCondition() {
-    return condition;
-  }
-
-  public Boolean getDistinct() {
-    return distinct;
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Alias.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Alias.java
@@ -5,6 +5,11 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 /**
@@ -13,39 +18,21 @@ import org.opensearch.sql.ast.AbstractNodeVisitor;
  * eventually. This can avoid restoring the info in toString() method which is inaccurate because
  * original info is already lost.
  */
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@RequiredArgsConstructor
+@ToString
 public class Alias extends UnresolvedExpression {
 
   /** Original field name. */
-  private String name;
+  private final String name;
 
   /** Expression aliased. */
-  private UnresolvedExpression delegated;
+  private final UnresolvedExpression delegated;
 
   /** Optional field alias. */
   private String alias;
-
-  public Alias(String name, UnresolvedExpression delegated, String alias) {
-    this.name = name;
-    this.delegated = delegated;
-    this.alias = alias;
-  }
-
-  public Alias(String name, UnresolvedExpression delegated) {
-    this.name = name;
-    this.delegated = delegated;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public UnresolvedExpression getDelegated() {
-    return delegated;
-  }
-
-  public String getAlias() {
-    return alias;
-  }
 
   @Override
   public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/AllFields.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/AllFields.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 
@@ -12,6 +14,8 @@ import java.util.Collections;
 import java.util.List;
 
 /** Represent the All fields which is been used in SELECT *. */
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public class AllFields extends UnresolvedExpression {
   public static final AllFields INSTANCE = new AllFields();
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/And.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/And.java
@@ -5,18 +5,19 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
-import java.util.Arrays;
-import java.util.List;
-
 /** Expression node of logic AND. */
+@ToString
+@EqualsAndHashCode(callSuper = true)
 public class And extends BinaryExpression {
 
   public And(UnresolvedExpression left, UnresolvedExpression right) {
-    super(left,right);
+    super(left, right);
   }
-  
+
   @Override
   public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
     return nodeVisitor.visitAnd(this, context);

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Argument.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Argument.java
@@ -5,33 +5,28 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
 
 /** Argument. */
+@Getter
+@ToString
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class Argument extends UnresolvedExpression {
   private final String name;
   private final Literal value;
-
-  public Argument(String name, Literal value) {
-    this.name = name;
-    this.value = value;
-  }
 
   //    private final DataType valueType;
   @Override
   public List<UnresolvedExpression> getChild() {
     return Arrays.asList(value);
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public Literal getValue() {
-    return value;
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/AttributeList.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/AttributeList.java
@@ -6,13 +6,21 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
 
 /** Expression node that includes a list of Expression nodes. */
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
 public class AttributeList extends UnresolvedExpression {
-  private List<UnresolvedExpression> attrList;
+  private final List<UnresolvedExpression> attrList;
 
   @Override
   public List<UnresolvedExpression> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Between.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Between.java
@@ -5,6 +5,11 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 
@@ -12,6 +17,11 @@ import java.util.Arrays;
 import java.util.List;
 
 /** Unresolved expression for BETWEEN. */
+@Getter
+@Setter
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@ToString
 public class Between extends UnresolvedExpression {
 
   /** Value for range check. */
@@ -22,12 +32,6 @@ public class Between extends UnresolvedExpression {
 
   /** Upper bound of the range (inclusive). */
   private UnresolvedExpression upperBound;
-
-  public Between(UnresolvedExpression value, UnresolvedExpression lowerBound, UnresolvedExpression upperBound) {
-    this.value = value;
-    this.lowerBound = lowerBound;
-    this.upperBound = upperBound;
-  }
 
   @Override
   public List<? extends Node> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/BinaryExpression.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/BinaryExpression.java
@@ -5,30 +5,22 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import java.util.Arrays;
 import java.util.List;
 
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public abstract class BinaryExpression extends UnresolvedExpression {
-    private UnresolvedExpression left;
-    private UnresolvedExpression right;
-
-    public BinaryExpression(UnresolvedExpression left, UnresolvedExpression right) {
-        this.left = left;
-        this.right = right;
-    }
+    private final UnresolvedExpression left;
+    private final UnresolvedExpression right;
 
     @Override
     public List<UnresolvedExpression> getChild() {
         return Arrays.asList(left, right);
     }
-
-    public UnresolvedExpression getLeft() {
-        return left;
-    }
-
-    public UnresolvedExpression getRight() {
-        return right;
-    }
-
 }
-

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Case.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Case.java
@@ -6,12 +6,20 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 
 import java.util.List;
 
 /** AST node that represents CASE clause similar as Switch statement in programming language. */
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@ToString
 public class Case extends UnresolvedExpression {
 
   /** Value to be compared by WHEN statements. Null in the case of CASE WHEN conditions. */
@@ -25,24 +33,6 @@ public class Case extends UnresolvedExpression {
 
   /** Expression that represents ELSE statement result. */
   private UnresolvedExpression elseClause;
-
-  public Case(UnresolvedExpression caseValue, List<When> whenClauses, UnresolvedExpression elseClause) {
-    this.caseValue =caseValue;
-    this.whenClauses = whenClauses;
-    this.elseClause = elseClause;
-  }
-
-  public UnresolvedExpression getCaseValue() {
-    return caseValue;
-  }
-
-  public List<When> getWhenClauses() {
-    return whenClauses;
-  }
-
-  public UnresolvedExpression getElseClause() {
-    return elseClause;
-  }
 
   @Override
   public List<? extends Node> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Compare.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Compare.java
@@ -5,37 +5,27 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
 
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Compare extends UnresolvedExpression {
-    private String operator;
-    private UnresolvedExpression left;
-    private UnresolvedExpression right;
-
-    public Compare(String operator, UnresolvedExpression left, UnresolvedExpression right) {
-        this.operator = operator;
-        this.left = left;
-        this.right = right;
-    }
+    private final String operator;
+    private final UnresolvedExpression left;
+    private final UnresolvedExpression right;
 
     @Override
     public List<UnresolvedExpression> getChild() {
         return Arrays.asList(left, right);
-    }
-
-    public String getOperator() {
-        return operator;
-    }
-
-    public UnresolvedExpression getLeft() {
-        return left;
-    }
-
-    public UnresolvedExpression getRight() {
-        return right;
     }
 
     @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/DataType.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/DataType.java
@@ -5,10 +5,13 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.data.type.ExprCoreType;
 
 /** The DataType defintion in AST. Question, could we use {@link ExprCoreType} directly in AST? */
 
+@RequiredArgsConstructor
 public enum DataType {
   TYPE_ERROR(ExprCoreType.UNKNOWN),
   NULL(ExprCoreType.UNDEFINED),
@@ -26,13 +29,5 @@ public enum DataType {
   TIMESTAMP(ExprCoreType.TIMESTAMP),
   INTERVAL(ExprCoreType.INTERVAL);
 
-   private final ExprCoreType coreType;
-
-  DataType(ExprCoreType type) {
-      this.coreType = type;
-  }
-
-  public ExprCoreType getCoreType() {
-    return coreType;
-  }
+  @Getter private final  ExprCoreType coreType;
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/EqualTo.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/EqualTo.java
@@ -5,28 +5,23 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
 
 /** Expression node of binary operator or comparison relation EQUAL. */
+@ToString
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class EqualTo extends UnresolvedExpression {
     private final UnresolvedExpression left;
     private final UnresolvedExpression right;
-
-    public EqualTo(UnresolvedExpression left, UnresolvedExpression right) {
-        this.left = left;
-        this.right = right;
-    }
-
-    public UnresolvedExpression getLeft() {
-        return left;
-    }
-
-    public UnresolvedExpression getRight() {
-        return right;
-    }
 
     @Override
     public List<UnresolvedExpression> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Field.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Field.java
@@ -6,11 +6,17 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Collections;
 import java.util.List;
 
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public class Field extends UnresolvedExpression {
   private final QualifiedName field;
   private final List<Argument> fieldArgs;
@@ -24,14 +30,6 @@ public class Field extends UnresolvedExpression {
   public Field(QualifiedName field, List<Argument> fieldArgs) {
     this.field = field;
     this.fieldArgs = fieldArgs;
-  }
-
-  public QualifiedName getField() {
-    return field;
-  }
-
-  public List<Argument> getFieldArgs() {
-    return fieldArgs;
   }
 
   public boolean hasArgument() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/FieldsMapping.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/FieldsMapping.java
@@ -1,16 +1,17 @@
 package org.opensearch.sql.ast.expression;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
 
+@Getter
+@RequiredArgsConstructor
 public class FieldsMapping extends UnresolvedExpression {
 
     private final List<UnresolvedExpression> fieldsMappingList;
 
-    public <R> FieldsMapping(List<UnresolvedExpression> fieldsMappingList) {
-        this.fieldsMappingList = fieldsMappingList;
-    }
     public List<UnresolvedExpression> getChild() {
         return fieldsMappingList;
     }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Function.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Function.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Collections;
@@ -15,15 +18,12 @@ import java.util.stream.Collectors;
  * Expression node of scalar function. Params include function name (@funcName) and function
  * arguments (@funcArgs)
  */
-
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Function extends UnresolvedExpression {
-  private String funcName;
-  private List<UnresolvedExpression> funcArgs;
-
-  public Function(String funcName, List<UnresolvedExpression> funcArgs) {
-    this.funcName = funcName;
-    this.funcArgs = funcArgs;
-  }
+  private final String funcName;
+  private final List<UnresolvedExpression> funcArgs;
 
   @Override
   public List<UnresolvedExpression> getChild() {
@@ -33,14 +33,6 @@ public class Function extends UnresolvedExpression {
   @Override
   public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
     return nodeVisitor.visitFunction(this, context);
-  }
-
-  public String getFuncName() {
-    return funcName;
-  }
-
-  public List<UnresolvedExpression> getFuncArgs() {
-    return funcArgs;
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/In.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/In.java
@@ -5,6 +5,10 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Arrays;
@@ -15,15 +19,13 @@ import java.util.List;
  * wildcard field expression, nested field expression (@field). And the values that the field is
  * mapped to (@valueList).
  */
-
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class In extends UnresolvedExpression {
-  private UnresolvedExpression field;
-  private List<UnresolvedExpression> valueList;
-
-  public In(UnresolvedExpression field, List<UnresolvedExpression> valueList) {
-    this.field = field;
-    this.valueList = valueList;
-  }
+  private final UnresolvedExpression field;
+  private final List<UnresolvedExpression> valueList;
 
   @Override
   public List<UnresolvedExpression> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Interval.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Interval.java
@@ -5,21 +5,24 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Collections;
 import java.util.List;
 
-
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Interval extends UnresolvedExpression {
 
   private final UnresolvedExpression value;
   private final IntervalUnit unit;
 
-  public Interval(UnresolvedExpression value, IntervalUnit unit) {
-    this.value = value;
-    this.unit = unit;
-  }
   public Interval(UnresolvedExpression value, String unit) {
     this.value = value;
     this.unit = IntervalUnit.of(unit);
@@ -28,14 +31,6 @@ public class Interval extends UnresolvedExpression {
   @Override
   public List<UnresolvedExpression> getChild() {
     return Collections.singletonList(value);
-  }
-
-  public UnresolvedExpression getValue() {
-    return value;
-  }
-
-  public IntervalUnit getUnit() {
-    return unit;
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/IntervalUnit.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/IntervalUnit.java
@@ -6,10 +6,13 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-
+@Getter
+@RequiredArgsConstructor
 public enum IntervalUnit {
   UNKNOWN,
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/IsEmpty.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/IsEmpty.java
@@ -1,16 +1,19 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
 
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class IsEmpty extends UnresolvedExpression {
-    private Case caseValue;
-
-    public IsEmpty(Case caseValue) {
-        this.caseValue = caseValue;
-    }
+    private final Case caseValue;
 
     @Override
     public List<UnresolvedExpression> getChild() {
@@ -20,10 +23,6 @@ public class IsEmpty extends UnresolvedExpression {
     @Override
     public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
         return nodeVisitor.visitIsEmpty(this, context);
-    }
-
-    public Case getCaseValue() {
-        return caseValue;
     }
 
     @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Let.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Let.java
@@ -6,6 +6,10 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
@@ -13,24 +17,13 @@ import java.util.List;
 /**
  * Represent the assign operation. e.g. velocity = distance/speed.
  */
-
-
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Let extends UnresolvedExpression {
-    private Field var;
-    private UnresolvedExpression expression;
-
-    public Let(Field var, UnresolvedExpression expression) {
-        this.var = var;
-        this.expression = expression;
-    }
-
-    public Field getVar() {
-        return var;
-    }
-
-    public UnresolvedExpression getExpression() {
-        return expression;
-    }
+    private final Field var;
+    private final UnresolvedExpression expression;
 
     @Override
     public List<UnresolvedExpression> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Literal.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Literal.java
@@ -6,6 +6,9 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
@@ -14,16 +17,13 @@ import java.util.List;
  * Expression node of literal type Params include literal value (@value) and literal data type
  * (@type) which can be selected from {@link DataType}.
  */
-
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Literal extends UnresolvedExpression {
 
-    private Object value;
-    private DataType type;
-
-    public Literal(Object value, DataType dataType) {
-        this.value = value;
-        this.type = dataType;
-    }
+    private final Object value;
+    private final DataType type;
 
     @Override
     public List<UnresolvedExpression> getChild() {
@@ -33,14 +33,6 @@ public class Literal extends UnresolvedExpression {
     @Override
     public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
         return nodeVisitor.visitLiteral(this, context);
-    }
-
-    public Object getValue() {
-        return value;
-    }
-
-    public DataType getType() {
-        return type;
     }
 
     @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Map.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Map.java
@@ -5,29 +5,23 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
 
 /** Expression node of one-to-one mapping relation. */
-
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Map extends UnresolvedExpression {
-  private UnresolvedExpression origin;
-  private UnresolvedExpression target;
-
-  public Map(UnresolvedExpression origin, UnresolvedExpression target) {
-    this.origin = origin;
-    this.target = target;
-  }
-
-  public UnresolvedExpression getOrigin() {
-    return origin;
-  }
-
-  public UnresolvedExpression getTarget() {
-    return target;
-  }
+  private final UnresolvedExpression origin;
+  private final UnresolvedExpression target;
 
   @Override
   public List<UnresolvedExpression> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Not.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Not.java
@@ -5,27 +5,26 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
 
 /** Expression node of the logic NOT. */
-
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Not extends UnresolvedExpression {
-  private UnresolvedExpression expression;
-
-  public Not(UnresolvedExpression expression) {
-    this.expression = expression;
-  }
+  private final UnresolvedExpression expression;
 
   @Override
   public List<UnresolvedExpression> getChild() {
     return Arrays.asList(expression);
-  }
-
-  public UnresolvedExpression getExpression() {
-    return expression;
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Or.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Or.java
@@ -5,16 +5,19 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
 
 /** Expression node of the logic OR. */
-
+@ToString
+@EqualsAndHashCode(callSuper = true)
 public class Or extends BinaryExpression {
   public Or(UnresolvedExpression left, UnresolvedExpression right) {
-    super(left,right);
+    super(left, right);
   }
   @Override
   public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/ParseMethod.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/ParseMethod.java
@@ -5,14 +5,15 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum ParseMethod {
   REGEX("regex"),
   GROK("grok"),
   PATTERNS("patterns");
 
-   private final String name;
-
-    ParseMethod(String name) {
-        this.name = name;
-    }
+  private final String name;
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/QualifiedName.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/QualifiedName.java
@@ -6,19 +6,22 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
+@Getter
+@EqualsAndHashCode(callSuper = false)
 public class QualifiedName extends UnresolvedExpression {
   private final List<String> parts;
 
@@ -33,10 +36,6 @@ public class QualifiedName extends UnresolvedExpression {
       throw new IllegalArgumentException("parts is empty");
     }
     this.parts = partsList;
-  }
-
-  public List<String> getParts() {
-    return parts;
   }
 
   /** Construct {@link QualifiedName} from list of string. */
@@ -107,18 +106,5 @@ public class QualifiedName extends UnresolvedExpression {
   @Override
   public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
     return nodeVisitor.visitQualifiedName(this, context);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    QualifiedName that = (QualifiedName) o;
-    return Objects.equals(parts, that.parts);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(parts);
   }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Scope.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Scope.java
@@ -1,6 +1,11 @@
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 /** Scope expression node. Params include field expression and the scope value. */
+@ToString
+@EqualsAndHashCode(callSuper = true)
 public class Scope extends Span {
     public Scope(UnresolvedExpression field, UnresolvedExpression value, SpanUnit unit) {
         super(field, value, unit);

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Span.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Span.java
@@ -6,33 +6,23 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
 
 /** Span expression node. Params include field expression and the span value. */
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@ToString
 public class Span extends UnresolvedExpression {
-  private UnresolvedExpression field;
-  private UnresolvedExpression value;
-  private SpanUnit unit;
-
-  public Span(UnresolvedExpression field, UnresolvedExpression value, SpanUnit unit) {
-    this.field = field;
-    this.value = value;
-    this.unit = unit;
-  }
-
-  public UnresolvedExpression getField() {
-    return field;
-  }
-
-  public UnresolvedExpression getValue() {
-    return value;
-  }
-
-  public SpanUnit getUnit() {
-    return unit;
-  }
+  private final UnresolvedExpression field;
+  private final UnresolvedExpression value;
+  private final SpanUnit unit;
 
   @Override
   public List<UnresolvedExpression> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/SpanUnit.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/SpanUnit.java
@@ -6,10 +6,13 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-
+@Getter
+@RequiredArgsConstructor
 public enum SpanUnit {
   UNKNOWN("unknown"),
   NONE(""),
@@ -38,10 +41,6 @@ public enum SpanUnit {
   static {
     ImmutableList.Builder<SpanUnit> builder = ImmutableList.builder();
     SPAN_UNITS = builder.add(SpanUnit.values()).build();
-  }
-
-  SpanUnit(String name) {
-    this.name = name;
   }
 
   /** Util method to get span unit given the unit name. */

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/UnresolvedArgument.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/UnresolvedArgument.java
@@ -5,21 +5,23 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
 
 /** Argument. */
-
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class UnresolvedArgument extends UnresolvedExpression {
   private final String argName;
   private final UnresolvedExpression value;
-
-  public UnresolvedArgument(String argName, UnresolvedExpression value) {
-    this.argName = argName;
-    this.value = value;
-  }
 
   @Override
   public List<UnresolvedExpression> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/UnresolvedAttribute.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/UnresolvedAttribute.java
@@ -6,6 +6,10 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
@@ -14,13 +18,11 @@ import java.util.List;
  * Expression node, representing the syntax that is not resolved to any other expression nodes yet
  * but non-negligible This expression is often created as the index name, field name etc.
  */
-
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@Getter
 public class UnresolvedAttribute extends UnresolvedExpression {
-  private String attr;
-
-  public UnresolvedAttribute(String attr) {
-    this.attr = attr;
-  }
 
   @Override
   public List<UnresolvedExpression> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/UnresolvedExpression.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/UnresolvedExpression.java
@@ -5,9 +5,13 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 
+@EqualsAndHashCode(callSuper = false)
+@ToString
 public abstract class UnresolvedExpression extends Node {
   @Override
   public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/When.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/When.java
@@ -6,32 +6,27 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 
 import java.util.List;
 
 /** AST node that represents WHEN clause. */
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@RequiredArgsConstructor
+@ToString
 public class When extends UnresolvedExpression {
 
   /** WHEN condition, either a search condition or compare value if case value present. */
-  private UnresolvedExpression condition;
+  private final UnresolvedExpression condition;
 
   /** Result to return if condition matched. */
-  private UnresolvedExpression result;
-
-  public When(UnresolvedExpression condition, UnresolvedExpression result) {
-    this.condition = condition;
-    this.result = result;
-  }
-
-  public UnresolvedExpression getCondition() {
-    return condition;
-  }
-
-  public UnresolvedExpression getResult() {
-    return result;
-  }
+  private final UnresolvedExpression result;
 
   @Override
   public List<? extends Node> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/WindowFunction.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/WindowFunction.java
@@ -6,6 +6,11 @@
 package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
@@ -13,16 +18,15 @@ import org.opensearch.sql.ast.tree.Sort.SortOption;
 
 import java.util.List;
 
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@RequiredArgsConstructor
+@ToString
 public class WindowFunction extends UnresolvedExpression {
-  private UnresolvedExpression function;
+  private final UnresolvedExpression function;
   private List<UnresolvedExpression> partitionByList;
   private List<Pair<SortOption, UnresolvedExpression>> sortList;
-
-  public WindowFunction(UnresolvedExpression function, List<UnresolvedExpression> partitionByList, List<Pair<SortOption, UnresolvedExpression>> sortList) {
-    this.function = function;
-    this.partitionByList = partitionByList;
-    this.sortList = sortList;
-  }
 
   @Override
   public List<? extends Node> getChild() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Xor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Xor.java
@@ -5,19 +5,20 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
 
 /** Expression node of the logic XOR. */
-
+@ToString
+@EqualsAndHashCode(callSuper = true)
 public class Xor extends BinaryExpression {
-  private UnresolvedExpression left;
-  private UnresolvedExpression right;
 
   public Xor(UnresolvedExpression left, UnresolvedExpression right) {
-    super(left,right);
+    super(left, right);
   }
   
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/statement/Explain.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/statement/Explain.java
@@ -8,20 +8,16 @@
 
 package org.opensearch.sql.ast.statement;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 /** Explain Statement. */
+@Data
+@EqualsAndHashCode(callSuper = false)
 public class Explain extends Statement {
 
-  private Statement statement;
-
-  public Explain(Query statement) {
-    this.statement = statement;
-  }
-
-  public Statement getStatement() {
-    return statement;
-  }
+  private final Statement statement;
 
   @Override
   public <R, C> R accept(AbstractNodeVisitor<R, C> visitor, C context) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/statement/Query.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/statement/Query.java
@@ -8,23 +8,24 @@
 
 package org.opensearch.sql.ast.statement;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 
 /** Query Statement. */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Query extends Statement {
 
-  protected UnresolvedPlan plan;
-  protected int fetchSize;
-
-  public Query(UnresolvedPlan plan, int fetchSize) {
-    this.plan = plan;
-    this.fetchSize = fetchSize;
-  }
-
-  public UnresolvedPlan getPlan() {
-    return plan;
-  }
+  protected final UnresolvedPlan plan;
+  protected final int fetchSize;
 
   @Override
   public <R, C> R accept(AbstractNodeVisitor<R, C> visitor, C context) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Aggregation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Aggregation.java
@@ -6,6 +6,10 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
@@ -14,6 +18,10 @@ import java.util.Collections;
 import java.util.List;
 
 /** Logical plan node of Aggregation, the interface for building aggregation actions in queries. */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public class Aggregation extends UnresolvedPlan {
   private List<UnresolvedExpression> aggExprList;
   private List<UnresolvedExpression> sortExprList;
@@ -42,26 +50,6 @@ public class Aggregation extends UnresolvedPlan {
     this.groupExprList = groupExprList;
     this.span = span;
     this.argExprList = argExprList;
-  }
-
-  public List<UnresolvedExpression> getAggExprList() {
-    return aggExprList;
-  }
-
-  public List<UnresolvedExpression> getSortExprList() {
-    return sortExprList;
-  }
-
-  public List<UnresolvedExpression> getGroupExprList() {
-    return groupExprList;
-  }
-
-  public UnresolvedExpression getSpan() {
-    return span;
-  }
-
-  public List<Argument> getArgExprList() {
-    return argExprList;
   }
 
   public boolean hasArgument() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Correlation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Correlation.java
@@ -1,6 +1,10 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.FieldsMapping;
@@ -10,7 +14,10 @@ import org.opensearch.sql.ast.expression.Scope;
 import java.util.List;
 
 /** Logical plan node of correlation , the interface for building the searching sources. */
-
+@ToString
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class Correlation extends UnresolvedPlan {
     private final CorrelationType correlationType;
     private final List<QualifiedName> fieldsList;
@@ -40,27 +47,9 @@ public class Correlation extends UnresolvedPlan {
         return this;
     }
 
-    public CorrelationType getCorrelationType() {
-        return correlationType;
-    }
-
-    public List<QualifiedName> getFieldsList() {
-        return fieldsList;
-    }
-
-    public Scope getScope() {
-        return scope;
-    }
-
-    public FieldsMapping getMappingListContext() {
-        return mappingListContext;
-    }
-
     public enum CorrelationType {
         self,
         exact,
         approximate
     }
-
-    
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Dedupe.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Dedupe.java
@@ -6,6 +6,12 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Field;
@@ -13,33 +19,21 @@ import org.opensearch.sql.ast.expression.Field;
 import java.util.List;
 
 /** AST node represent Dedupe operation. */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
 public class Dedupe extends UnresolvedPlan {
   private UnresolvedPlan child;
-  private List<Argument> options;
-  private List<Field> fields;
-
-  public Dedupe(UnresolvedPlan child, List<Argument> options, List<Field> fields) {
-    this.child = child;
-    this.options = options;
-    this.fields = fields;
-  }
-  public Dedupe(List<Argument> options, List<Field> fields) {
-    this.options = options;
-    this.fields = fields;
-  }
+  private final List<Argument> options;
+  private final List<Field> fields;
 
   @Override
   public Dedupe attach(UnresolvedPlan child) {
     this.child = child;
     return this;
-  }
-
-  public List<Argument> getOptions() {
-    return options;
-  }
-
-  public List<Field> getFields() {
-    return fields;
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/DescribeRelation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/DescribeRelation.java
@@ -5,11 +5,13 @@
 
 package org.opensearch.sql.ast.tree;
 
+import lombok.ToString;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
 /**
  * Extend Relation to describe the table itself
  */
+@ToString
 public class DescribeRelation extends Relation{
     public DescribeRelation(UnresolvedExpression tableName) {
         super(tableName);

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Eval.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Eval.java
@@ -6,23 +6,25 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Let;
 
 import java.util.List;
 
 /** AST node represent Eval operation. */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Eval extends UnresolvedPlan {
-  private List<Let> expressionList;
+  private final List<Let> expressionList;
   private UnresolvedPlan child;
-
-  public Eval(List<Let> expressionList) {
-    this.expressionList = expressionList;
-  }
-
-  public List<Let> getExpressionList() {
-    return expressionList;
-  }
 
   @Override
   public Eval attach(UnresolvedPlan child) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Filter.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Filter.java
@@ -6,13 +6,18 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
 import java.util.List;
 
 /** Logical plan node of Filter, the interface for building filters in queries. */
-
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@Getter
 public class Filter extends UnresolvedPlan {
   private UnresolvedExpression condition;
   private UnresolvedPlan child;
@@ -25,10 +30,6 @@ public class Filter extends UnresolvedPlan {
   public Filter attach(UnresolvedPlan child) {
     this.child = child;
     return this;
-  }
-
-  public UnresolvedExpression getCondition() {
-    return condition;
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Head.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Head.java
@@ -6,41 +6,33 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
 
 /** AST node represent Head operation. */
-
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
 public class Head extends UnresolvedPlan {
 
   private UnresolvedPlan child;
-  private Integer size;
-  private Integer from;
-
-  public Head(UnresolvedPlan child, Integer size, Integer from) {
-    this.child = child;
-    this.size = size;
-    this.from = from;
-  }
-
-  public Head(Integer size, Integer from) {
-    this.size = size;
-    this.from = from;
-  }
+  private final Integer size;
+  private final Integer from;
 
   @Override
   public Head attach(UnresolvedPlan child) {
     this.child = child;
     return this;
-  }
-
-  public Integer getSize() {
-    return size;
-  }
-
-  public Integer getFrom() {
-    return from;
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Join.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Join.java
@@ -8,13 +8,20 @@ package org.opensearch.sql.ast.tree;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableMap;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
+@ToString
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class Join extends UnresolvedPlan {
     private UnresolvedPlan left;
     private final UnresolvedPlan right;
@@ -23,21 +30,6 @@ public class Join extends UnresolvedPlan {
     private final JoinType joinType;
     private final Optional<UnresolvedExpression> joinCondition;
     private final JoinHint joinHint;
-
-    public Join(
-            UnresolvedPlan right,
-            String leftAlias,
-            String rightAlias,
-            JoinType joinType,
-            Optional<UnresolvedExpression> joinCondition,
-            JoinHint joinHint) {
-        this.right = right;
-        this.leftAlias = leftAlias;
-        this.rightAlias = rightAlias;
-        this.joinType = joinType;
-        this.joinCondition = joinCondition;
-        this.joinHint = joinHint;
-    }
 
     @Override
     public UnresolvedPlan attach(UnresolvedPlan child) {
@@ -65,56 +57,13 @@ public class Join extends UnresolvedPlan {
         FULL
     }
 
-    public UnresolvedPlan getRight() {
-        return right;
-    }
-
-    public String getLeftAlias() {
-        return leftAlias;
-    }
-
-    public String getRightAlias() {
-        return rightAlias;
-    }
-
-    public JoinType getJoinType() {
-        return joinType;
-    }
-
-    public Optional<UnresolvedExpression> getJoinCondition() {
-        return joinCondition;
-    }
-
-    public JoinHint getJoinHint() {
-        return joinHint;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Join join = (Join) o;
-        return Objects.equals(left, join.left) && Objects.equals(right, join.right) && Objects.equals(leftAlias, join.leftAlias) && Objects.equals(rightAlias, join.rightAlias) && joinType == join.joinType && Objects.equals(joinCondition, join.joinCondition) && Objects.equals(joinHint, join.joinHint);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(left, right, leftAlias, rightAlias, joinType, joinCondition, joinHint);
-    }
-
+    @Getter
+    @RequiredArgsConstructor
     public static class JoinHint {
         private final Map<String, String> hints;
 
         public JoinHint() {
             this.hints = ImmutableMap.of();
-        }
-
-        public JoinHint(Map<String, String> hints) {
-            this.hints = hints;
-        }
-
-        public Map<String, String> getHints() {
-            return hints;
         }
     }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Kmeans.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Kmeans.java
@@ -7,20 +7,28 @@ package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Literal;
 
 import java.util.List;
 import java.util.Map;
 
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+@RequiredArgsConstructor
+@AllArgsConstructor
 public class Kmeans extends UnresolvedPlan {
     private UnresolvedPlan child;
 
-    private Map<String, Literal> arguments;
-
-    public Kmeans(ImmutableMap<String, Literal> arguments) {
-        this.arguments = arguments;
-    }
+    private final Map<String, Literal> arguments;
 
     @Override
     public UnresolvedPlan attach(UnresolvedPlan child) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Limit.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Limit.java
@@ -6,19 +6,22 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
 
+@RequiredArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
 public class Limit extends UnresolvedPlan {
     private UnresolvedPlan child;
-    private Integer limit;
-    private Integer offset;
-
-    public Limit(Integer limit, Integer offset) {
-        this.limit = limit;
-        this.offset = offset;
-    }
+    private final Integer limit;
+    private final Integer offset;
 
     @Override
     public Limit attach(UnresolvedPlan child) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Lookup.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Lookup.java
@@ -6,6 +6,10 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.Alias;
@@ -18,23 +22,22 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /** AST node represent Lookup operation. */
+@ToString
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class Lookup extends UnresolvedPlan {
     private UnresolvedPlan child;
     private final UnresolvedPlan lookupRelation;
     private final Map<Alias, Field> lookupMappingMap;
     private final OutputStrategy outputStrategy;
+    /**
+     * Output candidate field map.
+     *  Format: Key -> Alias(outputFieldName, inputField), Value -> Field(outputField). For example:
+     *  1. When output candidate is "name AS cName", the key will be Alias("cName", Field(name)), the value will be Field(cName)
+     *  2. When output candidate is "dept", the key is Alias("dept", Field(dept)), value is Field(dept)
+     */
     private final Map<Alias, Field> outputCandidateMap;
-
-    public Lookup(
-        UnresolvedPlan lookupRelation,
-        Map<Alias, Field> lookupMappingMap,
-        OutputStrategy outputStrategy,
-        Map<Alias, Field> outputCandidateMap) {
-        this.lookupRelation = lookupRelation;
-        this.lookupMappingMap = lookupMappingMap;
-        this.outputStrategy = outputStrategy;
-        this.outputCandidateMap = outputCandidateMap;
-    }
 
     @Override
     public UnresolvedPlan attach(UnresolvedPlan child) {
@@ -55,10 +58,6 @@ public class Lookup extends UnresolvedPlan {
     public enum OutputStrategy {
         APPEND,
         REPLACE
-    }
-
-    public UnresolvedPlan getLookupRelation() {
-        return lookupRelation;
     }
 
     public String getLookupSubqueryAliasName() {
@@ -85,20 +84,6 @@ public class Lookup extends UnresolvedPlan {
                 Map.Entry::getValue,
                 (k, y) -> y,
                 LinkedHashMap::new));
-    }
-
-    public OutputStrategy getOutputStrategy() {
-        return outputStrategy;
-    }
-
-    /**
-     * Output candidate field map.
-     *  Format: Key -> Alias(outputFieldName, inputField), Value -> Field(outputField). For example:
-     *  1. When output candidate is "name AS cName", the key will be Alias("cName", Field(name)), the value will be Field(cName)
-     *  2. When output candidate is "dept", the key is Alias("dept", Field(dept)), value is Field(dept)
-     */
-    public Map<Alias, Field> getOutputCandidateMap() {
-        return outputCandidateMap;
     }
 
     /** Return a new input field list with source side SubqueryAlias */

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Parse.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Parse.java
@@ -6,6 +6,12 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.ParseMethod;
@@ -15,54 +21,27 @@ import java.util.List;
 import java.util.Map;
 
 /** AST node represent Parse with regex operation. */
-
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
 public class Parse extends UnresolvedPlan {
   /** Method used to parse a field. */
-  private  ParseMethod parseMethod;
+  private final ParseMethod parseMethod;
 
   /** Field. */
-  private  UnresolvedExpression sourceField;
+  private final UnresolvedExpression sourceField;
 
   /** Pattern. */
-  private  Literal pattern;
+  private final Literal pattern;
 
   /** Optional arguments. */
-  private  Map<String, Literal> arguments;
+  private final Map<String, Literal> arguments;
 
   /** Child Plan. */
   private UnresolvedPlan child;
-
-  public Parse(ParseMethod parseMethod, UnresolvedExpression sourceField, Literal pattern, Map<String, Literal> arguments, UnresolvedPlan child) {
-    this.parseMethod = parseMethod;
-    this.sourceField = sourceField;
-    this.pattern = pattern;
-    this.arguments = arguments;
-    this.child = child;
-  }
-
-  public Parse(ParseMethod parseMethod, UnresolvedExpression sourceField, Literal pattern, Map<String, Literal> arguments) {
-
-    this.parseMethod = parseMethod;
-    this.sourceField = sourceField;
-    this.pattern = pattern;
-    this.arguments = arguments;
-  }
-
-  public ParseMethod getParseMethod() {
-    return parseMethod;
-  }
-
-  public UnresolvedExpression getSourceField() {
-    return sourceField;
-  }
-
-  public Literal getPattern() {
-    return pattern;
-  }
-
-  public Map<String, Literal> getArguments() {
-    return arguments;
-  }
 
   @Override
   public Parse attach(UnresolvedPlan child) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Project.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Project.java
@@ -6,6 +6,10 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
@@ -14,8 +18,11 @@ import java.util.Collections;
 import java.util.List;
 
 /** Logical plan node of Project, the interface for building the list of searching fields. */
+@ToString
+@Getter
+@EqualsAndHashCode(callSuper = false)
 public class Project extends UnresolvedPlan {
-   private List<UnresolvedExpression> projectList;
+  @Setter private List<UnresolvedExpression> projectList;
   private List<Argument> argExprList;
   private UnresolvedPlan child;
 
@@ -27,14 +34,6 @@ public class Project extends UnresolvedPlan {
   public Project(List<UnresolvedExpression> projectList, List<Argument> argExprList) {
     this.projectList = projectList;
     this.argExprList = argExprList;
-  }
-
-  public List<UnresolvedExpression> getProjectList() {
-    return projectList;
-  }
-
-  public List<Argument> getArgExprList() {
-    return argExprList;
   }
 
   public boolean hasArgument() {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/RareAggregation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/RareAggregation.java
@@ -5,12 +5,16 @@
 
 package org.opensearch.sql.ast.tree;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
 import java.util.Collections;
 import java.util.List;
 
 /** Logical plan node of Rare (Aggregation) command, the interface for building aggregation actions in queries. */
+@ToString
+@EqualsAndHashCode(callSuper = true)
 public class RareAggregation extends Aggregation {
   /** Aggregation Constructor without span and argument. */
   public RareAggregation(
@@ -19,5 +23,4 @@ public class RareAggregation extends Aggregation {
       List<UnresolvedExpression> groupExprList) {
     super(aggExprList, sortExprList, groupExprList, null, Collections.emptyList());
   }
-
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/RareTopN.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/RareTopN.java
@@ -5,6 +5,12 @@
 
 package org.opensearch.sql.ast.tree;
 
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Field;
@@ -14,42 +20,24 @@ import java.util.Collections;
 import java.util.List;
 
 /** AST node represent RareTopN operation. */
-
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
 public class RareTopN extends UnresolvedPlan {
 
   private UnresolvedPlan child;
-  private CommandType commandType;
-  private List<Argument> noOfResults;
-  private List<Field> fields;
-  private List<UnresolvedExpression> groupExprList;
-
-  public RareTopN( CommandType commandType, List<Argument> noOfResults, List<Field> fields, List<UnresolvedExpression> groupExprList) {
-    this.commandType = commandType;
-    this.noOfResults = noOfResults;
-    this.fields = fields;
-    this.groupExprList = groupExprList;
-  }
+  private final CommandType commandType;
+  private final List<Argument> noOfResults;
+  private final List<Field> fields;
+  private final List<UnresolvedExpression> groupExprList;
 
   @Override
   public RareTopN attach(UnresolvedPlan child) {
     this.child = child;
     return this;
-  }
-
-  public CommandType getCommandType() {
-    return commandType;
-  }
-
-  public List<Argument> getNoOfResults() {
-    return noOfResults;
-  }
-
-  public List<Field> getFields() {
-    return fields;
-  }
-
-  public List<UnresolvedExpression> getGroupExprList() {
-    return groupExprList;
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Relation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Relation.java
@@ -6,6 +6,10 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
@@ -15,7 +19,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /** Logical plan node of Relation, the interface for building the searching sources. */
-
+@AllArgsConstructor
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Relation extends UnresolvedPlan {
   private static final String COMMA = ",";
 
@@ -23,10 +30,6 @@ public class Relation extends UnresolvedPlan {
 
   public Relation(UnresolvedExpression tableName) {
     this(tableName, null);
-  }
-
-  public Relation(List<UnresolvedExpression> tableName) {
-    this.tableName = tableName;
   }
 
   public Relation(UnresolvedExpression tableName, String alias) {
@@ -46,7 +49,6 @@ public class Relation extends UnresolvedPlan {
     return tableName.stream().map(Object::toString).collect(Collectors.toList());
   }
 
- 
   /**
    * Return alias.
    *

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Rename.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Rename.java
@@ -6,11 +6,19 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Map;
 
 import java.util.List;
 
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@RequiredArgsConstructor
 public class Rename extends UnresolvedPlan {
   private final List<Map> renameList;
   private UnresolvedPlan child;
@@ -18,14 +26,6 @@ public class Rename extends UnresolvedPlan {
   public Rename(List<Map> renameList, UnresolvedPlan child) {
     this.renameList = renameList;
     this.child = child;
-  }
-
-  public Rename(List<Map> renameList) {
-    this.renameList = renameList;
-  }
-
-  public List<Map> getRenameList() {
-    return renameList;
   }
 
   @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Sort.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Sort.java
@@ -6,6 +6,12 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Field;
 
@@ -19,19 +25,14 @@ import static org.opensearch.sql.ast.tree.Sort.SortOrder.DESC;
 /**
  * AST node for Sort {@link Sort#sortList} represent a list of sort expression and sort options.
  */
-
-
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
 public class Sort extends UnresolvedPlan {
     private UnresolvedPlan child;
-    private List<Field> sortList;
-
-    public Sort(List<Field> sortList) {
-        this.sortList = sortList;
-    }
-    public Sort(UnresolvedPlan child, List<Field> sortList) {
-        this.child = child;
-        this.sortList = sortList;
-    }
+    private final List<Field> sortList;
 
     @Override
     public Sort attach(UnresolvedPlan child) {
@@ -49,14 +50,10 @@ public class Sort extends UnresolvedPlan {
         return nodeVisitor.visitSort(this, context);
     }
 
-    public List<Field> getSortList() {
-        return sortList;
-    }
-
     /**
      * Sort Options.
      */
-
+    @Data
     public static class SortOption {
 
         /**
@@ -69,13 +66,8 @@ public class Sort extends UnresolvedPlan {
          */
         public static SortOption DEFAULT_DESC = new SortOption(DESC, NULL_LAST);
 
-        private SortOrder sortOrder;
-        private NullOrder nullOrder;
-
-        public SortOption(SortOrder sortOrder, NullOrder nullOrder) {
-            this.sortOrder = sortOrder;
-            this.nullOrder = nullOrder;
-        }
+        private final SortOrder sortOrder;
+        private final NullOrder nullOrder;
     }
 
     public enum SortOrder {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/SubqueryAlias.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/SubqueryAlias.java
@@ -6,19 +6,23 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
 import java.util.Objects;
 
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@ToString
 public class SubqueryAlias extends UnresolvedPlan {
-    private final String alias;
+    @Getter private final String alias;
     private UnresolvedPlan child;
-
-    public SubqueryAlias(String alias, UnresolvedPlan child) {
-        this.alias = alias;
-        this.child = child;
-    }
 
     /**
      * Create an alias (SubqueryAlias) for a sub-query with a default alias name
@@ -26,10 +30,6 @@ public class SubqueryAlias extends UnresolvedPlan {
     public SubqueryAlias(UnresolvedPlan child, String suffix) {
         this.alias = "__auto_generated_subquery_name" + suffix;
         this.child = child;
-    }
-
-    public String getAlias() {
-        return alias;
     }
 
     public List<UnresolvedPlan> getChild() {
@@ -45,18 +45,5 @@ public class SubqueryAlias extends UnresolvedPlan {
     @Override
     public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
         return nodeVisitor.visitSubqueryAlias(this, context);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SubqueryAlias alias1 = (SubqueryAlias) o;
-        return Objects.equals(alias, alias1.alias) && Objects.equals(child, alias1.child);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(alias, child);
     }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/TableFunction.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/TableFunction.java
@@ -6,6 +6,10 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
@@ -15,22 +19,14 @@ import java.util.List;
 /**
  * AST Node for Table Function.
  */
-
-
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class TableFunction extends UnresolvedPlan {
 
-    private UnresolvedExpression functionName;
+    private final UnresolvedExpression functionName;
 
-    private List<UnresolvedExpression> arguments;
-
-    public TableFunction(UnresolvedExpression functionName, List<UnresolvedExpression> arguments) {
-        this.functionName = functionName;
-        this.arguments = arguments;
-    }
-
-    public List<UnresolvedExpression> getArguments() {
-        return arguments;
-    }
+    @Getter private final List<UnresolvedExpression> arguments;
 
     public QualifiedName getFunctionName() {
         return (QualifiedName) functionName;

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/TopAggregation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/TopAggregation.java
@@ -5,6 +5,10 @@
 
 package org.opensearch.sql.ast.tree;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
@@ -13,6 +17,9 @@ import java.util.List;
 import java.util.Optional;
 
 /** Logical plan node of Top (Aggregation) command, the interface for building aggregation actions in queries. */
+@ToString
+@Getter
+@EqualsAndHashCode(callSuper = true)
 public class TopAggregation extends Aggregation {
   private final Optional<Literal> results;
 
@@ -24,9 +31,5 @@ public class TopAggregation extends Aggregation {
       List<UnresolvedExpression> groupExprList) {
     super(aggExprList, sortExprList, groupExprList, null, Collections.emptyList());
     this.results = results;
-  }
-
-  public Optional<Literal> getResults() {
-    return results;
   }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/UnresolvedPlan.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/UnresolvedPlan.java
@@ -5,12 +5,14 @@
 
 package org.opensearch.sql.ast.tree;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 
 /** Abstract unresolved plan. */
-
-
+@EqualsAndHashCode(callSuper = false)
+@ToString
 public abstract class UnresolvedPlan extends Node {
   @Override
   public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Values.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Values.java
@@ -6,6 +6,10 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.Literal;
@@ -15,16 +19,13 @@ import java.util.List;
 /**
  * AST node class for a sequence of literal values.
  */
-
-
+@ToString
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
 public class Values extends UnresolvedPlan {
 
-    private List<List<Literal>> values;
-
-    public <T> Values(List<T> list) {
-        
-    }
-
+    private final List<List<Literal>> values;
 
     @Override
     public UnresolvedPlan attach(UnresolvedPlan child) {


### PR DESCRIPTION
### Description
Some expression and plan nodes in PPL Spark lack of `equals` and `hashCode` methods which may cause potential bugs.
Import Lombok dependency for `ppl-spark-integration` module and **align the related codes** with SQL's implementation.

This is a code refactor PR which doesn't introduce any new functionality.

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-spark/issues/702

### Check List
- ~~[ ] Updated documentation (ppl-spark-integration/README.md)~~
- ~~[ ] Implemented unit tests~~
- ~~[ ] Implemented tests for combination with other commands~~
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
