### PR TITLE
[Infrastructure] Move style check ahead of Integ test

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -22,8 +22,8 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
-      - name: Integ Test
-        run: sbt integtest/integration
-
       - name: Style check
         run: sbt scalafmtCheckAll
+
+      - name: Integ Test
+        run: sbt integtest/integration


### PR DESCRIPTION
### Description
Even the current build strategy is `fail-fast: false` (matrix level), thanks to `jobs.<job_id>.continue-on-error` is false as default, style check fail out with an notification before Integ Test could be time saving.
<img width="921" alt="Screenshot 2024-10-16 at 15 29 29" src="https://github.com/user-attachments/assets/2eb83f20-ed33-4c8f-8000-9817e7cdb4cd">



### Issues Resolved
https://github.com/opensearch-project/opensearch-spark/issues/782

### Check List
- [ ] Updated documentation (ppl-spark-integration/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
