### PR TITLE
Support aggregate functions in Eval expressions

### DIFF
--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -473,6 +473,7 @@ evalFunctionName
    | systemFunctionName
    | positionFunctionName
    | coalesceFunctionName
+   | statsFunctionName
    ;
 
 functionArgs


### PR DESCRIPTION
### Description
Aggregate functions could work in select clause even there is no group by as long as all items in `select` are aggregate functions.
Here are some examples:
```sql
select max(a) from t
select max(a), min(a), count(a) from t
```
But the following queries should throw exceptions
```sql
select a, max(a) from t
select a, max(a), min(a), count(a) from t
select *, max(a), min(a), count(a) from t
```
They could work with a `group by`
```sql
select a, max(a) from t group by b
select a, max(a), min(a), count(a) from t group by b
select *, max(a), min(a), count(a) from t group by b
```

Similar, aggregate functions in PPL could work in `eval` command, because an eval expression equals to add a projection to existing project list.
Here are some examples:
```sql
source=t | eval m = max(a) | fields m
source=t | eval m = max(a), n = count(a) | fields m, n
source=t | eval m = max(a) | n = count(a) | fields m, n
```
But the following PPL queries should throw exceptions
```sql
source=t | eval m = max(a) -- equals to all fields plus m
source=t | eval m = max(a), n = count(a) | fields a, m, n
source=t | eval m = max(a) | n = count(a) | fields a, m, n
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/755

### Check List
~- [ ] Updated documentation (ppl-spark-integration/README.md)~
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
