### PR TITLE
Support `Eventstats` in PPL

### DIFF
--- a/docs/ppl-lang/PPL-Example-Commands.md
+++ b/docs/ppl-lang/PPL-Example-Commands.md
@@ -167,6 +167,34 @@ source = table |  where ispresent(a) |
 - `source = table | stats avg(age) as avg_state_age by country, state | stats avg(avg_state_age) as avg_country_age by country`
 - `source = table | stats avg(age) as avg_city_age by country, state, city | eval new_avg_city_age = avg_city_age - 1 | stats avg(new_avg_city_age) as avg_state_age by country, state | where avg_state_age > 18 | stats avg(avg_state_age) as avg_adult_country_age by country`
 
+#### **Event Aggregations**
+[See additional command details](ppl-eventstats-command.md)
+
+- `source = table | eventstats avg(a) `
+- `source = table | where a < 50 | eventstats avg(c) `
+- `source = table | eventstats max(c) by b`
+- `source = table | eventstats count(c) by b | head 5`
+- `source = table | eventstats stddev_samp(c)`
+- `source = table | eventstats stddev_pop(c)`
+- `source = table | eventstats percentile(c, 90)`
+- `source = table | eventstats percentile_approx(c, 99)`
+
+**Limitation: distinct aggregation could not used in `eventstats`:**_
+- `source = table | eventstats distinct_count(c)` (throw exception)
+
+**Aggregations With Span**
+- `source = table  | eventstats count(a) by span(a, 10) as a_span`
+- `source = table  | eventstats sum(age) by span(age, 5) as age_span | head 2`
+- `source = table  | eventstats avg(age) by span(age, 20) as age_span, country  | sort - age_span |  head 2`
+
+**Aggregations With TimeWindow Span (tumble windowing function)**
+- `source = table | eventstats sum(productsAmount) by span(transactionDate, 1d) as age_date | sort age_date`
+- `source = table | eventstats sum(productsAmount) by span(transactionDate, 1w) as age_date, productId`
+
+**Aggregations Group by Multiple Times**
+- `source = table | eventstats avg(age) as avg_state_age by country, state | eventstats avg(avg_state_age) as avg_country_age by country`
+- `source = table | eventstats avg(age) as avg_city_age by country, state, city | eval new_avg_city_age = avg_city_age - 1 | eventstats avg(new_avg_city_age) as avg_state_age by country, state | where avg_state_age > 18 | eventstats avg(avg_state_age) as avg_adult_country_age by country`
+
 #### **Dedup**
 
 [See additional command details](ppl-dedup-command.md)

--- a/docs/ppl-lang/README.md
+++ b/docs/ppl-lang/README.md
@@ -50,6 +50,8 @@ For additional examples see the next [documentation](PPL-Example-Commands.md).
 
     - [`stats command`](ppl-stats-command.md)
 
+    - [`eventstats command`](ppl-eventstats-command.md)
+
     - [`where command`](ppl-where-command.md)
 
     - [`head command`](ppl-head-command.md)

