### PR TITLE
Add query execution metrics

### DIFF
--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -113,11 +113,6 @@ public final class MetricConstants {
     public static final String STREAMING_HEARTBEAT_FAILED_METRIC = "streaming.heartbeat.failed.count";
 
     /**
-     * Metric name for tracking the processing time of batch job.
-     */
-    public static final String BATCH_PROCESSING_TIME_METRIC = "batch.processingTime";
-
-    /**
      * Metric for tracking the latency of query execution (start to complete query execution) excluding result write.
      */
     public static final String QUERY_EXECUTION_TIME_METRIC = "query.execution.processingTime";

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -112,6 +112,16 @@ public final class MetricConstants {
      */
     public static final String STREAMING_HEARTBEAT_FAILED_METRIC = "streaming.heartbeat.failed.count";
 
+    /**
+     * Metric name for tracking the processing time of batch job.
+     */
+    public static final String BATCH_PROCESSING_TIME_METRIC = "batch.processingTime";
+
+    /**
+     * Metric for tracking the latency of query execution (start to complete query execution) excluding result write.
+     */
+    public static final String QUERY_EXECUTION_TIME_METRIC = "query.execution.processingTime";
+
     private MetricConstants() {
         // Private constructor to prevent instantiation
     }

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricsUtil.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricsUtil.java
@@ -107,6 +107,10 @@ public final class MetricsUtil {
         return context != null ? context.stop() : null;
     }
 
+    public static Timer getTimer(String metricName, boolean isIndexMetric) {
+        return getOrCreateTimer(metricName, isIndexMetric);
+    }
+
     /**
      * Registers a gauge metric with the provided name and value.
      *

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -5,7 +5,7 @@
 
 package org.apache.spark.sql
 
-import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.{ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}
@@ -14,7 +14,7 @@ import scala.util.{Failure, Success, Try}
 
 import org.opensearch.flint.common.model.FlintStatement
 import org.opensearch.flint.common.scheduler.model.LangType
-import org.opensearch.flint.core.metrics.MetricConstants
+import org.opensearch.flint.core.metrics.{MetricConstants, MetricsUtil}
 import org.opensearch.flint.core.metrics.MetricsUtil.incrementCounter
 import org.opensearch.flint.spark.FlintSpark
 
@@ -136,6 +136,8 @@ case class JobOperator(
             "",
             startTime))
     } finally {
+      emitQueryExecutionTimeMetric(startTime)
+
       try {
         dataToWrite.foreach(df => writeDataFrameToOpensearch(df, resultIndex, osClient))
       } catch {
@@ -148,11 +150,14 @@ case class JobOperator(
       statement.error = Some(error)
       statementExecutionManager.updateStatement(statement)
 
-      cleanUpResources(exceptionThrown, threadPool)
+      cleanUpResources(exceptionThrown, threadPool, startTime)
     }
   }
 
-  def cleanUpResources(exceptionThrown: Boolean, threadPool: ThreadPoolExecutor): Unit = {
+  def cleanUpResources(
+      exceptionThrown: Boolean,
+      threadPool: ThreadPoolExecutor,
+      startTime: Long): Unit = {
     val isStreaming = jobType.equalsIgnoreCase(FlintJobType.STREAMING)
     try {
       // Wait for streaming job complete if no error
@@ -182,6 +187,8 @@ case class JobOperator(
     }
     recordStreamingCompletionStatus(exceptionThrown)
 
+    emitBatchProcessingTimeMetric(startTime)
+
     // Check for non-daemon threads that may prevent the driver from shutting down.
     // Non-daemon threads other than the main thread indicate that the driver is still processing tasks,
     // which may be due to unresolved bugs in dependencies or threads not being properly shut down.
@@ -192,6 +199,21 @@ case class JobOperator(
       // If exiting with non-zero status, emr-s job will fail.
       // This is a part of the fault tolerance mechanism to handle such scenarios gracefully
       System.exit(0)
+    }
+  }
+
+  private def emitQueryExecutionTimeMetric(startTime: Long): Unit = {
+    MetricsUtil
+      .getTimer(MetricConstants.QUERY_EXECUTION_TIME_METRIC, false)
+      .update(System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
+  }
+
+  private def emitBatchProcessingTimeMetric(startTime: Long): Unit = {
+    if (jobType.equalsIgnoreCase(FlintJobType.BATCH)) {
+      val latency = System.currentTimeMillis() - startTime;
+      MetricsUtil
+        .getTimer(MetricConstants.BATCH_PROCESSING_TIME_METRIC, false)
+        .update(latency, TimeUnit.MILLISECONDS)
     }
   }
 

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -187,8 +187,6 @@ case class JobOperator(
     }
     recordStreamingCompletionStatus(exceptionThrown)
 
-    emitBatchProcessingTimeMetric(startTime)
-
     // Check for non-daemon threads that may prevent the driver from shutting down.
     // Non-daemon threads other than the main thread indicate that the driver is still processing tasks,
     // which may be due to unresolved bugs in dependencies or threads not being properly shut down.
@@ -206,15 +204,6 @@ case class JobOperator(
     MetricsUtil
       .getTimer(MetricConstants.QUERY_EXECUTION_TIME_METRIC, false)
       .update(System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
-  }
-
-  private def emitBatchProcessingTimeMetric(startTime: Long): Unit = {
-    if (jobType.equalsIgnoreCase(FlintJobType.BATCH)) {
-      val latency = System.currentTimeMillis() - startTime;
-      MetricsUtil
-        .getTimer(MetricConstants.BATCH_PROCESSING_TIME_METRIC, false)
-        .update(latency, TimeUnit.MILLISECONDS)
-    }
   }
 
   def stop(): Unit = {


### PR DESCRIPTION
### Description
- Add query execution metrics
- batch.processingTime: execution duration for batch query.
- query.execution.processingTime: Duration from start to complete query (excluding writing result)

![Metrics-CloudWatch-us-west-2-10-21-2024_04_28_PM](https://github.com/user-attachments/assets/0449ab21-b3cc-4209-9c91-d1f71364fd21)

### Related Issues
n/a

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
