### PR TITLE
Re-select an excluded field should throw SyntaxCheckException

### DIFF
--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
@@ -75,6 +75,7 @@ import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TopAggregation;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.ppl.utils.AggregatorTranslator;
 import org.opensearch.sql.ppl.utils.BuiltinFunctionTranslator;
 import org.opensearch.sql.ppl.utils.ComparatorTransformer;
@@ -337,7 +338,16 @@ public class CatalystQueryPlanVisitor extends AbstractNodeVisitor<LogicalPlan, C
 
     @Override
     public LogicalPlan visitProject(Project node, CatalystPlanContext context) {
-        if (!node.isExcluded()) {
+        if (node.isExcluded()) {
+            List<UnresolvedExpression> intersect = context.getProjectedFields().stream()
+                .filter(node.getProjectList()::contains)
+                .collect(Collectors.toList());
+            if (!intersect.isEmpty()) {
+                // Fields in parent projection, but they have be excluded in child. For example,
+                // source=t | fields - A, B | fields A, B, C will throw "[Field A, Field B] can't be resolved"
+                throw new SyntaxCheckException(intersect + " can't be resolved");
+            }
+        } else {
             context.withProjectedFields(node.getProjectList());
         }
         LogicalPlan child = node.getChild().get(0).accept(this, context);

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanBasicQueriesTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanBasicQueriesTranslatorTestSuite.scala
@@ -6,6 +6,7 @@
 package org.opensearch.flint.spark.ppl
 
 import org.opensearch.flint.spark.ppl.PlaneUtils.plan
+import org.opensearch.sql.common.antlr.SyntaxCheckException
 import org.opensearch.sql.ppl.{CatalystPlanContext, CatalystQueryPlanVisitor}
 import org.scalatest.matchers.should.Matchers
 
@@ -310,5 +311,34 @@ class PPLLogicalPlanBasicQueriesTranslatorTestSuite
     val planWithLimit = GlobalLimit(Literal(5), LocalLimit(Literal(5), dropAB))
     val expectedPlan = Project(Seq(UnresolvedStar(None)), planWithLimit)
     comparePlans(expectedPlan, logPlan, false)
+  }
+
+  test("test fields + then - field list") {
+    val context = new CatalystPlanContext
+    val logPlan = planTransformer.visit(
+      plan(pplParser, "source=t | fields + A, B, C | fields - A, B"),
+      context)
+
+    val table = UnresolvedRelation(Seq("t"))
+    val projectABC = Project(
+      Seq(UnresolvedAttribute("A"), UnresolvedAttribute("B"), UnresolvedAttribute("C")),
+      table)
+    val dropList = Seq(UnresolvedAttribute("A"), UnresolvedAttribute("B"))
+    val dropAB = DataFrameDropColumns(dropList, projectABC)
+
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropAB)
+    comparePlans(expectedPlan, logPlan, false)
+  }
+
+  test("test fields - then + field list") {
+    val context = new CatalystPlanContext
+    val thrown = intercept[SyntaxCheckException] {
+      planTransformer.visit(
+        plan(pplParser, "source=t | fields - A, B | fields + A, B, C"),
+        context)
+    }
+    assert(
+      thrown.getMessage
+        === "[Field(field=A, fieldArgs=[]), Field(field=B, fieldArgs=[])] can't be resolved")
   }
 }


### PR DESCRIPTION
### Description
A followup bugfix of https://github.com/opensearch-project/opensearch-spark/pull/698
Fields listed in parent projection, but they have be excluded in child. For example,
`source=t | fields - A, B | fields A, B, C` will throw *[Field A, Field B] can't be resolved*

### Issues Resolved
Related to https://github.com/opensearch-project/opensearch-spark/issues/696

### Check List
- [x] Updated documentation (ppl-spark-integration/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