--- a/docs/ppl-lang/ppl-eventstats-command.md
+++ b/docs/ppl-lang/ppl-eventstats-command.md
@@ -1,0 +1,327 @@
+## PPL `eventstats` command
+
+### Description
+The `eventstats` command enriches your event data with calculated summary statistics. It operates by analyzing specified fields within your events, computing various statistical measures, and then appending these results as new fields to each original event.
+
+Key aspects of `eventstats`:
+
+1. It performs calculations across the entire result set or within defined groups.
+2. The original events remain intact, with new fields added to contain the statistical results.
+3. The command is particularly useful for comparative analysis, identifying outliers, or providing additional context to individual events.
+
+### Difference between [`stats`](ppl-stats-command.md) and `eventstats`
+The `stats` and `eventstats` commands are both used for calculating statistics, but they have some key differences in how they operate and what they produce:
+
+- Output Format:
+  - `stats`: Produces a summary table with only the calculated statistics.
+  - `eventstats`: Adds the calculated statistics as new fields to the existing events, preserving the original data.
+- Event Retention:
+  - `stats`: Reduces the result set to only the statistical summary, discarding individual events.
+  - `eventstats`: Retains all original events and adds new fields with the calculated statistics.
+- Use Cases:
+  - `stats`: Best for creating summary reports or dashboards. Often used as a final command to summarize results.
+  - `eventstats`: Useful when you need to enrich events with statistical context for further analysis or filtering. Can be used mid-search to add statistics that can be used in subsequent commands.
+
+### Syntax
+`eventstats <aggregation>... [by-clause]`
+
+### **aggregation:**
+mandatory. A aggregation function. The argument of aggregation must be field.
+
+**by-clause**: optional.
+
+#### Syntax:
+`by [span-expression,] [field,]...`
+
+**Description:**
+
+The by clause could be the fields and expressions like scalar functions and aggregation functions.
+Besides, the span clause can be used to split specific field into buckets in the same interval, the eventstats then does the aggregation by these span buckets.
+
+**Default**:
+
+If no `<by-clause>` is specified, the eventstats command aggregates over the entire result set.
+
+### **`span-expression`**:
+optional, at most one.
+
+#### Syntax:
+`span(field_expr, interval_expr)`
+
+**Description:**
+
+The unit of the interval expression is the natural unit by default.
+If the field is a date and time type field, and the interval is in date/time units, you will need to specify the unit in the interval expression.
+
+For example, to split the field ``age`` into buckets by 10 years, it looks like ``span(age, 10)``. And here is another example of time span, the span to split a ``timestamp`` field into hourly intervals, it looks like ``span(timestamp, 1h)``.
+
+* Available time unit:
+```
++----------------------------+
+| Span Interval Units        |
++============================+
+| millisecond (ms)           |
++----------------------------+
+| second (s)                 |
++----------------------------+
+| minute (m, case sensitive) |
++----------------------------+
+| hour (h)                   |
++----------------------------+
+| day (d)                    |
++----------------------------+
+| week (w)                   |
++----------------------------+
+| month (M, case sensitive)  |
++----------------------------+
+| quarter (q)                |
++----------------------------+
+| year (y)                   |
++----------------------------+
+```
+
+### Aggregation Functions
+
+#### _COUNT_
+
+**Description**
+
+Returns a count of the number of expr in the rows retrieved by a SELECT statement.
+
+Example:
+
+    os> source=accounts | eventstats count();
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+---------+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | count() |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+---------+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 4       |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 4       |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 4       |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 4       |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+---------+
+
+
+#### _SUM_
+
+**Description**
+
+`SUM(expr)`. Returns the sum of expr.
+
+Example:
+
+    os> source=accounts | eventstats sum(age) by gender;
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+--------------------+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | sum(age) by gender |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+--------------------+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 101                |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 101                |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 28                 |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 101                |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+--------------------+
+
+
+#### _AVG_
+
+**Description**
+
+`AVG(expr)`. Returns the average value of expr.
+
+Example:
+
+    os> source=accounts | eventstats avg(age) by gender;
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+--------------------+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | avg(age) by gender |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+--------------------+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 33.67              |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 33.67              |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 28.00              |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 33.67              |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+--------------------+
+
+
+#### MAX
+
+**Description**
+
+`MAX(expr)` Returns the maximum value of expr.
+
+Example:
+
+    os> source=accounts | eventstats max(age);
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----------+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | max(age)  |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----------+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 36        |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 36        |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 36        |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 36        |
++----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----------+
+
+
+#### MIN
+
+**Description**
+
+`MIN(expr)` Returns the minimum value of expr.
+
+Example:
+
+    os> source=accounts | eventstats min(age);
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----------+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | min(age)  |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----------+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 28        |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 28        |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 28        |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 28        |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----------+
+
+
+#### STDDEV_SAMP
+
+**Description**
+
+`STDDEV_SAMP(expr)` Return the sample standard deviation of expr.
+
+Example:
+
+    os> source=accounts | eventstats stddev_samp(age);
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+------------------------+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | stddev_samp(age)       |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+------------------------+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 3.304037933599835      |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 3.304037933599835      |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 3.304037933599835      |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 3.304037933599835      |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+------------------------+
+
+
+#### STDDEV_POP
+
+**Description**
+
+`STDDEV_POP(expr)` Return the population standard deviation of expr.
+
+Example:
+
+    os> source=accounts | eventstats stddev_pop(age);
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+------------------------+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | stddev_pop(age)        |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+------------------------+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 2.8613807855648994     |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 2.8613807855648994     |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 2.8613807855648994     |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 2.8613807855648994     |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+------------------------+
+
+
+#### PERCENTILE or PERCENTILE_APPROX
+
+**Description**
+
+`PERCENTILE(expr, percent)` or `PERCENTILE_APPROX(expr, percent)` Return the approximate percentile value of expr at the specified percentage.
+
+* percent: The number must be a constant between 0 and 100.
+---
+
+Examples:
+
+    os> source=accounts | eventstats percentile(age, 90) by gender;
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+--------------------------------+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | percentile(age, 90) by gender  |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+--------------------------------+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 36                             |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 36                             |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 28                             |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 36                             |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+--------------------------------+
+
+
+### Example 1: Calculate the average, sum and count of a field by group
+
+The example show calculate the average age, sum age and count of events of all the accounts group by gender.
+
+PPL query:
+
+    os> source=accounts | eventstats avg(age) as avg_age, sum(age) as sum_age, count() as count by gender;
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----------+-----------+-------+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | avg_age   | sum_age   | count |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----------+-----------+-------+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 33.666667 | 101       | 3     |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 33.666667 | 101       | 3     |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 28.000000 | 28        | 1     |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 33.666667 | 101       | 3     |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----------+-----------+-------+
+
+
+### Example 2: Calculate the count by a span
+
+The example gets the count of age by the interval of 10 years.
+
+PPL query:
+
+    os> source=accounts | eventstats count(age) by span(age, 10) as age_span
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+----------+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | age_span |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+----------+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 3        |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 3        |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 1        |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 3        |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+----------+
+
+
+### Example 3: Calculate the count by a gender and span
+
+The example gets the count of age by the interval of 5 years and group by gender.
+
+PPL query:
+
+    os> source=accounts | eventstats count() as cnt by span(age, 5) as age_span, gender
+    fetched rows / total rows = 4/4
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----+
+    | account_number | balance  | firstname | lastname | age | gender | address               | employer | email                    | city   | state | cnt |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----+
+    | 1              | 39225    | Amber     | Duke     | 32  | M      | 880 Holmes Lane       | Pyrami   | amberduke@pyrami.com     | Brogan | IL    | 2   |
+    | 6              | 5686     | Hattie    | Bond     | 36  | M      | 671 Bristol Street    | Netagy   | hattiebond@netagy.com    | Dante  | TN    | 1   |
+    | 13             | 32838    | Nanette   | Bates    | 28  | F      | 789 Madison Street    | Quility  |                          | Nogal  | VA    | 1   |
+    | 18             | 4180     | Dale      | Adams    | 33  | M      | 467 Hutchinson Court  |          | daleadams@boink.com      | Orick  | MD    | 2   |
+    +----------------+----------+-----------+----------+-----+--------+-----------------------+----------+--------------------------+--------+-------+-----+
+
+
+### Usage
+- `source = table | eventstats avg(a) `
+- `source = table | where a < 50 | eventstats avg(c) `
+- `source = table | eventstats max(c) by b`
+- `source = table | eventstats count(c) by b | head 5`
+- `source = table | eventstats distinct_count(c)`
+- `source = table | eventstats stddev_samp(c)`
+- `source = table | eventstats stddev_pop(c)`
+- `source = table | eventstats percentile(c, 90)`
+- `source = table | eventstats percentile_approx(c, 99)`
+
+**Aggregations With Span**
+- `source = table  | eventstats count(a) by span(a, 10) as a_span`
+- `source = table  | eventstats sum(age) by span(age, 5) as age_span | head 2`
+- `source = table  | eventstats avg(age) by span(age, 20) as age_span, country  | sort - age_span |  head 2`
+
+**Aggregations With TimeWindow Span (tumble windowing function)**
+
+- `source = table | eventstats sum(productsAmount) by span(transactionDate, 1d) as age_date | sort age_date`
+- `source = table | eventstats sum(productsAmount) by span(transactionDate, 1w) as age_date, productId`
+
+**Aggregations Group by Multiple Levels**
+
+- `source = table | eventstats avg(age) as avg_state_age by country, state | eventstats avg(avg_state_age) as avg_country_age by country`
+- `source = table | eventstats avg(age) as avg_city_age by country, state, city | eval new_avg_city_age = avg_city_age - 1 | eventstats avg(new_avg_city_age) as avg_state_age by country, state | where avg_state_age > 18 | eventstats avg(avg_state_age) as avg_adult_country_age by country`
+

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLEventstatsITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLEventstatsITSuite.scala
@@ -1,0 +1,379 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.ppl
+
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedFunction, UnresolvedRelation, UnresolvedStar}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Divide, Floor, Literal, Multiply, RowFrame, SpecifiedWindowFrame, UnboundedFollowing, UnboundedPreceding, WindowExpression, WindowSpecDefinition}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Window}
+import org.apache.spark.sql.streaming.StreamTest
+
+class FlintSparkPPLEventstatsITSuite
+    extends QueryTest
+    with LogicalPlanTestUtils
+    with FlintPPLSuite
+    with StreamTest {
+
+  /** Test table and index name */
+  private val testTable = "spark_catalog.default.flint_ppl_test"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    // Create test table
+    createPartitionedStateCountryTable(testTable)
+  }
+
+  protected override def afterEach(): Unit = {
+    super.afterEach()
+    // Stop all streaming jobs if any
+    spark.streams.active.foreach { job =>
+      job.stop()
+      job.awaitTermination()
+    }
+  }
+
+  test("test eventstats avg") {
+    val frame = sql(s"""
+                       | source = $testTable | eventstats avg(age)
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 36.25),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 36.25),
+      Row("Jake", 70, "California", "USA", 2023, 4, 36.25),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 36.25))
+    assertSameRows(expected, frame)
+
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+    val table = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test"))
+    val windowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        Nil,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgWindowExprAlias = Alias(windowExpression, "avg(age)")()
+    val windowPlan = Window(Seq(avgWindowExprAlias), Nil, Nil, table)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan)
+    comparePlans(logicalPlan, expectedPlan, checkAnalysis = false)
+  }
+
+  test("test eventstats avg, max, min, count") {
+    val frame = sql(s"""
+                       | source = $testTable | eventstats avg(age) as avg_age, max(age) as max_age, min(age) as min_age, count(age) as count
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 36.25, 70, 20, 4),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 36.25, 70, 20, 4),
+      Row("Jake", 70, "California", "USA", 2023, 4, 36.25, 70, 20, 4),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 36.25, 70, 20, 4))
+    assertSameRows(expected, frame)
+
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+    val table = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test"))
+    val avgWindowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        Nil,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgWindowExprAlias = Alias(avgWindowExpression, "avg_age")()
+
+    val maxWindowExpression = WindowExpression(
+      UnresolvedFunction("MAX", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        Nil,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val maxWindowExprAlias = Alias(maxWindowExpression, "max_age")()
+
+    val minWindowExpression = WindowExpression(
+      UnresolvedFunction("MIN", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        Nil,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val minWindowExprAlias = Alias(minWindowExpression, "min_age")()
+
+    val countWindowExpression = WindowExpression(
+      UnresolvedFunction("COUNT", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        Nil,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val countWindowExprAlias = Alias(countWindowExpression, "count")()
+    val windowPlan = Window(
+      Seq(avgWindowExprAlias, maxWindowExprAlias, minWindowExprAlias, countWindowExprAlias),
+      Nil,
+      Nil,
+      table)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan)
+    comparePlans(logicalPlan, expectedPlan, checkAnalysis = false)
+  }
+
+  test("test eventstats avg by country") {
+    val frame = sql(s"""
+                       | source = $testTable | eventstats avg(age) by country
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 22.5),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 22.5),
+      Row("Jake", 70, "California", "USA", 2023, 4, 50),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 50))
+    assertSameRows(expected, frame)
+
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+    val table = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test"))
+    val partitionSpec = Seq(Alias(UnresolvedAttribute("country"), "country")())
+    val windowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgWindowExprAlias = Alias(windowExpression, "avg(age)")()
+    val windowPlan = Window(Seq(avgWindowExprAlias), partitionSpec, Nil, table)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan)
+    comparePlans(logicalPlan, expectedPlan, checkAnalysis = false)
+  }
+
+  test("test eventstats avg, max, min, count by country") {
+    val frame = sql(s"""
+                       | source = $testTable | eventstats avg(age) as avg_age, max(age) as max_age, min(age) as min_age, count(age) as count by country
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 22.5, 25, 20, 2),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 22.5, 25, 20, 2),
+      Row("Jake", 70, "California", "USA", 2023, 4, 50, 70, 30, 2),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 50, 70, 30, 2))
+    assertSameRows(expected, frame)
+
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+    val table = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test"))
+    val partitionSpec = Seq(Alias(UnresolvedAttribute("country"), "country")())
+    val avgWindowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgWindowExprAlias = Alias(avgWindowExpression, "avg_age")()
+
+    val maxWindowExpression = WindowExpression(
+      UnresolvedFunction("MAX", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val maxWindowExprAlias = Alias(maxWindowExpression, "max_age")()
+
+    val minWindowExpression = WindowExpression(
+      UnresolvedFunction("MIN", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val minWindowExprAlias = Alias(minWindowExpression, "min_age")()
+
+    val countWindowExpression = WindowExpression(
+      UnresolvedFunction("COUNT", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val countWindowExprAlias = Alias(countWindowExpression, "count")()
+    val windowPlan = Window(
+      Seq(avgWindowExprAlias, maxWindowExprAlias, minWindowExprAlias, countWindowExprAlias),
+      partitionSpec,
+      Nil,
+      table)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan)
+    comparePlans(logicalPlan, expectedPlan, checkAnalysis = false)
+  }
+
+  test("test eventstats avg, max, min, count by span") {
+    val frame = sql(s"""
+                       | source = $testTable | eventstats avg(age) as avg_age, max(age) as max_age, min(age) as min_age, count(age) as count by span(age, 10) as age_span
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 22.5, 25, 20, 2),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 22.5, 25, 20, 2),
+      Row("Jake", 70, "California", "USA", 2023, 4, 70, 70, 70, 1),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 30, 30, 30, 1))
+    assertSameRows(expected, frame)
+
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+    val table = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test"))
+    val span = Alias(
+      Multiply(Floor(Divide(UnresolvedAttribute("age"), Literal(10))), Literal(10)),
+      "age_span")()
+    val partitionSpec = Seq(span)
+    val windowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgWindowExprAlias = Alias(windowExpression, "avg_age")()
+
+    val maxWindowExpression = WindowExpression(
+      UnresolvedFunction("MAX", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val maxWindowExprAlias = Alias(maxWindowExpression, "max_age")()
+
+    val minWindowExpression = WindowExpression(
+      UnresolvedFunction("MIN", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val minWindowExprAlias = Alias(minWindowExpression, "min_age")()
+
+    val countWindowExpression = WindowExpression(
+      UnresolvedFunction("COUNT", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val countWindowExprAlias = Alias(countWindowExpression, "count")()
+    val windowPlan = Window(
+      Seq(avgWindowExprAlias, maxWindowExprAlias, minWindowExprAlias, countWindowExprAlias),
+      partitionSpec,
+      Nil,
+      table)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan)
+    comparePlans(logicalPlan, expectedPlan, checkAnalysis = false)
+  }
+
+  test("test eventstats avg, max, min, count by span and country") {
+    val frame = sql(s"""
+                       | source = $testTable | eventstats avg(age) as avg_age, max(age) as max_age, min(age) as min_age, count(age) as count by span(age, 10) as age_span, country
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 22.5, 25, 20, 2),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 22.5, 25, 20, 2),
+      Row("Jake", 70, "California", "USA", 2023, 4, 70, 70, 70, 1),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 30, 30, 30, 1))
+    assertSameRows(expected, frame)
+  }
+
+  test("test eventstats avg, max, min, count by span and state") {
+    val frame = sql(s"""
+                       | source = $testTable | eventstats avg(age) as avg_age, max(age) as max_age, min(age) as min_age, count(age) as count by span(age, 10) as age_span, state
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 25, 25, 25, 1),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 20, 20, 20, 1),
+      Row("Jake", 70, "California", "USA", 2023, 4, 70, 70, 70, 1),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 30, 30, 30, 1))
+    assertSameRows(expected, frame)
+  }
+
+  test("test eventstats stddev by span with filter") {
+    val frame = sql(s"""
+                       | source = $testTable | where country != 'USA' | eventstats stddev_samp(age) by span(age, 10) as age_span
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 3.5355339059327378),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 3.5355339059327378))
+    assertSameRows(expected, frame)
+  }
+
+  test("test eventstats stddev_pop by span with filter") {
+    val frame = sql(s"""
+                       | source = $testTable | where state != 'California' | eventstats stddev_pop(age) by span(age, 10) as age_span
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 2.5),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 2.5),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 0.0))
+    assertSameRows(expected, frame)
+  }
+
+  test("test eventstats percentile by span with filter") {
+    val frame = sql(s"""
+                       | source = $testTable | where state != 'California' | eventstats percentile_approx(age, 60) by span(age, 10) as age_span
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 25),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 25),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 30))
+    assertSameRows(expected, frame)
+  }
+
+  test("test multiple eventstats") {
+    val frame = sql(s"""
+                       | source = $testTable | eventstats avg(age) as avg_age by state, country | eventstats avg(avg_age) as avg_state_age by country
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 25.0, 22.5),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 20.0, 22.5),
+      Row("Jake", 70, "California", "USA", 2023, 4, 70.0, 50.0),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 30.0, 50.0))
+    assertSameRows(expected, frame)
+
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+    val partitionSpec = Seq(
+      Alias(UnresolvedAttribute("state"), "state")(),
+      Alias(UnresolvedAttribute("country"), "country")())
+    val table = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test"))
+    val avgAgeWindowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgAgeWindowExprAlias = Alias(avgAgeWindowExpression, "avg_age")()
+    val windowPlan1 = Window(Seq(avgAgeWindowExprAlias), partitionSpec, Nil, table)
+
+    val countryPartitionSpec = Seq(Alias(UnresolvedAttribute("country"), "country")())
+    val avgStateAgeWindowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("avg_age")), isDistinct = false),
+      WindowSpecDefinition(
+        countryPartitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgStateAgeWindowExprAlias = Alias(avgStateAgeWindowExpression, "avg_state_age")()
+    val windowPlan2 =
+      Window(Seq(avgStateAgeWindowExprAlias), countryPartitionSpec, Nil, windowPlan1)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan2)
+    comparePlans(logicalPlan, expectedPlan, checkAnalysis = false)
+  }
+
+  test("test multiple eventstats with eval") {
+    val frame = sql(s"""
+                       | source = $testTable | eventstats avg(age) as avg_age by state, country | eval new_avg_age = avg_age - 10 | eventstats avg(new_avg_age) as avg_state_age by country
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 25.0, 15.0, 12.5),
+      Row("Jane", 20, "Quebec", "Canada", 2023, 4, 20.0, 10.0, 12.5),
+      Row("Jake", 70, "California", "USA", 2023, 4, 70.0, 60.0, 40.0),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 30.0, 20.0, 40.0))
+    assertSameRows(expected, frame)
+  }
+
+  test("test multiple eventstats with eval and filter") {
+    val frame = sql(s"""
+                       | source = $testTable| eventstats avg(age) as avg_age by country, state, name | eval avg_age_divide_20 = avg_age - 20 | eventstats avg(avg_age_divide_20)
+                       | as avg_state_age by country, state | where avg_state_age > 0 | eventstats count(avg_state_age) as count_country_age_greater_20 by country
+                       | """.stripMargin)
+    val expected = Seq(
+      Row("John", 25, "Ontario", "Canada", 2023, 4, 25.0, 5.0, 5.0, 1),
+      Row("Jake", 70, "California", "USA", 2023, 4, 70.0, 50.0, 50.0, 2),
+      Row("Hello", 30, "New York", "USA", 2023, 4, 30.0, 10.0, 10.0, 2))
+    assertSameRows(expected, frame)
+  }
+
+  test("test eventstats distinct_count by span with filter") {
+    val exception = intercept[AnalysisException](sql(s"""
+                       | source = $testTable | where state != 'California' | eventstats distinct_count(age) by span(age, 10) as age_span
+                       | """.stripMargin))
+    assert(exception.message.contains("Distinct window functions are not supported"))
+  }
+}

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
@@ -18,6 +18,7 @@ WHERE:                              'WHERE';
 FIELDS:                             'FIELDS';
 RENAME:                             'RENAME';
 STATS:                              'STATS';
