### PR TITLE
Support recovery for index with external scheduler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,7 @@ lazy val flintCommons = (project in file("flint-commons"))
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest-flatspec" % "3.2.15" % "test",
       "org.scalatestplus" %% "mockito-4-6" % "3.2.15.0" % "test",
-      "org.projectlombok" % "lombok" % "1.18.30",
+      "org.projectlombok" % "lombok" % "1.18.30" % "provided",
     ),
     libraryDependencies ++= deps(sparkVersion),
     publish / skip := true,

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -108,19 +108,24 @@ public final class MetricConstants {
     public static final String STREAMING_SUCCESS_METRIC = "streaming.success.count";
 
     /**
-     * Metric for tracking the count of successful refresh operations.
+     * Metric for tracking the count of requests to external scheduler.
      */
-    public static final String REFRESH_SUCCESS_METRIC = "refresh.success.count";
+    public static final String EXTERNAL_SCHEDULER_REQUEST_CNT_METRIC = "externalScheduler.request.count";
 
     /**
-     * Metric for tracking the count of failed refresh operations.
+     * Metric for tracking the count of successful incremental refresh operations.
      */
-    public static final String REFRESH_FAILED_METRIC = "refresh.failed.count";
+    public static final String INCREMENTAL_REFRESH_SUCCESS_METRIC = "incrementalRefresh.success.count";
 
     /**
-     * Metric for tracking the processing time of refresh operations.
+     * Metric for tracking the count of failed incremental refresh operations.
      */
-    public static final String REFRESH_PROCESSING_TIME_METRIC = "refresh.processingTime";
+    public static final String INCREMENTAL_REFRESH_FAILED_METRIC = "incrementalRefresh.failed.count";
+
+    /**
+     * Metric for tracking the processing time of incremental refresh operations.
+     */
+    public static final String INCREMENTAL_REFRESH_PROCESSING_TIME_METRIC = "incrementalRefresh.processingTime";
 
     /**
      * Metric for tracking the count of failed heartbeat signals in streaming jobs.

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -108,6 +108,21 @@ public final class MetricConstants {
     public static final String STREAMING_SUCCESS_METRIC = "streaming.success.count";
 
     /**
+     * Metric for tracking the count of successful refresh operations.
+     */
+    public static final String REFRESH_SUCCESS_METRIC = "refresh.success.count";
+
+    /**
+     * Metric for tracking the count of failed refresh operations.
+     */
+    public static final String REFRESH_FAILED_METRIC = "refresh.failed.count";
+
+    /**
+     * Metric for tracking the processing time of refresh operations.
+     */
+    public static final String REFRESH_PROCESSING_TIME_METRIC = "refresh.processingTime";
+
+    /**
      * Metric for tracking the count of failed heartbeat signals in streaming jobs.
      */
     public static final String STREAMING_HEARTBEAT_FAILED_METRIC = "streaming.heartbeat.failed.count";

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -108,26 +108,6 @@ public final class MetricConstants {
     public static final String STREAMING_SUCCESS_METRIC = "streaming.success.count";
 
     /**
-     * Metric for tracking the count of requests to external scheduler.
-     */
-    public static final String EXTERNAL_SCHEDULER_REQUEST_CNT_METRIC = "externalScheduler.request.count";
-
-    /**
-     * Metric for tracking the count of successful incremental refresh operations.
-     */
-    public static final String INCREMENTAL_REFRESH_SUCCESS_METRIC = "incrementalRefresh.success.count";
-
-    /**
-     * Metric for tracking the count of failed incremental refresh operations.
-     */
-    public static final String INCREMENTAL_REFRESH_FAILED_METRIC = "incrementalRefresh.failed.count";
-
-    /**
-     * Metric for tracking the processing time of incremental refresh operations.
-     */
-    public static final String INCREMENTAL_REFRESH_PROCESSING_TIME_METRIC = "incrementalRefresh.processingTime";
-
-    /**
      * Metric for tracking the count of failed heartbeat signals in streaming jobs.
      */
     public static final String STREAMING_HEARTBEAT_FAILED_METRIC = "streaming.heartbeat.failed.count";

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricsUtil.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricsUtil.java
@@ -11,6 +11,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.apache.spark.SparkEnv;
 import org.apache.spark.metrics.source.FlintMetricSource;
+import org.apache.spark.metrics.source.FlintIndexMetricSource;
 import org.apache.spark.metrics.source.Source;
 import scala.collection.Seq;
 
@@ -33,10 +34,20 @@ public final class MetricsUtil {
      * If the counter does not exist, it is created before being incremented.
      *
      * @param metricName The name of the metric for which the counter is incremented.
-     *                   This name is used to retrieve or create the counter.
      */
     public static void incrementCounter(String metricName) {
-        Counter counter = getOrCreateCounter(metricName);
+        incrementCounter(metricName, false);
+    }
+
+    /**
+     * Increments the Counter metric associated with the given metric name.
+     * If the counter does not exist, it is created before being incremented.
+     *
+     * @param metricName The name of the metric for which the counter is incremented.
+     * @param isIndexMetric Whether this metric is an index-specific metric.
+     */
+    public static void incrementCounter(String metricName, boolean isIndexMetric) {
+        Counter counter = getOrCreateCounter(metricName, isIndexMetric);
         if (counter != null) {
             counter.inc();
         }
@@ -48,7 +59,17 @@ public final class MetricsUtil {
      * @param metricName The name of the metric counter to be decremented.
      */
     public static void decrementCounter(String metricName) {
-        Counter counter = getOrCreateCounter(metricName);
+        decrementCounter(metricName, false);
+    }
+
+    /**
+     * Decrements the value of the specified metric counter by one, if the counter exists and its current count is greater than zero.
+     *
+     * @param metricName The name of the metric counter to be decremented.
+     * @param isIndexMetric Whether this metric is an index-specific metric.
+     */
+    public static void decrementCounter(String metricName, boolean isIndexMetric) {
+        Counter counter = getOrCreateCounter(metricName, isIndexMetric);
         if (counter != null && counter.getCount() > 0) {
             counter.dec();
         }
@@ -56,21 +77,30 @@ public final class MetricsUtil {
 
     /**
      * Retrieves a {@link Timer.Context} for the specified metric name, creating a new timer if one does not already exist.
-     * This context can be used to measure the duration of a particular operation or event.
      *
      * @param metricName The name of the metric timer to retrieve the context for.
      * @return A {@link Timer.Context} instance for timing operations, or {@code null} if the timer could not be created or retrieved.
      */
     public static Timer.Context getTimerContext(String metricName) {
-        Timer timer = getOrCreateTimer(metricName);
+        return getTimerContext(metricName, false);
+    }
+
+    /**
+     * Retrieves a {@link Timer.Context} for the specified metric name, creating a new timer if one does not already exist.
+     *
+     * @param metricName The name of the metric timer to retrieve the context for.
+     * @param isIndexMetric Whether this metric is an index-specific metric.
+     * @return A {@link Timer.Context} instance for timing operations, or {@code null} if the timer could not be created or retrieved.
+     */
+    public static Timer.Context getTimerContext(String metricName, boolean isIndexMetric) {
+        Timer timer = getOrCreateTimer(metricName, isIndexMetric);
         return timer != null ? timer.time() : null;
     }
 
     /**
-     * Stops the timer associated with the given {@link Timer.Context}, effectively recording the elapsed time since the timer was started
-     * and returning the duration. If the context is {@code null}, this method does nothing and returns {@code null}.
+     * Stops the timer associated with the given {@link Timer.Context}.
      *
-     * @param context The {@link Timer.Context} to stop. May be {@code null}, in which case this method has no effect and returns {@code null}.
+     * @param context The {@link Timer.Context} to stop. May be {@code null}.
      * @return The elapsed time in nanoseconds since the timer was started, or {@code null} if the context was {@code null}.
      */
     public static Long stopTimer(Timer.Context context) {
@@ -79,13 +109,23 @@ public final class MetricsUtil {
 
     /**
      * Registers a gauge metric with the provided name and value.
-     * The gauge will reflect the current value of the AtomicInteger provided.
      *
      * @param metricName The name of the gauge metric to register.
-     * @param value      The AtomicInteger whose current value should be reflected by the gauge.
+     * @param value The AtomicInteger whose current value should be reflected by the gauge.
      */
     public static void registerGauge(String metricName, final AtomicInteger value) {
-        MetricRegistry metricRegistry = getMetricRegistry();
+        registerGauge(metricName, value, false);
+    }
+
+    /**
+     * Registers a gauge metric with the provided name and value.
+     *
+     * @param metricName The name of the gauge metric to register.
+     * @param value The AtomicInteger whose current value should be reflected by the gauge.
+     * @param isIndexMetric Whether this metric is an index-specific metric.
+     */
+    public static void registerGauge(String metricName, final AtomicInteger value, boolean isIndexMetric) {
+        MetricRegistry metricRegistry = getMetricRegistry(isIndexMetric);
         if (metricRegistry == null) {
             LOG.warning("MetricRegistry not available, cannot register gauge: " + metricName);
             return;
@@ -93,39 +133,37 @@ public final class MetricsUtil {
         metricRegistry.register(metricName, (Gauge<Integer>) value::get);
     }
 
-    // Retrieves or creates a new counter for the given metric name
-    private static Counter getOrCreateCounter(String metricName) {
-        MetricRegistry metricRegistry = getMetricRegistry();
+    private static Counter getOrCreateCounter(String metricName, boolean isIndexMetric) {
+        MetricRegistry metricRegistry = getMetricRegistry(isIndexMetric);
         return metricRegistry != null ? metricRegistry.counter(metricName) : null;
     }
 
-    // Retrieves or creates a new Timer for the given metric name
-    private static Timer getOrCreateTimer(String metricName) {
-        MetricRegistry metricRegistry = getMetricRegistry();
+    private static Timer getOrCreateTimer(String metricName, boolean isIndexMetric) {
+        MetricRegistry metricRegistry = getMetricRegistry(isIndexMetric);
         return metricRegistry != null ? metricRegistry.timer(metricName) : null;
     }
 
-    // Retrieves the MetricRegistry from the current Spark environment.
-    private static MetricRegistry getMetricRegistry() {
+    private static MetricRegistry getMetricRegistry(boolean isIndexMetric) {
         SparkEnv sparkEnv = SparkEnv.get();
         if (sparkEnv == null) {
             LOG.warning("Spark environment not available, cannot access MetricRegistry.");
             return null;
         }
 
-        FlintMetricSource flintMetricSource = getOrInitFlintMetricSource(sparkEnv);
-        return flintMetricSource.metricRegistry();
+        Source metricSource = isIndexMetric ? 
+            getOrInitMetricSource(sparkEnv, FlintMetricSource.FLINT_INDEX_METRIC_SOURCE_NAME(), FlintIndexMetricSource::new) :
+            getOrInitMetricSource(sparkEnv, FlintMetricSource.FLINT_METRIC_SOURCE_NAME(), FlintMetricSource::new);
+        return metricSource.metricRegistry();
     }
 
-    // Gets or initializes the FlintMetricSource
-    private static FlintMetricSource getOrInitFlintMetricSource(SparkEnv sparkEnv) {
-        Seq<Source> metricSourceSeq = sparkEnv.metricsSystem().getSourcesByName(FlintMetricSource.FLINT_METRIC_SOURCE_NAME());
+    private static Source getOrInitMetricSource(SparkEnv sparkEnv, String sourceName, java.util.function.Supplier<Source> sourceSupplier) {
+        Seq<Source> metricSourceSeq = sparkEnv.metricsSystem().getSourcesByName(sourceName);
 
         if (metricSourceSeq == null || metricSourceSeq.isEmpty()) {
-            FlintMetricSource metricSource = new FlintMetricSource();
+            Source metricSource = sourceSupplier.get();
             sparkEnv.metricsSystem().registerSource(metricSource);
             return metricSource;
         }
-        return (FlintMetricSource) metricSourceSeq.head();
+        return metricSourceSeq.head();
     }
 }

--- a/flint-core/src/main/scala/apache/spark/metrics/source/FlintMetricSource.scala
+++ b/flint-core/src/main/scala/apache/spark/metrics/source/FlintMetricSource.scala
@@ -7,13 +7,25 @@ package org.apache.spark.metrics.source
 
 import com.codahale.metrics.MetricRegistry
 
-class FlintMetricSource() extends Source {
+/**
+ * Metric source for general Flint metrics.
+ */
+class FlintMetricSource extends Source {
 
   // Implementing the Source trait
   override val sourceName: String = FlintMetricSource.FLINT_METRIC_SOURCE_NAME
   override val metricRegistry: MetricRegistry = new MetricRegistry
 }
 
+/**
+ * Metric source for Flint index-specific metrics.
+ */
+class FlintIndexMetricSource extends Source {
+  override val sourceName: String = FlintMetricSource.FLINT_INDEX_METRIC_SOURCE_NAME
+  override val metricRegistry: MetricRegistry = new MetricRegistry
+}
+
 object FlintMetricSource {
   val FLINT_METRIC_SOURCE_NAME = "Flint" // Default source name
+  val FLINT_INDEX_METRIC_SOURCE_NAME = "FlintIndex" // Index specific source name
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -105,6 +105,8 @@ public class FlintOptions implements Serializable {
 
   public static final String DEFAULT_SUPPORT_SHARD = "true";
 
+  private static final String UNKNOWN = "UNKNOWN";
+
   public static final String BULK_REQUEST_RATE_LIMIT_PER_NODE = "bulkRequestRateLimitPerNode";
   public static final String DEFAULT_BULK_REQUEST_RATE_LIMIT_PER_NODE = "0";
   public static final String DEFAULT_EXTERNAL_SCHEDULER_INTERVAL = "5 minutes";
@@ -186,9 +188,9 @@ public class FlintOptions implements Serializable {
    * @return the AWS accountId
    */
   public String getAWSAccountId() {
-    String clusterName = System.getenv().getOrDefault("FLINT_CLUSTER_NAME", "");
+    String clusterName = System.getenv().getOrDefault("FLINT_CLUSTER_NAME", UNKNOWN + ":" + UNKNOWN);
     String[] parts = clusterName.split(":");
-    return parts.length == 2 ? parts[0] : "";
+    return parts.length == 2 ? parts[0] : UNKNOWN;
   }
 
   public String getSystemIndexName() {

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -107,6 +107,7 @@ public class FlintOptions implements Serializable {
 
   public static final String BULK_REQUEST_RATE_LIMIT_PER_NODE = "bulkRequestRateLimitPerNode";
   public static final String DEFAULT_BULK_REQUEST_RATE_LIMIT_PER_NODE = "0";
+  public static final String DEFAULT_EXTERNAL_SCHEDULER_INTERVAL = "5 minutes";
 
   public FlintOptions(Map<String, String> options) {
     this.options = options;

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -174,7 +174,7 @@ object FlintSparkConf {
   val EXTERNAL_SCHEDULER_INTERVAL_THRESHOLD =
     FlintConfig("spark.flint.job.externalScheduler.interval")
       .doc("Interval threshold in minutes for external scheduler to trigger index refresh")
-      .createWithDefault("5 minutes")
+      .createWithDefault(FlintOptions.DEFAULT_EXTERNAL_SCHEDULER_INTERVAL)
 
   val CHECKPOINT_LOCATION_ROOT_DIR = FlintConfig("spark.flint.index.checkpointLocation.rootDir")
     .doc("Root directory of a user specified checkpoint location for index refresh")
@@ -294,8 +294,10 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
 
   def isExternalSchedulerEnabled: Boolean = EXTERNAL_SCHEDULER_ENABLED.readFrom(reader).toBoolean
 
-  def externalSchedulerIntervalThreshold(): String =
-    EXTERNAL_SCHEDULER_INTERVAL_THRESHOLD.readFrom(reader)
+  def externalSchedulerIntervalThreshold(): String = {
+    val value = EXTERNAL_SCHEDULER_INTERVAL_THRESHOLD.readFrom(reader)
+    if (value.trim.isEmpty) FlintOptions.DEFAULT_EXTERNAL_SCHEDULER_INTERVAL else value
+  }
 
   def checkpointLocationRootDir: Option[String] = CHECKPOINT_LOCATION_ROOT_DIR.readFrom(reader)
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
@@ -5,20 +5,14 @@
 
 package org.opensearch.flint.spark
 
-import java.util.Collections
-
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
-import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.{CHECKPOINT_LOCATION, REFRESH_INTERVAL, SCHEDULER_MODE}
-import org.opensearch.flint.spark.FlintSparkIndexOptions.empty
+import org.opensearch.flint.spark.FlintSparkIndexOptions.{empty, updateOptionsWithDefaults}
 import org.opensearch.flint.spark.refresh.FlintSparkIndexRefresh
-import org.opensearch.flint.spark.refresh.FlintSparkIndexRefresh.SchedulerMode
-import org.opensearch.flint.spark.scheduler.util.IntervalSchedulerParser
 
 import org.apache.spark.sql.catalog.Column
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.flint.{findField, loadTable, parseTableName, qualifyTableName}
-import org.apache.spark.sql.flint.config.FlintSparkConf
 import org.apache.spark.sql.types.{StructField, StructType}
 
 /**
@@ -155,61 +149,5 @@ abstract class FlintSparkIndexBuilder(flint: FlintSpark) {
       nullable = field.nullable,
       isPartition = false, // useless for now so just set to false
       isBucket = false)
-  }
-
-  /**
-   * Updates the options with a default values for Create and Alter index.
-   *
-   * @param indexName
-   *   The index name string
-   * @param options
-   *   The original FlintSparkIndexOptions
-   * @return
-   *   Updated FlintSparkIndexOptions
-   */
-  private def updateOptionsWithDefaults(
-      indexName: String,
-      options: FlintSparkIndexOptions): FlintSparkIndexOptions = {
-    val flintSparkConf = new FlintSparkConf(Collections.emptyMap[String, String])
-
-    val updatedOptions =
-      new scala.collection.mutable.HashMap[String, String]() ++= options.options
-
-    // Add checkpoint location if not present
-    options.checkpointLocation(indexName, flintSparkConf).foreach { location =>
-      updatedOptions += (CHECKPOINT_LOCATION.toString -> location)
-    }
-
-    // Update scheduler mode and refresh interval only if auto refresh is enabled
-    if (!options.autoRefresh()) {
-      return FlintSparkIndexOptions(updatedOptions.toMap)
-    }
-
-    val externalSchedulerEnabled = flintSparkConf.isExternalSchedulerEnabled
-    val thresholdInterval =
-      IntervalSchedulerParser.parse(flintSparkConf.externalSchedulerIntervalThreshold())
-    val currentInterval = options.refreshInterval().map(IntervalSchedulerParser.parse)
-
-    (
-      externalSchedulerEnabled,
-      currentInterval,
-      updatedOptions.get(SCHEDULER_MODE.toString)) match {
-      case (true, Some(interval), _) if interval.getInterval >= thresholdInterval.getInterval =>
-        updatedOptions += (SCHEDULER_MODE.toString -> SchedulerMode.EXTERNAL.toString)
-      case (true, None, Some("external")) =>
-        updatedOptions += (REFRESH_INTERVAL.toString -> flintSparkConf
-          .externalSchedulerIntervalThreshold())
-      case (true, None, None) =>
-        updatedOptions += (SCHEDULER_MODE.toString -> SchedulerMode.EXTERNAL.toString)
-        updatedOptions += (REFRESH_INTERVAL.toString -> flintSparkConf
-          .externalSchedulerIntervalThreshold())
-      case (false, _, Some("external")) =>
-        throw new IllegalArgumentException(
-          "External scheduler mode spark conf is not enabled but refresh interval is set to external scheduler mode")
-      case _ =>
-        updatedOptions += (SCHEDULER_MODE.toString -> SchedulerMode.INTERNAL.toString)
-    }
-
-    FlintSparkIndexOptions(updatedOptions.toMap)
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexFactory.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexFactory.scala
@@ -7,6 +7,7 @@ package org.opensearch.flint.spark
 
 import java.util.Collections
 
+import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.collection.JavaConverters.mapAsScalaMapConverter
 
 import org.opensearch.flint.common.metadata.FlintMetadata
@@ -47,6 +48,26 @@ object FlintSparkIndexFactory extends Logging {
         logWarning(s"Failed to create Flint index from metadata $metadata", e)
         None
     }
+  }
+
+  /**
+   * Creates Flint index with default options.
+   *
+   * @param index
+   *   Flint index
+   * @param metadata
+   *   Flint metadata
+   * @return
+   *   Flint index with default options
+   */
+  def createWithDefaultOptions(index: FlintSparkIndex): Option[FlintSparkIndex] = {
+    val originalOptions = index.options
+    val updatedOptions =
+      FlintSparkIndexOptions.updateOptionsWithDefaults(index.name(), originalOptions)
+    val updatedMetadata = index
+      .metadata()
+      .copy(options = updatedOptions.options.mapValues(_.asInstanceOf[AnyRef]).asJava)
+    this.create(updatedMetadata)
   }
 
   private def doCreate(metadata: FlintMetadata): FlintSparkIndex = {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
@@ -257,7 +257,7 @@ object FlintSparkIndexOptions {
           .externalSchedulerIntervalThreshold())
       case (false, _, Some("external")) =>
         throw new IllegalArgumentException(
-          "External scheduler mode spark conf is not enabled but refresh interval is set to external scheduler mode")
+          "spark.flint.job.externalScheduler.enabled is false but refresh interval is set to external scheduler mode")
       case _ =>
         updatedOptions += (SCHEDULER_MODE.toString -> SchedulerMode.INTERNAL.toString)
     }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
@@ -236,10 +236,6 @@ object FlintSparkIndexOptions {
     val thresholdInterval =
       IntervalSchedulerParser.parse(flintSparkConf.externalSchedulerIntervalThreshold())
     val currentInterval = options.refreshInterval().map(IntervalSchedulerParser.parse)
-
-    logInfo(s"updateOptionsWithDefaults - before updatedOptions: ${updatedOptions}")
-    logInfo(s"currentInterval.isDefined: ${currentInterval.isDefined}")
-    logInfo(s"${updatedOptions.get(SCHEDULER_MODE.toString).equals(Some("external"))}")
     (
       externalSchedulerEnabled,
       currentInterval.isDefined,
@@ -263,10 +259,8 @@ object FlintSparkIndexOptions {
         throw new IllegalArgumentException(
           "External scheduler mode spark conf is not enabled but refresh interval is set to external scheduler mode")
       case _ =>
-        logInfo("Debug only")
         updatedOptions += (SCHEDULER_MODE.toString -> SchedulerMode.INTERNAL.toString)
     }
-    logInfo(s"updateOptionsWithDefaults - updatedOptions: ${updatedOptions}")
     FlintSparkIndexOptions(updatedOptions.toMap)
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/util/RefreshMetricsAspect.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/util/RefreshMetricsAspect.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.refresh.util
+
+import org.opensearch.flint.core.metrics.MetricsUtil
+
+/**
+ * A trait that provides aspect-oriented metrics functionality for refresh operations.
+ *
+ * This trait can be mixed into classes that need to track metrics for various operations,
+ * particularly those related to index refreshing. It provides a method to wrap operations with
+ * metric collection, including timing and success/failure counting.
+ */
+trait RefreshMetricsAspect {
+
+  /**
+   * Wraps an operation with metric collection.
+   *
+   * @param clientId
+   *   The ID of the client performing the operation
+   * @param dataSource
+   *   The name of the data source being used
+   * @param indexName
+   *   The name of the index being operated on
+   * @param metricPrefix
+   *   The prefix for the metrics (e.g., "incrementalRefresh")
+   * @param block
+   *   The operation to be performed and measured
+   * @return
+   *   The result of the operation
+   *
+   * This method will:
+   *   1. Start a timer for the operation 2. Execute the provided operation 3. Increment a success
+   *      or failure counter based on the outcome 4. Stop the timer 5. Return the result of the
+   *      operation or throw any exception that occurred
+   */
+  def withMetrics(clientId: String, dataSource: String, indexName: String, metricPrefix: String)(
+      block: => Option[String]): Option[String] = {
+    val refreshMetricsHelper = new RefreshMetricsHelper(clientId, dataSource, indexName)
+
+    val processingTimeMetric = s"$metricPrefix.processingTime"
+    val successMetric = s"$metricPrefix.success.count"
+    val failedMetric = s"$metricPrefix.failed.count"
+
+    val timerContext = refreshMetricsHelper.getTimerContext(processingTimeMetric)
+
+    try {
+      val result = block
+      refreshMetricsHelper.incrementCounter(successMetric)
+      result
+    } catch {
+      case e: Exception =>
+        refreshMetricsHelper.incrementCounter(failedMetric)
+        throw e
+    } finally {
+      MetricsUtil.stopTimer(timerContext)
+    }
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/util/RefreshMetricsHelper.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/util/RefreshMetricsHelper.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.refresh.util
+
+import com.codahale.metrics.Timer
+import org.opensearch.flint.core.metrics.MetricsUtil
+
+/**
+ * Helper class for constructing dimensioned metric names used in refresh operations.
+ */
+class RefreshMetricsHelper(clientId: String, dataSource: String, indexName: String) {
+  private val isIndexMetric = true
+
+  /**
+   * Increments a counter metric with the specified dimensioned name.
+   *
+   * @param metricName
+   *   The name of the metric to increment
+   */
+  def incrementCounter(metricName: String): Unit = {
+    MetricsUtil.incrementCounter(
+      RefreshMetricsHelper.constructDimensionedMetricName(
+        metricName,
+        clientId,
+        dataSource,
+        indexName),
+      isIndexMetric)
+  }
+
+  /**
+   * Gets a timer context for the specified metric name.
+   *
+   * @param metricName
+   *   The name of the metric
+   * @return
+   *   A Timer.Context object
+   */
+  def getTimerContext(metricName: String): Timer.Context = {
+    MetricsUtil.getTimerContext(
+      RefreshMetricsHelper.constructDimensionedMetricName(
+        metricName,
+        clientId,
+        dataSource,
+        indexName),
+      isIndexMetric)
+  }
+}
+
+object RefreshMetricsHelper {
+
+  /**
+   * Constructs a dimensioned metric name for external scheduler request count.
+   *
+   * @param metricName
+   *   The name of the metric
+   * @param clientId
+   *   The ID of the client making the request
+   * @param dataSource
+   *   The data source being used
+   * @param indexName
+   *   The name of the index being refreshed
+   * @return
+   *   A formatted string representing the dimensioned metric name
+   */
+  private def constructDimensionedMetricName(
+      metricName: String,
+      clientId: String,
+      dataSource: String,
+      indexName: String): String = {
+    s"${metricName}[clientId##${clientId},dataSource##${dataSource},indexName##${indexName}]"
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/AsyncQuerySchedulerBuilder.java
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/AsyncQuerySchedulerBuilder.java
@@ -30,13 +30,13 @@ public class AsyncQuerySchedulerBuilder {
 
   public static AsyncQueryScheduler build(FlintOptions options) {
     String className = options.getCustomAsyncQuerySchedulerClass();
-    logger.info("Attempting to instantiate AsyncQueryScheduler with class name: {}", className);
 
     if (className.isEmpty()) {
       return new OpenSearchAsyncQueryScheduler(options);
     }
 
     // Attempts to instantiate AsyncQueryScheduler using reflection
+    logger.info("Attempting to instantiate AsyncQueryScheduler with class name: {}", className);
     try {
       Class<?> asyncQuerySchedulerClass = Class.forName(className);
       Constructor<?> constructor = asyncQuerySchedulerClass.getConstructor();

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
@@ -10,8 +10,10 @@ import java.time.Instant
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState
 import org.opensearch.flint.common.scheduler.AsyncQueryScheduler
 import org.opensearch.flint.common.scheduler.model.{AsyncQuerySchedulerRequest, LangType}
+import org.opensearch.flint.core.metrics.{MetricConstants, MetricsUtil}
 import org.opensearch.flint.core.storage.OpenSearchClientUtils
 import org.opensearch.flint.spark.FlintSparkIndex
+import org.opensearch.flint.spark.refresh.util.RefreshMetricsHelper
 import org.opensearch.flint.spark.scheduler.AsyncQuerySchedulerBuilder.AsyncQuerySchedulerAction
 import org.opensearch.flint.spark.scheduler.util.RefreshQueryGenerator
 
@@ -49,6 +51,7 @@ class FlintSparkJobExternalSchedulingService(
     val clientId = flintSparkConf.flintOptions().getAWSAccountId()
     // This is to make sure jobId is consistent with the index name
     val indexName = OpenSearchClientUtils.sanitizeIndexName(index.name())
+    val refreshMetricsHelper = new RefreshMetricsHelper(clientId, dataSource, indexName)
 
     logInfo(s"handleAsyncQueryScheduler invoked: $action")
 
@@ -80,6 +83,7 @@ class FlintSparkJobExternalSchedulingService(
       case _ => throw new IllegalArgumentException(s"Unsupported action: $action")
     }
 
+    refreshMetricsHelper.incrementCounter(MetricConstants.EXTERNAL_SCHEDULER_REQUEST_CNT_METRIC)
     None // Return None for all cases
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
@@ -36,11 +36,11 @@ class FlintSparkJobExternalSchedulingService(
     extends FlintSparkJobSchedulingService
     with Logging {
 
-  initialStateForUpdate = IndexState.ACTIVE
-  finalStateForUpdate = IndexState.ACTIVE
-
-  initialStateForUnschedule = IndexState.ACTIVE
-  finalStateForUnschedule = IndexState.ACTIVE
+  override val stateTransitions: StateTransitions = StateTransitions(
+    initialStateForUpdate = IndexState.ACTIVE,
+    finalStateForUpdate = IndexState.ACTIVE,
+    initialStateForUnschedule = IndexState.ACTIVE,
+    finalStateForUnschedule = IndexState.ACTIVE)
 
   override def handleJob(
       index: FlintSparkIndex,

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
@@ -10,10 +10,9 @@ import java.time.Instant
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState
 import org.opensearch.flint.common.scheduler.AsyncQueryScheduler
 import org.opensearch.flint.common.scheduler.model.{AsyncQuerySchedulerRequest, LangType}
-import org.opensearch.flint.core.metrics.{MetricConstants, MetricsUtil}
 import org.opensearch.flint.core.storage.OpenSearchClientUtils
 import org.opensearch.flint.spark.FlintSparkIndex
-import org.opensearch.flint.spark.refresh.util.RefreshMetricsHelper
+import org.opensearch.flint.spark.refresh.util.RefreshMetricsAspect
 import org.opensearch.flint.spark.scheduler.AsyncQuerySchedulerBuilder.AsyncQuerySchedulerAction
 import org.opensearch.flint.spark.scheduler.util.RefreshQueryGenerator
 
@@ -36,6 +35,7 @@ class FlintSparkJobExternalSchedulingService(
     flintAsyncQueryScheduler: AsyncQueryScheduler,
     flintSparkConf: FlintSparkConf)
     extends FlintSparkJobSchedulingService
+    with RefreshMetricsAspect
     with Logging {
 
   override val stateTransitions: StateTransitions = StateTransitions(
@@ -51,39 +51,40 @@ class FlintSparkJobExternalSchedulingService(
     val clientId = flintSparkConf.flintOptions().getAWSAccountId()
     // This is to make sure jobId is consistent with the index name
     val indexName = OpenSearchClientUtils.sanitizeIndexName(index.name())
-    val refreshMetricsHelper = new RefreshMetricsHelper(clientId, dataSource, indexName)
 
     logInfo(s"handleAsyncQueryScheduler invoked: $action")
 
-    val baseRequest = AsyncQuerySchedulerRequest
-      .builder()
-      .accountId(clientId)
-      .jobId(indexName)
-      .dataSource(dataSource)
+    withMetrics(clientId, dataSource, indexName, "externalScheduler") {
+      val baseRequest = AsyncQuerySchedulerRequest
+        .builder()
+        .accountId(clientId)
+        .jobId(indexName)
+        .dataSource(dataSource)
 
-    val request = action match {
-      case AsyncQuerySchedulerAction.SCHEDULE | AsyncQuerySchedulerAction.UPDATE =>
-        val currentTime = Instant.now()
-        baseRequest
-          .scheduledQuery(RefreshQueryGenerator.generateRefreshQuery(index))
-          .queryLang(LangType.SQL)
-          .interval(index.options.refreshInterval().get)
-          .enabled(true)
-          .enabledTime(currentTime)
-          .lastUpdateTime(currentTime)
-          .build()
-      case _ => baseRequest.build()
+      val request = action match {
+        case AsyncQuerySchedulerAction.SCHEDULE | AsyncQuerySchedulerAction.UPDATE =>
+          val currentTime = Instant.now()
+          baseRequest
+            .scheduledQuery(RefreshQueryGenerator.generateRefreshQuery(index))
+            .queryLang(LangType.SQL)
+            .interval(index.options.refreshInterval().get)
+            .enabled(true)
+            .enabledTime(currentTime)
+            .lastUpdateTime(currentTime)
+            .build()
+        case _ => baseRequest.build()
+      }
+
+      action match {
+        case AsyncQuerySchedulerAction.SCHEDULE => flintAsyncQueryScheduler.scheduleJob(request)
+        case AsyncQuerySchedulerAction.UPDATE => flintAsyncQueryScheduler.updateJob(request)
+        case AsyncQuerySchedulerAction.UNSCHEDULE =>
+          flintAsyncQueryScheduler.unscheduleJob(request)
+        case AsyncQuerySchedulerAction.REMOVE => flintAsyncQueryScheduler.removeJob(request)
+        case _ => throw new IllegalArgumentException(s"Unsupported action: $action")
+      }
+
+      None // Return None for all cases
     }
-
-    action match {
-      case AsyncQuerySchedulerAction.SCHEDULE => flintAsyncQueryScheduler.scheduleJob(request)
-      case AsyncQuerySchedulerAction.UPDATE => flintAsyncQueryScheduler.updateJob(request)
-      case AsyncQuerySchedulerAction.UNSCHEDULE => flintAsyncQueryScheduler.unscheduleJob(request)
-      case AsyncQuerySchedulerAction.REMOVE => flintAsyncQueryScheduler.removeJob(request)
-      case _ => throw new IllegalArgumentException(s"Unsupported action: $action")
-    }
-
-    refreshMetricsHelper.incrementCounter(MetricConstants.EXTERNAL_SCHEDULER_REQUEST_CNT_METRIC)
-    None // Return None for all cases
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
@@ -7,8 +7,10 @@ package org.opensearch.flint.spark.scheduler
 
 import java.time.Instant
 
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState
 import org.opensearch.flint.common.scheduler.AsyncQueryScheduler
 import org.opensearch.flint.common.scheduler.model.{AsyncQuerySchedulerRequest, LangType}
+import org.opensearch.flint.core.storage.OpenSearchClientUtils
 import org.opensearch.flint.spark.FlintSparkIndex
 import org.opensearch.flint.spark.scheduler.AsyncQuerySchedulerBuilder.AsyncQuerySchedulerAction
 import org.opensearch.flint.spark.scheduler.util.RefreshQueryGenerator
@@ -34,12 +36,19 @@ class FlintSparkJobExternalSchedulingService(
     extends FlintSparkJobSchedulingService
     with Logging {
 
+  initialStateForUpdate = IndexState.ACTIVE
+  finalStateForUpdate = IndexState.ACTIVE
+
+  initialStateForUnschedule = IndexState.ACTIVE
+  finalStateForUnschedule = IndexState.ACTIVE
+
   override def handleJob(
       index: FlintSparkIndex,
       action: AsyncQuerySchedulerAction): Option[String] = {
     val dataSource = flintSparkConf.flintOptions().getDataSourceName()
     val clientId = flintSparkConf.flintOptions().getAWSAccountId()
-    val indexName = index.name()
+    // This is to make sure jobId is consistent with the index name
+    val indexName = OpenSearchClientUtils.sanitizeIndexName(index.name())
 
     logInfo(s"handleAsyncQueryScheduler invoked: $action")
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobInternalSchedulingService.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobInternalSchedulingService.scala
@@ -34,11 +34,11 @@ class FlintSparkJobInternalSchedulingService(
     extends FlintSparkJobSchedulingService
     with Logging {
 
-  initialStateForUpdate = IndexState.ACTIVE
-  finalStateForUpdate = IndexState.REFRESHING
-
-  initialStateForUnschedule = IndexState.REFRESHING
-  finalStateForUnschedule = IndexState.ACTIVE
+  override val stateTransitions: StateTransitions = StateTransitions(
+    initialStateForUpdate = IndexState.ACTIVE,
+    finalStateForUpdate = IndexState.REFRESHING,
+    initialStateForUnschedule = IndexState.REFRESHING,
+    finalStateForUnschedule = IndexState.ACTIVE)
 
   /**
    * Handles job-related actions for a given Flint Spark index.

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobInternalSchedulingService.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobInternalSchedulingService.scala
@@ -7,6 +7,7 @@ package org.opensearch.flint.spark.scheduler
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState
 import org.opensearch.flint.spark.{FlintSparkIndex, FlintSparkIndexMonitor}
 import org.opensearch.flint.spark.refresh.FlintSparkIndexRefresh
 import org.opensearch.flint.spark.scheduler.AsyncQuerySchedulerBuilder.AsyncQuerySchedulerAction
@@ -33,6 +34,12 @@ class FlintSparkJobInternalSchedulingService(
     extends FlintSparkJobSchedulingService
     with Logging {
 
+  initialStateForUpdate = IndexState.ACTIVE
+  finalStateForUpdate = IndexState.REFRESHING
+
+  initialStateForUnschedule = IndexState.REFRESHING
+  finalStateForUnschedule = IndexState.ACTIVE
+
   /**
    * Handles job-related actions for a given Flint Spark index.
    *
@@ -52,7 +59,7 @@ class FlintSparkJobInternalSchedulingService(
     action match {
       case AsyncQuerySchedulerAction.SCHEDULE => None // No-op
       case AsyncQuerySchedulerAction.UPDATE =>
-        logInfo("Updating index state monitor")
+        logInfo("Scheduling index state monitor")
         flintIndexMonitor.startMonitor(indexName)
         startRefreshingJob(index)
       case AsyncQuerySchedulerAction.UNSCHEDULE =>

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobSchedulingService.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobSchedulingService.scala
@@ -18,11 +18,13 @@ import org.apache.spark.sql.flint.config.FlintSparkConf
  */
 trait FlintSparkJobSchedulingService {
 
-  var initialStateForUpdate: IndexState = _
-  var finalStateForUpdate: IndexState = _
+  case class StateTransitions(
+      initialStateForUpdate: IndexState,
+      finalStateForUpdate: IndexState,
+      initialStateForUnschedule: IndexState,
+      finalStateForUnschedule: IndexState)
 
-  var initialStateForUnschedule: IndexState = _
-  var finalStateForUnschedule: IndexState = _
+  val stateTransitions: StateTransitions
 
   /**
    * Handles a job action for a given Flint Spark index.

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobSchedulingService.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobSchedulingService.scala
@@ -5,6 +5,7 @@
 
 package org.opensearch.flint.spark.scheduler
 
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState.IndexState
 import org.opensearch.flint.common.scheduler.AsyncQueryScheduler
 import org.opensearch.flint.spark.{FlintSparkIndex, FlintSparkIndexMonitor}
 import org.opensearch.flint.spark.scheduler.AsyncQuerySchedulerBuilder.AsyncQuerySchedulerAction
@@ -16,6 +17,12 @@ import org.apache.spark.sql.flint.config.FlintSparkConf
  * Trait defining the interface for Flint Spark job scheduling services.
  */
 trait FlintSparkJobSchedulingService {
+
+  var initialStateForUpdate: IndexState = _
+  var finalStateForUpdate: IndexState = _
+
+  var initialStateForUnschedule: IndexState = _
+  var finalStateForUnschedule: IndexState = _
 
   /**
    * Handles a job action for a given Flint Spark index.

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/util/RefreshQueryGenerator.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/util/RefreshQueryGenerator.scala
@@ -6,6 +6,7 @@
 package org.opensearch.flint.spark.scheduler.util
 
 import org.opensearch.flint.spark.FlintSparkIndex
+import org.opensearch.flint.spark.FlintSparkIndex.quotedTableName
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
@@ -25,11 +26,11 @@ object RefreshQueryGenerator {
   def generateRefreshQuery(index: FlintSparkIndex): String = {
     index match {
       case skippingIndex: FlintSparkSkippingIndex =>
-        s"REFRESH SKIPPING INDEX ON ${skippingIndex.tableName}"
+        s"REFRESH SKIPPING INDEX ON ${quotedTableName(skippingIndex.tableName)}"
       case coveringIndex: FlintSparkCoveringIndex =>
-        s"REFRESH INDEX ${coveringIndex.indexName} ON ${coveringIndex.tableName}"
+        s"REFRESH INDEX ${coveringIndex.indexName} ON ${quotedTableName(coveringIndex.tableName)}"
       case materializedView: FlintSparkMaterializedView =>
-        s"REFRESH MATERIALIZED VIEW ${materializedView.mvName}"
+        s"REFRESH MATERIALIZED VIEW ${quotedTableName(materializedView.mvName)}"
       case _ =>
         throw new IllegalArgumentException(
           s"Unsupported index type: ${index.getClass.getSimpleName}")

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/mv/FlintSparkMaterializedViewAstBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/mv/FlintSparkMaterializedViewAstBuilder.scala
@@ -10,7 +10,6 @@ import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import org.antlr.v4.runtime.tree.RuleNode
 import org.opensearch.flint.spark.FlintSpark
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView
-import org.opensearch.flint.spark.refresh.FlintSparkIndexRefresh.SchedulerMode
 import org.opensearch.flint.spark.sql.{FlintSparkSqlCommand, FlintSparkSqlExtensionsVisitor, SparkSqlAstBuilder}
 import org.opensearch.flint.spark.sql.FlintSparkSqlAstBuilder.{getFullTableName, getSqlText, IndexBelongsTo}
 import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser._

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -114,6 +114,19 @@ class FlintSparkConfSuite extends FlintSuite {
     }
   }
 
+  test("externalSchedulerIntervalThreshold should return default value when empty") {
+    val options = FlintSparkConf(Map("spark.flint.job.externalScheduler.interval" -> "").asJava)
+    assert(options
+      .externalSchedulerIntervalThreshold() === FlintOptions.DEFAULT_EXTERNAL_SCHEDULER_INTERVAL)
+  }
+
+  test("externalSchedulerIntervalThreshold should return configured value when set") {
+    val configuredValue = "30"
+    val options =
+      FlintSparkConf(Map("spark.flint.job.externalScheduler.interval" -> configuredValue).asJava)
+    assert(options.externalSchedulerIntervalThreshold() === configuredValue)
+  }
+
   /**
    * Delete index `indexNames` after calling `f`.
    */

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexBuilderSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexBuilderSuite.scala
@@ -208,7 +208,7 @@ class FlintSparkIndexBuilderSuite
         None,
         None,
         Some(
-          "External scheduler mode spark conf is not enabled but refresh interval is set to external schedule")),
+          "spark.flint.job.externalScheduler.enabled is false but refresh interval is set to external scheduler mode")),
       (
         "set external mode when interval above threshold and no mode specified",
         true,

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/scheduler/util/RefreshQueryGeneratorSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/scheduler/util/RefreshQueryGeneratorSuite.scala
@@ -6,6 +6,7 @@
 package org.opensearch.flint.spark.scheduler.util;
 
 import org.mockito.Mockito._
+import org.opensearch.flint.common.metadata.FlintMetadata
 import org.opensearch.flint.spark.FlintSparkIndex
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView
@@ -16,33 +17,42 @@ import org.apache.spark.SparkFunSuite
 
 class RefreshQueryGeneratorTest extends SparkFunSuite with Matchers {
 
+  val testTable = "dummy.default.testTable"
+  val expectedTableName = "dummy.default.`testTable`"
+
+  val mockMetadata = mock(classOf[FlintMetadata])
+
   test("generateRefreshQuery should return correct query for FlintSparkSkippingIndex") {
     val mockIndex = mock(classOf[FlintSparkSkippingIndex])
-    when(mockIndex.tableName).thenReturn("testTable")
+    when(mockIndex.metadata()).thenReturn(mockMetadata)
+    when(mockIndex.tableName).thenReturn(testTable)
 
     val result = RefreshQueryGenerator.generateRefreshQuery(mockIndex)
-    result shouldBe "REFRESH SKIPPING INDEX ON testTable"
+    result shouldBe s"REFRESH SKIPPING INDEX ON ${expectedTableName}"
   }
 
   test("generateRefreshQuery should return correct query for FlintSparkCoveringIndex") {
     val mockIndex = mock(classOf[FlintSparkCoveringIndex])
     when(mockIndex.indexName).thenReturn("testIndex")
-    when(mockIndex.tableName).thenReturn("testTable")
+    when(mockIndex.tableName).thenReturn(testTable)
 
     val result = RefreshQueryGenerator.generateRefreshQuery(mockIndex)
-    result shouldBe "REFRESH INDEX testIndex ON testTable"
+    result shouldBe s"REFRESH INDEX testIndex ON ${expectedTableName}"
   }
 
   test("generateRefreshQuery should return correct query for FlintSparkMaterializedView") {
     val mockIndex = mock(classOf[FlintSparkMaterializedView])
-    when(mockIndex.mvName).thenReturn("testMV")
+    when(mockIndex.metadata()).thenReturn(mockMetadata)
+    when(mockIndex.mvName).thenReturn(testTable)
 
     val result = RefreshQueryGenerator.generateRefreshQuery(mockIndex)
-    result shouldBe "REFRESH MATERIALIZED VIEW testMV"
+    result shouldBe s"REFRESH MATERIALIZED VIEW ${expectedTableName}"
   }
 
   test("generateRefreshQuery should throw IllegalArgumentException for unsupported index type") {
     val mockIndex = mock(classOf[FlintSparkIndex])
+    when(mockIndex.metadata()).thenReturn(mockMetadata)
+    when(mockIndex.metadata().source).thenReturn(testTable)
 
     val exception = intercept[IllegalArgumentException] {
       RefreshQueryGenerator.generateRefreshQuery(mockIndex)

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -15,6 +15,7 @@ import org.opensearch.client.RequestOptions
 import org.opensearch.flint.common.FlintVersion.current
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.storage.{FlintOpenSearchIndexMetadataService, OpenSearchClientUtils}
+import org.opensearch.flint.spark.FlintSparkIndex.quotedTableName
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.getFlintIndexName
 import org.opensearch.flint.spark.scheduler.OpenSearchAsyncQueryScheduler
 import org.scalatest.matchers.must.Matchers.{contain, defined}
@@ -194,7 +195,8 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
       val sourceMap = response.getSourceAsMap
 
       sourceMap.get("jobId") shouldBe testFlintIndex
-      sourceMap.get("scheduledQuery") shouldBe s"REFRESH INDEX $testIndex ON $testTable"
+      sourceMap
+        .get("scheduledQuery") shouldBe s"REFRESH INDEX $testIndex ON ${quotedTableName(testTable)}"
       sourceMap.get("enabled") shouldBe true
       sourceMap.get("queryLang") shouldBe "sql"
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -16,6 +16,7 @@ import org.opensearch.client.RequestOptions
 import org.opensearch.flint.common.FlintVersion.current
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.storage.{FlintOpenSearchIndexMetadataService, OpenSearchClientUtils}
+import org.opensearch.flint.spark.FlintSparkIndex.quotedTableName
 import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.CHECKPOINT_LOCATION
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.getFlintIndexName
 import org.opensearch.flint.spark.scheduler.OpenSearchAsyncQueryScheduler
@@ -365,7 +366,8 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
       val sourceMap = response.getSourceAsMap
 
       sourceMap.get("jobId") shouldBe testFlintIndex
-      sourceMap.get("scheduledQuery") shouldBe s"REFRESH MATERIALIZED VIEW $testMvName"
+      sourceMap
+        .get("scheduledQuery") shouldBe s"REFRESH MATERIALIZED VIEW ${quotedTableName(testMvName)}"
       sourceMap.get("enabled") shouldBe true
       sourceMap.get("queryLang") shouldBe "sql"
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -47,6 +47,8 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
     super.afterEach()
     deleteTestIndex(testFlintIndex)
     sql(s"DROP TABLE $testTable")
+    conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
+    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
   }
 
   test("create materialized view with auto refresh") {
@@ -119,8 +121,6 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
 
       // Drop index with test scheduler
       sql(s"DROP MATERIALIZED VIEW $testMvName")
-      conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
-      conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     }
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -16,7 +16,7 @@ import org.opensearch.client.RequestOptions
 import org.opensearch.flint.common.FlintVersion.current
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.storage.{FlintOpenSearchIndexMetadataService, OpenSearchClientUtils}
-import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
+import org.opensearch.flint.spark.FlintSparkIndex.{quotedTableName, ID_COLUMN}
 import org.opensearch.flint.spark.scheduler.OpenSearchAsyncQueryScheduler
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingFileIndex
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
@@ -338,7 +338,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
       val sourceMap = response.getSourceAsMap
 
       sourceMap.get("jobId") shouldBe testIndex
-      sourceMap.get("scheduledQuery") shouldBe s"REFRESH SKIPPING INDEX ON $testTable"
+      sourceMap
+        .get("scheduledQuery") shouldBe s"REFRESH SKIPPING INDEX ON ${quotedTableName(testTable)}"
       sourceMap.get("enabled") shouldBe true
       sourceMap.get("queryLang") shouldBe "sql"
 


### PR DESCRIPTION
### Description

1. Support recovery for index with external scheduler
2. Support `ALTER` scheduler_mode between internal and external in single statement
3. Add index level metrics for refresh query, with dimension (clientId, dataSource, indexName)
![Screenshot 2024-10-09 at 17 07 26](https://github.com/user-attachments/assets/6c075e66-c124-43f5-97b0-a828f959f14b)

4. Support external scheduler with index name including `-`
5. optimize `build.sbt` on dependency package complie

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/762

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
