### PR TITLE
[0.5-nexus] Disable Fields Minus in grammar to avoid data correctness issue

### DIFF
--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -87,7 +87,7 @@ mappingClause
     ;
 
 fieldsCommand
-   : FIELDS (PLUS | MINUS)? fieldList
+   : FIELDS (PLUS)? fieldList
    ;
 
 renameCommand

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/ArgumentFactory.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/ArgumentFactory.java
@@ -25,10 +25,7 @@ public class ArgumentFactory {
    * @return the list of arguments fetched from the fields command
    */
   public static List<Argument> getArgumentList(OpenSearchPPLParser.FieldsCommandContext ctx) {
-    return Collections.singletonList(
-        ctx.MINUS() != null
-            ? new Argument("exclude", new Literal(true, DataType.BOOLEAN))
-            : new Argument("exclude", new Literal(false, DataType.BOOLEAN)));
+    return Collections.singletonList(new Argument("exclude", new Literal(false, DataType.BOOLEAN)));
   }
 
   /**


### PR DESCRIPTION
### Description
The Fields Minus Command `fields - <field list>` has been supported from https://github.com/opensearch-project/opensearch-spark/pull/698 which is required Spark 3.5.0+
But its grammar presented at the beginning of this repository created, which the `-` in `fields - <field list>` is ignored by default. So in branch 0.5-nexus whose spark version is 3.3.2 will cause data correctness issue (the command results equal to command `fields + <field list>`).

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-spark/issues/731

### Check List
- [ ] Updated documentation (ppl-spark-integration/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).