+EVENTSTATS:                         'EVENTSTATS';
 DEDUP:                              'DEDUP';
 SORT:                               'SORT';
 EVAL:                               'EVAL';

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -115,7 +115,7 @@ renameCommand
    ;
 
 statsCommand
-   : STATS (PARTITIONS EQUAL partitions = integerLiteral)? (ALLNUM EQUAL allnum = booleanLiteral)? (DELIM EQUAL delim = stringLiteral)? statsAggTerm (COMMA statsAggTerm)* (statsByClause)? (DEDUP_SPLITVALUES EQUAL dedupsplit = booleanLiteral)?
+   : (STATS | EVENTSTATS) (PARTITIONS EQUAL partitions = integerLiteral)? (ALLNUM EQUAL allnum = booleanLiteral)? (DELIM EQUAL delim = stringLiteral)? statsAggTerm (COMMA statsAggTerm)* (statsByClause)? (DEDUP_SPLITVALUES EQUAL dedupsplit = booleanLiteral)?
    ;
 
 dedupCommand

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -307,4 +307,8 @@ public abstract class AbstractNodeVisitor<T, C> {
   public T visitExistsSubquery(ExistsSubquery node, C context) {
     return visitChildren(node, context);
   }
+
+  public T visitWindow(Window node, C context) {
+    return visitChildren(node, context);
+  }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Window.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Window.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+import java.util.List;
+
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class Window extends UnresolvedPlan {
+    private final List<UnresolvedExpression> windowFunctionList;
+    private final List<UnresolvedExpression> partExprList;
+    private final List<UnresolvedExpression> sortExprList;
+    @Setter private UnresolvedExpression span;
+    private UnresolvedPlan child;
+
+    @Override
+    public UnresolvedPlan attach(UnresolvedPlan child) {
+        this.child = child;
+        return this;
+    }
+
+    @Override
+    public List<UnresolvedPlan> getChild() {
+        return ImmutableList.of(this.child);
+    }
+
+    @Override
+    public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+        return nodeVisitor.visitWindow(this, context);
+    }
+}

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
@@ -81,12 +81,14 @@ import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TopAggregation;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.ast.tree.Window;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.ppl.utils.AggregatorTranslator;
 import org.opensearch.sql.ppl.utils.BuiltinFunctionTranslator;
 import org.opensearch.sql.ppl.utils.ComparatorTransformer;
 import org.opensearch.sql.ppl.utils.ParseStrategy;
 import org.opensearch.sql.ppl.utils.SortUtils;
