### PR TITLE
[Backport 0.5] Support table identifier contains dot with backticks

### DIFF
--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBasicITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBasicITSuite.scala
@@ -26,7 +26,7 @@ class FlintSparkPPLBasicITSuite
   private val t2 = "`spark_catalog`.default.`flint_ppl_test2`"
   private val t3 = "spark_catalog.`default`.`flint_ppl_test3`"
   private val t4 = "`spark_catalog`.`default`.flint_ppl_test4"
-  
+
   override def beforeAll(): Unit = {
     super.beforeAll()
 
@@ -129,8 +129,7 @@ class FlintSparkPPLBasicITSuite
 
   test("test backtick table names and name contains '.'") {
     Seq(t1, t2, t3, t4).foreach { table =>
-      val frame = sql(
-        s"""
+      val frame = sql(s"""
            | source = $table| head 2
            | """.stripMargin)
       assert(frame.collect().length == 2)
@@ -139,15 +138,13 @@ class FlintSparkPPLBasicITSuite
     val t5 = "`spark_catalog`.default.`flint/ppl/test5.log`"
     val t6 = "spark_catalog.default.`flint_ppl_test6.log`"
     Seq(t5, t6).foreach { table =>
-      val ex = intercept[AnalysisException](sql(
-        s"""
+      val ex = intercept[AnalysisException](sql(s"""
            | source = $table| head 2
            | """.stripMargin))
       assert(ex.getMessage().contains("TABLE_OR_VIEW_NOT_FOUND"))
     }
     val t7 = "spark_catalog.default.flint_ppl_test7.log"
-    val ex = intercept[IllegalArgumentException](sql(
-      s"""
+    val ex = intercept[IllegalArgumentException](sql(s"""
          | source = $t7| head 2
          | """.stripMargin))
     assert(ex.getMessage().contains("Invalid table name"))
@@ -155,8 +152,7 @@ class FlintSparkPPLBasicITSuite
 
   test("test describe backtick table names and name contains '.'") {
     Seq(t1, t2, t3, t4).foreach { table =>
-      val frame = sql(
-        s"""
+      val frame = sql(s"""
            | describe $table
            | """.stripMargin)
       assert(frame.collect().length > 0)
@@ -165,15 +161,13 @@ class FlintSparkPPLBasicITSuite
     val t5 = "`spark_catalog`.default.`flint/ppl/test5.log`"
     val t6 = "spark_catalog.default.`flint_ppl_test6.log`"
     Seq(t5, t6).foreach { table =>
-      val ex = intercept[AnalysisException](sql(
-        s"""
+      val ex = intercept[AnalysisException](sql(s"""
            | describe $table
            | """.stripMargin))
       assert(ex.getMessage().contains("TABLE_OR_VIEW_NOT_FOUND"))
     }
     val t7 = "spark_catalog.default.flint_ppl_test7.log"
-    val ex = intercept[IllegalArgumentException](sql(
-      s"""
+    val ex = intercept[IllegalArgumentException](sql(s"""
          | describe $t7
          | """.stripMargin))
     assert(ex.getMessage().contains("Invalid table name"))

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBasicITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBasicITSuite.scala
@@ -179,36 +179,6 @@ class FlintSparkPPLBasicITSuite
     assert(ex.getMessage().contains("Invalid table name"))
   }
 
-  test("test explain backtick table names and name contains '.'") {
-    Seq(t1, t2, t3, t4).foreach { table =>
-      val frame = sql(
-        s"""
-           | explain extended | source = $table
-           | """.stripMargin)
-      assert(frame.collect().length > 0)
-    }
-    // test read table which is unable to create
-    val table = "`spark_catalog`.default.`flint/ppl/test4.log`"
-    val frame = sql(
-      s"""
-         | explain extended | source = $table
-         | """.stripMargin)
-    val logicalPlan: LogicalPlan = frame.queryExecution.logical
-    val relation = UnresolvedRelation(Seq("spark_catalog", "default", "flint/ppl/test4.log"))
-    val expectedPlan: LogicalPlan =
-      ExplainCommand(
-        Project(Seq(UnresolvedStar(None)), relation),
-        ExplainMode.fromString("extended"))
-    comparePlans(logicalPlan, expectedPlan, checkAnalysis = false)
-
-    val t7 = "spark_catalog.default.flint_ppl_test7.log"
-    val ex = intercept[IllegalArgumentException](sql(
-      s"""
-         | explain extended | source = $t7
-         | """.stripMargin))
-    assert(ex.getMessage().contains("Invalid table name"))
-  }
-  
   test("create ppl simple query test") {
     val testTableQuoted = "`spark_catalog`.`default`.`flint_ppl_test`"
     Seq(testTable, testTableQuoted).foreach { table =>

--- a/ppl-spark-integration/README.md
+++ b/ppl-spark-integration/README.md
@@ -226,7 +226,11 @@ See the next samples of PPL queries :
 
 **Describe**
  - `describe table`  This command is equal to the `DESCRIBE EXTENDED table` SQL command
-
+ - `describe schema.table`
+ - `` describe schema.`table` ``
+ - `describe catalog.schema.table`
+ - `` describe catalog.schema.`table` ``
+ - `` describe `catalog`.`schema`.`table` ``
 **Fields**
  - `source = table`
  - `source = table | fields a,b,c`

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Relation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Relation.java
@@ -38,7 +38,6 @@ public class Relation extends UnresolvedPlan {
   private String alias;
 
   /**
-   * Return table name.
    *
    * @return table name
    */
@@ -46,7 +45,11 @@ public class Relation extends UnresolvedPlan {
     return tableName.stream().map(Object::toString).collect(Collectors.toList());
   }
 
- 
+
+  public List<QualifiedName> getQualifiedNames() {
+    return tableName.stream().map(t -> (QualifiedName) t).collect(Collectors.toList());
+  }
+  
   /**
    * Return alias.
    *

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/RelationUtils.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/RelationUtils.java
@@ -1,8 +1,10 @@
 package org.opensearch.sql.ppl.utils;
 
+import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.opensearch.sql.ast.expression.QualifiedName;
+import scala.Option$;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +17,6 @@ public interface RelationUtils {
      *
      * @param relations
      * @param node
-     * @param contextRelations
      * @return
      */
     static Optional<QualifiedName> resolveField(List<UnresolvedRelation> relations, QualifiedName node, List<LogicalPlan> tables) {
@@ -28,5 +29,27 @@ public interface RelationUtils {
                                 .orElse(false))
                 .findFirst()
                 .map(rel -> node);
+    }
+   
+    static TableIdentifier getTableIdentifier(QualifiedName qualifiedName) {
+        TableIdentifier identifier;
+        if (qualifiedName.getParts().isEmpty()) {
+            throw new IllegalArgumentException("Empty table name is invalid");
+        } else if (qualifiedName.getParts().size() == 1) {
+            identifier = new TableIdentifier(qualifiedName.getParts().get(0));
+        } else if (qualifiedName.getParts().size() == 2) {
+            identifier = new TableIdentifier(
+                    qualifiedName.getParts().get(1),
+                    Option$.MODULE$.apply(qualifiedName.getParts().get(0)));
+        } else if (qualifiedName.getParts().size() == 3) {
+            identifier = new TableIdentifier(
+                    qualifiedName.getParts().get(2),
+                    Option$.MODULE$.apply(qualifiedName.getParts().get(1)),
+                    Option$.MODULE$.apply(qualifiedName.getParts().get(0)));
+        } else {
+            throw new IllegalArgumentException("Invalid table name: " + qualifiedName
+                    + " Syntax: [ database_name. ] table_name");
+        }
+        return identifier;
     }
 }

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanBasicQueriesTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanBasicQueriesTranslatorTestSuite.scala
@@ -36,7 +36,7 @@ class PPLLogicalPlanBasicQueriesTranslatorTestSuite
     assert(
       thrown.getMessage === "Invalid table name: t.b.c.d Syntax: [ database_name. ] table_name")
   }
-  
+
   test("test describe with backticks") {
     val context = new CatalystPlanContext
     val logPlan =
@@ -49,7 +49,7 @@ class PPLLogicalPlanBasicQueriesTranslatorTestSuite
       output = DescribeRelation.getOutputAttrs)
     comparePlans(expectedPlan, logPlan, false)
   }
-  
+
   test("test describe FQN table clause") {
     val context = new CatalystPlanContext
     val logPlan =

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanBasicQueriesTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanBasicQueriesTranslatorTestSuite.scala
@@ -36,14 +36,27 @@ class PPLLogicalPlanBasicQueriesTranslatorTestSuite
     assert(
       thrown.getMessage === "Invalid table name: t.b.c.d Syntax: [ database_name. ] table_name")
   }
+  
+  test("test describe with backticks") {
+    val context = new CatalystPlanContext
+    val logPlan =
+      planTransformer.visit(plan(pplParser, "describe t.b.`c.d`", false), context)
 
+    val expectedPlan = DescribeTableCommand(
+      TableIdentifier("c.d", Option("b"), Option("t")),
+      Map.empty[String, String].empty,
+      isExtended = true,
+      output = DescribeRelation.getOutputAttrs)
+    comparePlans(expectedPlan, logPlan, false)
+  }
+  
   test("test describe FQN table clause") {
     val context = new CatalystPlanContext
     val logPlan =
-      planTransformer.visit(plan(pplParser, "describe schema.default.http_logs", false), context)
+      planTransformer.visit(plan(pplParser, "describe catalog.schema.http_logs", false), context)
 
     val expectedPlan = DescribeTableCommand(
-      TableIdentifier("http_logs", Option("schema"), Option("default")),
+      TableIdentifier("http_logs", Option("schema"), Option("catalog")),
       Map.empty[String, String].empty,
       isExtended = true,
       output = DescribeRelation.getOutputAttrs)
@@ -64,10 +77,10 @@ class PPLLogicalPlanBasicQueriesTranslatorTestSuite
 
   test("test FQN table describe table clause") {
     val context = new CatalystPlanContext
-    val logPlan = planTransformer.visit(plan(pplParser, "describe catalog.t", false), context)
+    val logPlan = planTransformer.visit(plan(pplParser, "describe schema.t", false), context)
 
     val expectedPlan = DescribeTableCommand(
-      TableIdentifier("t", Option("catalog")),
+      TableIdentifier("t", Option("schema")),
       Map.empty[String, String].empty,
       isExtended = true,
       output = DescribeRelation.getOutputAttrs)


### PR DESCRIPTION
### Description
backport 768 bug fix to 0.5

### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/767

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
