### PR TITLE
AND should have higher precedence than OR in predicate expression

### DIFF
--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -358,8 +358,8 @@ expression
 logicalExpression
    : comparisonExpression                                       # comparsion
    | NOT logicalExpression                                      # logicalNot
-   | left = logicalExpression OR right = logicalExpression      # logicalOr
    | left = logicalExpression (AND)? right = logicalExpression  # logicalAnd
+   | left = logicalExpression OR right = logicalExpression      # logicalOr
    | left = logicalExpression XOR right = logicalExpression     # logicalXor
    | booleanExpression                                          # booleanExpr
    | isEmptyExpression                                          # isEmptyExpr


### PR DESCRIPTION
### Description
In SQL, `AND` has higher precedence than `OR`.
Example:
```sql
SELECT *
FROM employees
WHERE department = 'HR'
   OR job_title = 'Manager'
   AND salary > 50000;
```
In this query, the `AND` between `job_title = 'Manager'` and `salary > 50000` is evaluated first, because `AND` has higher precedence than `OR`. It equals to
```sql
WHERE department = 'HR'
   OR (job_title = 'Manager' AND salary > 50000);

```

But in PPL, this query will be evaluated with wrong order:
```sql
source=employees
| where department = 'HR' OR job_title = 'Manager' AND salary > 50000
```
was evaluated to
```sql
source=employees
| where (department = 'HR' OR job_title = 'Manager') AND salary > 50000
```

### Issues Resolved
Resolve https://github.com/opensearch-project/opensearch-spark/issues/770

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