+import org.opensearch.sql.ppl.utils.WindowSpecTransformer;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.IterableLike;
@@ -115,6 +117,7 @@ import static org.opensearch.sql.ppl.utils.LookupTransformer.buildProjectListFro
 import static org.opensearch.sql.ppl.utils.RelationUtils.getTableIdentifier;
 import static org.opensearch.sql.ppl.utils.RelationUtils.resolveField;
 import static org.opensearch.sql.ppl.utils.WindowSpecTransformer.window;
+import static scala.collection.JavaConverters.seqAsJavaList;
 
 /**
  * Utility class to traverse PPL logical plan and translate it into catalyst logical plan
@@ -324,6 +327,30 @@ public class CatalystQueryPlanVisitor extends AbstractNodeVisitor<LogicalPlan, C
         Seq<Expression> groupingExpression = context.retainAllGroupingNamedParseExpressions(p -> p);
         Seq<NamedExpression> aggregateExpressions = context.retainAllNamedParseExpressions(p -> (NamedExpression) p);
         return context.apply(p -> new Aggregate(groupingExpression, aggregateExpressions, p));
+    }
+
+    @Override
+    public LogicalPlan visitWindow(Window node, CatalystPlanContext context) {
+        node.getChild().get(0).accept(this, context);
+        List<Expression> windowFunctionExpList = visitExpressionList(node.getWindowFunctionList(), context);
+        Seq<Expression> windowFunctionExpressions = context.retainAllNamedParseExpressions(p -> p);
+        List<Expression> partitionExpList = visitExpressionList(node.getPartExprList(), context);
+        UnresolvedExpression span = node.getSpan();
+        if (!Objects.isNull(span)) {
+            visitExpression(span, context);
+        }
+        Seq<Expression> partitionSpec = context.retainAllNamedParseExpressions(p -> p);
+        Seq<SortOrder> orderSpec = seq(new ArrayList<SortOrder>());
+        Seq<NamedExpression> aggregatorFunctions = seq(
+            seqAsJavaList(windowFunctionExpressions).stream()
+                .map(w -> WindowSpecTransformer.buildAggregateWindowFunction(w, partitionSpec, orderSpec))
+                .collect(Collectors.toList()));
+        return context.apply(p ->
+            new org.apache.spark.sql.catalyst.plans.logical.Window(
+                aggregatorFunctions,
+                partitionSpec,
+                orderSpec,
+                p));
     }
 
     @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -269,14 +269,24 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
             .map(this::internalVisitExpression)
             .orElse(null);
 
-    Aggregation aggregation =
-        new Aggregation(
-            aggListBuilder.build(),
-            emptyList(),
-            groupList,
-            span,
-            ArgumentFactory.getArgumentList(ctx));
-    return aggregation;
+    if (ctx.STATS() != null) {
+      Aggregation aggregation =
+          new Aggregation(
+              aggListBuilder.build(),
+              emptyList(),
+              groupList,
+              span,
+              ArgumentFactory.getArgumentList(ctx));
+      return aggregation;
+    } else {
+      Window window =
+          new Window(
+              aggListBuilder.build(),
+              groupList,
+              emptyList());
+      window.setSpan(span);
+      return window;
+    }
   }
 
   /** Dedup command. */

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanEventstatsTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanEventstatsTranslatorTestSuite.scala
@@ -1,0 +1,256 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.ppl
+
+import org.opensearch.flint.spark.ppl.PlaneUtils.plan
+import org.opensearch.sql.ppl.{CatalystPlanContext, CatalystQueryPlanVisitor}
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedFunction, UnresolvedRelation, UnresolvedStar}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Divide, Floor, Literal, Multiply, RowFrame, SpecifiedWindowFrame, UnboundedFollowing, UnboundedPreceding, WindowExpression, WindowSpecDefinition}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Window}
+
+class PPLLogicalPlanEventstatsTranslatorTestSuite
+    extends SparkFunSuite
+    with PlanTest
+    with LogicalPlanTestUtils
+    with Matchers {
+
+  private val planTransformer = new CatalystQueryPlanVisitor()
+  private val pplParser = new PPLSyntaxParser()
+
+  test("test eventstats avg") {
+    val context = new CatalystPlanContext
+    val logPlan =
+      planTransformer.visit(plan(pplParser, "source = table | eventstats avg(age)"), context)
+
+    val table = UnresolvedRelation(Seq("table"))
+    val windowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        Nil,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgWindowExprAlias = Alias(windowExpression, "avg(age)")()
+    val windowPlan = Window(Seq(avgWindowExprAlias), Nil, Nil, table)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan)
+    comparePlans(expectedPlan, logPlan, false)
+  }
+
+  test("test eventstats avg, max, min, count") {
+    val context = new CatalystPlanContext
+    val logPlan =
+      planTransformer.visit(
+        plan(
+          pplParser,
+          "source = table | eventstats avg(age) as avg_age, max(age) as max_age, min(age) as min_age, count(age) as count"),
+        context)
+
+    val table = UnresolvedRelation(Seq("table"))
+    val avgWindowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        Nil,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgWindowExprAlias = Alias(avgWindowExpression, "avg_age")()
+
+    val maxWindowExpression = WindowExpression(
+      UnresolvedFunction("MAX", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        Nil,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val maxWindowExprAlias = Alias(maxWindowExpression, "max_age")()
+
+    val minWindowExpression = WindowExpression(
+      UnresolvedFunction("MIN", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        Nil,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val minWindowExprAlias = Alias(minWindowExpression, "min_age")()
+
+    val countWindowExpression = WindowExpression(
+      UnresolvedFunction("COUNT", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        Nil,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val countWindowExprAlias = Alias(countWindowExpression, "count")()
+    val windowPlan = Window(
+      Seq(avgWindowExprAlias, maxWindowExprAlias, minWindowExprAlias, countWindowExprAlias),
+      Nil,
+      Nil,
+      table)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan)
+    comparePlans(expectedPlan, logPlan, checkAnalysis = false)
+  }
+
+  test("test eventstats avg by country") {
+    val context = new CatalystPlanContext
+    val logPlan =
+      planTransformer.visit(
+        plan(pplParser, "source = table | eventstats avg(age) by country"),
+        context)
+
+    val table = UnresolvedRelation(Seq("table"))
+    val partitionSpec = Seq(Alias(UnresolvedAttribute("country"), "country")())
+    val windowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgWindowExprAlias = Alias(windowExpression, "avg(age)")()
+    val windowPlan = Window(Seq(avgWindowExprAlias), partitionSpec, Nil, table)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan)
+    comparePlans(expectedPlan, logPlan, checkAnalysis = false)
+  }
+
+  test("test eventstats avg, max, min, count by country") {
+    val context = new CatalystPlanContext
+    val logPlan =
+      planTransformer.visit(
+        plan(
+          pplParser,
+          "source = table | eventstats avg(age) as avg_age, max(age) as max_age, min(age) as min_age, count(age) as count by country"),
+        context)
+
+    val table = UnresolvedRelation(Seq("table"))
+    val partitionSpec = Seq(Alias(UnresolvedAttribute("country"), "country")())
+    val avgWindowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgWindowExprAlias = Alias(avgWindowExpression, "avg_age")()
+
+    val maxWindowExpression = WindowExpression(
+      UnresolvedFunction("MAX", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val maxWindowExprAlias = Alias(maxWindowExpression, "max_age")()
+
+    val minWindowExpression = WindowExpression(
+      UnresolvedFunction("MIN", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val minWindowExprAlias = Alias(minWindowExpression, "min_age")()
+
+    val countWindowExpression = WindowExpression(
+      UnresolvedFunction("COUNT", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val countWindowExprAlias = Alias(countWindowExpression, "count")()
+    val windowPlan = Window(
+      Seq(avgWindowExprAlias, maxWindowExprAlias, minWindowExprAlias, countWindowExprAlias),
+      partitionSpec,
+      Nil,
+      table)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan)
+    comparePlans(expectedPlan, logPlan, checkAnalysis = false)
+  }
+
+  test("test eventstats avg, max, min, count by span") {
+    val context = new CatalystPlanContext
+    val logPlan =
+      planTransformer.visit(
+        plan(
+          pplParser,
+          "source = table | eventstats avg(age) as avg_age, max(age) as max_age, min(age) as min_age, count(age) as count by span(age, 10) as age_span"),
+        context)
+
+    val table = UnresolvedRelation(Seq("table"))
+    val span = Alias(
+      Multiply(Floor(Divide(UnresolvedAttribute("age"), Literal(10))), Literal(10)),
+      "age_span")()
+    val partitionSpec = Seq(span)
+    val windowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgWindowExprAlias = Alias(windowExpression, "avg_age")()
+
+    val maxWindowExpression = WindowExpression(
+      UnresolvedFunction("MAX", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val maxWindowExprAlias = Alias(maxWindowExpression, "max_age")()
+
+    val minWindowExpression = WindowExpression(
+      UnresolvedFunction("MIN", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val minWindowExprAlias = Alias(minWindowExpression, "min_age")()
+
+    val countWindowExpression = WindowExpression(
+      UnresolvedFunction("COUNT", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val countWindowExprAlias = Alias(countWindowExpression, "count")()
+    val windowPlan = Window(
+      Seq(avgWindowExprAlias, maxWindowExprAlias, minWindowExprAlias, countWindowExprAlias),
+      partitionSpec,
+      Nil,
+      table)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan)
+    comparePlans(expectedPlan, logPlan, checkAnalysis = false)
+  }
+
+  test("test multiple eventstats") {
+    val context = new CatalystPlanContext
+    val logPlan =
+      planTransformer.visit(
+        plan(
+          pplParser,
+          "source = table | eventstats avg(age) as avg_age by state, country | eventstats avg(avg_age) as avg_state_age by country"),
+        context)
+
+    val partitionSpec = Seq(
+      Alias(UnresolvedAttribute("state"), "state")(),
+      Alias(UnresolvedAttribute("country"), "country")())
+    val table = UnresolvedRelation(Seq("table"))
+    val avgAgeWindowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("age")), isDistinct = false),
+      WindowSpecDefinition(
+        partitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgAgeWindowExprAlias = Alias(avgAgeWindowExpression, "avg_age")()
+    val windowPlan1 = Window(Seq(avgAgeWindowExprAlias), partitionSpec, Nil, table)
+
+    val countryPartitionSpec = Seq(Alias(UnresolvedAttribute("country"), "country")())
+    val avgStateAgeWindowExpression = WindowExpression(
+      UnresolvedFunction("AVG", Seq(UnresolvedAttribute("avg_age")), isDistinct = false),
+      WindowSpecDefinition(
+        countryPartitionSpec,
+        Nil,
+        SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)))
+    val avgStateAgeWindowExprAlias = Alias(avgStateAgeWindowExpression, "avg_state_age")()
+    val windowPlan2 =
+      Window(Seq(avgStateAgeWindowExprAlias), countryPartitionSpec, Nil, windowPlan1)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), windowPlan2)
+    comparePlans(expectedPlan, logPlan, checkAnalysis = false)
+  }
+}


### PR DESCRIPTION
### Description
## PPL `eventstats` command

### Description
The `eventstats` command enriches your event data with calculated summary statistics. It operates by analyzing specified fields within your events, computing various statistical measures, and then appending these results as new fields to each original event.

Key aspects of `eventstats`:

1. It performs calculations across the entire result set or within defined groups.
2. The original events remain intact, with new fields added to contain the statistical results.
3. The command is particularly useful for comparative analysis, identifying outliers, or providing additional context to individual events.

### Difference between [`stats`](ppl-stats-command.md) and `eventstats`
The `stats` and `eventstats` commands are both used for calculating statistics, but they have some key differences in how they operate and what they produce:

- Output Format:
  - `stats`: Produces a summary table with only the calculated statistics.
  - `eventstats`: Adds the calculated statistics as new fields to the existing events, preserving the original data.
- Event Retention:
  - `stats`: Reduces the result set to only the statistical summary, discarding individual events.
  - `eventstats`: Retains all original events and adds new fields with the calculated statistics.
- Use Cases:
  - `stats`: Best for creating summary reports or dashboards. Often used as a final command to summarize results.
  - `eventstats`: Useful when you need to enrich events with statistical context for further analysis or filtering. Can be used mid-search to add statistics that can be used in subsequent commands.

### Syntax
```sql
eventstats <aggregation>... [by-clause]
```
(check "docs/ppl-lang/ppl-eventstats-command.md" for details)

#### **Event Aggregations**
[See additional command details](ppl-eventstats-command.md)

- `source = table | eventstats avg(a) `
- `source = table | where a < 50 | eventstats avg(c) `
- `source = table | eventstats max(c) by b`
- `source = table | eventstats count(c) by b | head 5`
- `source = table | eventstats stddev_samp(c)`
- `source = table | eventstats stddev_pop(c)`
- `source = table | eventstats percentile(c, 90)`
- `source = table | eventstats percentile_approx(c, 99)`

**Limitation: distinct aggregation could not used in `eventstats`:**_
- `source = table | eventstats distinct_count(c)` (throw exception)

**Aggregations With Span**
- `source = table  | eventstats count(a) by span(a, 10) as a_span`
- `source = table  | eventstats sum(age) by span(age, 5) as age_span | head 2`
- `source = table  | eventstats avg(age) by span(age, 20) as age_span, country  | sort - age_span |  head 2`

**Aggregations With TimeWindow Span (tumble windowing function)**
- `source = table | eventstats sum(productsAmount) by span(transactionDate, 1d) as age_date | sort age_date`
- `source = table | eventstats sum(productsAmount) by span(transactionDate, 1w) as age_date, productId`

**Aggregations Group by Multiple Times**
- `source = table | eventstats avg(age) as avg_state_age by country, state | eventstats avg(avg_state_age) as avg_country_age by country`
- `source = table | eventstats avg(age) as avg_city_age by country, state, city | eval new_avg_city_age = avg_city_age - 1 | eventstats avg(new_avg_city_age) as avg_state_age by country, state | where avg_state_age > 18 | eventstats avg(avg_state_age) as avg_adult_country_age by country`


### Related Issues
Resolves #660 

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
