### PR TITLE
Add auth-crt lib as runtime dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ lazy val flintCore = (project in file("flint-core"))
         exclude ("com.fasterxml.jackson.core", "jackson-databind"),
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.12.593"
         exclude("com.fasterxml.jackson.core", "jackson-databind"),
-      "software.amazon.awssdk" % "auth-crt" % "2.28.10" % "provided",
+      "software.amazon.awssdk" % "auth-crt" % "2.28.10",
       "org.scalactic" %% "scalactic" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest-flatspec" % "3.2.15" % "test",


### PR DESCRIPTION
### Description
Add auth-crt lib as runtime dependency

### Issues Resolved

The fat jar doesn't include auth-crt lib will cause runtime issue:

```
java.lang.NoClassDefFoundError: software/amazon/awssdk/authcrt/signer/AwsCrtV4aSigner
```

after this change:

```
Searching in /usr/lib/spark/jars/opensearch-spark-sql-application_2.12-latest.jar
software/amazon/awssdk/authcrt/signer/AwsCrtV4aSigner$Builder.class
software/amazon/awssdk/authcrt/signer/AwsCrtV4aSigner.class
software/amazon/awssdk/authcrt/signer/internal/DefaultAwsCrtV4aSigner$1.class
software/amazon/awssdk/authcrt/signer/internal/DefaultAwsCrtV4aSigner$BuilderImpl.class
software/amazon/awssdk/authcrt/signer/internal/DefaultAwsCrtV4aSigner.class
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
