### PR TITLE
Test suites unset custom config even when test failure

### DIFF
--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexBuilderSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexBuilderSuite.scala
@@ -38,6 +38,13 @@ class FlintSparkIndexBuilderSuite extends FlintSuite {
     super.afterAll()
   }
 
+  override def afterEach(): Unit = {
+    super.afterEach()
+    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
+    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_INTERVAL_THRESHOLD.key)
+    conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
+  }
+
   test("indexOptions should not have checkpoint location when no conf") {
     assert(!conf.contains(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key))
 
@@ -208,13 +215,6 @@ class FlintSparkIndexBuilderSuite extends FlintSuite {
     }
     exception.getMessage should include(
       "External scheduler mode is not enabled in the configuration")
-  }
-
-  override def afterEach(): Unit = {
-    super.afterEach()
-    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
-    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_INTERVAL_THRESHOLD.key)
-    conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
   }
 
   private def builder(): FakeFlintSparkIndexBuilder = {

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexITSuite.scala
@@ -39,7 +39,8 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
 
   override def afterEach(): Unit = {
     super.afterEach()
-
+    conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
+    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     // Delete all test indices
     deleteTestIndex(testFlintIndex)
   }
@@ -162,8 +163,6 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
       assert(
         checkpointLocation.get.contains(testFlintIndex),
         s"Checkpoint location dir should contain ${testFlintIndex}")
-
-      conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
     }
   }
 
@@ -209,7 +208,6 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
 
       val indexData = flint.queryIndex(testFlintIndex)
       checkAnswer(indexData, Seq(Row("Hello", 30), Row("World", 25)))
-      conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     }
   }
 
@@ -289,8 +287,6 @@ class FlintSparkCoveringIndexITSuite extends FlintSparkSuite {
       assert(
         checkpointLocation.get.contains(testFlintIndex),
         s"Checkpoint location dir should contain ${testFlintIndex}")
-
-      conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
     }
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -37,7 +37,8 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
 
   override def afterEach(): Unit = {
     super.afterEach()
-
+    conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
+    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     // Delete all test indices
     deleteTestIndex(testFlintIndex)
     sql(s"DROP TABLE $testTable")
@@ -180,8 +181,6 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
 
       // Drop index with test scheduler
       sql(s"DROP INDEX $testIndex ON $testTable")
-      conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
-      conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     }
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -48,6 +48,8 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
 
   override def afterEach(): Unit = {
     super.afterEach()
+    conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
+    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     deleteTestIndex(testFlintIndex)
   }
 
@@ -130,8 +132,6 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
       assert(
         checkpointLocation.get.contains(testFlintIndex),
         s"Checkpoint location dir should contain ${testFlintIndex}")
-
-      conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
     }
   }
 
@@ -333,8 +333,6 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
       assert(
         checkpointLocation.get.contains(testFlintIndex),
         s"Checkpoint location dir should contain ${testFlintIndex}")
-
-      conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
     }
   }
 
@@ -385,8 +383,6 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
           Row(timestamp("2023-10-01 00:00:00"), 1),
           Row(timestamp("2023-10-01 00:10:00"), 2),
           Row(timestamp("2023-10-01 01:00:00"), 1)))
-
-      conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     }
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -45,6 +45,8 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
 
   override def afterEach(): Unit = {
     super.afterEach()
+    conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
+    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     deleteTestIndex(testFlintIndex)
     sql(s"DROP TABLE $testTable")
   }
@@ -119,8 +121,6 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
 
       // Drop index with test scheduler
       sql(s"DROP MATERIALIZED VIEW $testMvName")
-      conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
-      conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     }
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -49,6 +49,8 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
   }
 
   override def afterEach(): Unit = {
+    conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
+    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     // Delete all test indices
     deleteTestIndex(testIndex)
     sql(s"DROP TABLE $testTable")
@@ -215,8 +217,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
       assert(
         checkpointLocation.get.contains(testIndex),
         s"Checkpoint location dir should contain ${testIndex}")
-
-      conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
     }
   }
 
@@ -363,7 +363,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
       // Expect to only refresh the new file
       flint.refreshIndex(testIndex) shouldBe empty
       flint.queryIndex(testIndex).collect().toSet should have size 1
-      conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     }
   }
 
@@ -442,8 +441,6 @@ class FlintSparkSkippingIndexITSuite extends FlintSparkSuite {
       assert(
         checkpointLocation.get.contains(testIndex),
         s"Checkpoint location dir should contain ${testIndex}")
-
-      conf.unsetConf(FlintSparkConf.CHECKPOINT_LOCATION_ROOT_DIR.key)
     }
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSqlITSuite.scala
@@ -37,7 +37,8 @@ class FlintSparkSkippingIndexSqlITSuite extends FlintSparkSuite with ExplainSuit
 
   protected override def afterEach(): Unit = {
     super.afterEach()
-
+    conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
+    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     deleteTestIndex(testIndex)
     sql(s"DROP TABLE $testTable")
   }
@@ -98,8 +99,6 @@ class FlintSparkSkippingIndexSqlITSuite extends FlintSparkSuite with ExplainSuit
       flint.queryIndex(testIndex).count() shouldBe 2
 
       sql(s"DROP SKIPPING INDEX ON $testTable")
-      conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
-      conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
     }
   }
 


### PR DESCRIPTION
### Description
Some test cases set custom Spark config values and unset them at the end. However, if the test case fails, then the custom setting won't be unset, and will affect other test cases.
This PR fixes that.
This should reduce the current CI failure to only the external scheduler test cases.
We could check CI result to see failed tests reduced from 23 to 8.

Later backport to main. PR made here since CI failure now only happens on this branch (`0.5-nexus`). 

- [ ] Backport main

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
