### PR TITLE
Add read/write bytes metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ lazy val flintCore = (project in file("flint-core"))
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.12.593"
         exclude("com.fasterxml.jackson.core", "jackson-databind"),
       "software.amazon.awssdk" % "auth-crt" % "2.28.10",
+      "org.projectlombok" % "lombok" % "1.18.30" % "provided",
       "org.scalactic" %% "scalactic" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest-flatspec" % "3.2.15" % "test",

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/HistoricGauge.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/HistoricGauge.java
@@ -10,35 +10,26 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Value;
 
 /**
  * Gauge which stores historic data points with timestamps.
  * This is used for emitting separate data points per request, instead of single aggregated metrics.
  */
 public class HistoricGauge implements Gauge<Long> {
+  @AllArgsConstructor
+  @Value
   public static class DataPoint {
     Long value;
     long timestamp;
-
-    DataPoint(long value, long timestamp) {
-      this.value = value;
-      this.timestamp = timestamp;
-    }
-
-    public Long getValue() {
-      return value;
-    }
-
-    public long getTimestamp() {
-      return timestamp;
-    }
   }
 
   private final List<DataPoint> dataPoints = Collections.synchronizedList(new LinkedList<>());
 
   /**
    * This method will just return first value.
-   * @return
+   * @return first value
    */
   @Override
   public Long getValue() {
@@ -49,6 +40,10 @@ public class HistoricGauge implements Gauge<Long> {
     }
   }
 
+  /**
+   * Add new data point. Current time stamp will be attached to the data point.
+   * @param value metric value
+   */
   public void addDataPoint(Long value) {
     dataPoints.add(new DataPoint(value, System.currentTimeMillis()));
   }

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/HistoricGauge.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/HistoricGauge.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core.metrics;
+
+import com.codahale.metrics.Gauge;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Gauge which stores historic data points with timestamps.
+ * This is used for emitting separate data points per request, instead of single aggregated metrics.
+ */
+public class HistoricGauge implements Gauge<Long> {
+  public static class DataPoint {
+    Long value;
+    long timestamp;
+
+    DataPoint(long value, long timestamp) {
+      this.value = value;
+      this.timestamp = timestamp;
+    }
+
+    public Long getValue() {
+      return value;
+    }
+
+    public long getTimestamp() {
+      return timestamp;
+    }
+  }
+
+  private final List<DataPoint> dataPoints = Collections.synchronizedList(new LinkedList<>());
+
+  /**
+   * This method will just return first value.
+   * @return
+   */
+  @Override
+  public Long getValue() {
+    if (!dataPoints.isEmpty()) {
+      return dataPoints.get(0).value;
+    } else {
+      return null;
+    }
+  }
+
+  public void addDataPoint(Long value) {
+    dataPoints.add(new DataPoint(value, System.currentTimeMillis()));
+  }
+
+  /**
+   * Return copy of dataPoints and remove them from internal list
+   * @return copy of the data points
+   */
+  public List<DataPoint> pollDataPoints() {
+    int size = dataPoints.size();
+    List<DataPoint> result = new ArrayList<>(dataPoints.subList(0, size));
+    if (size > 0) {
+      dataPoints.subList(0, size).clear();
+    }
+    return result;
+  }
+}

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -117,6 +117,26 @@ public final class MetricConstants {
      */
     public static final String QUERY_EXECUTION_TIME_METRIC = "query.execution.processingTime";
 
+    /**
+     * Metric for tracking the total bytes read from input
+     */
+    public static final String INPUT_TOTAL_BYTES_READ = "input.totalBytesRead.count";
+
+    /**
+     * Metric for tracking the total records read from input
+     */
+    public static final String INPUT_TOTAL_RECORDS_READ = "input.totalRecordsRead.count";
+
+    /**
+     * Metric for tracking the total bytes written to output
+     */
+    public static final String OUTPUT_TOTAL_BYTES_WRITTEN = "output.totalBytesWritten.count";
+
+    /**
+     * Metric for tracking the total records written to output
+     */
+    public static final String OUTPUT_TOTAL_RECORDS_WRITTEN = "output.totalRecordsWritten.count";
+
     private MetricConstants() {
         // Private constructor to prevent instantiation
     }

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricsUtil.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricsUtil.java
@@ -121,10 +121,10 @@ public final class MetricsUtil {
     }
 
     /**
-     * Registers a gauge metric with the provided name and value.
+     * Registers a HistoricGauge metric with the provided name and value.
      *
-     * @param metricName The name of the gauge metric to register.
-     * @param value The AtomicInteger whose current value should be reflected by the gauge.
+     * @param metricName The name of the HistoricGauge metric to register.
+     * @param value The value to be stored
      */
     public static void addHistoricGauge(String metricName, final long value) {
         HistoricGauge historicGauge = getOrCreateHistoricGauge(metricName);
@@ -143,6 +143,16 @@ public final class MetricsUtil {
      *
      * @param metricName The name of the gauge metric to register.
      * @param value The AtomicInteger whose current value should be reflected by the gauge.
+     */
+    public static void registerGauge(String metricName, final AtomicInteger value) {
+        registerGauge(metricName, value, false);
+    }
+
+    /**
+     * Registers a gauge metric with the provided name and value.
+     *
+     * @param metricName The name of the gauge metric to register.
+     * @param value The AtomicInteger whose current value should be reflected by the gauge.
      * @param isIndexMetric Whether this metric is an index-specific metric.
      */
     public static void registerGauge(String metricName, final AtomicInteger value, boolean isIndexMetric) {
@@ -153,17 +163,6 @@ public final class MetricsUtil {
         }
         metricRegistry.register(metricName, (Gauge<Integer>) value::get);
     }
-
-    /**
-     * Registers a gauge metric with the provided name and value.
-     *
-     * @param metricName The name of the gauge metric to register.
-     * @param value The AtomicInteger whose current value should be reflected by the gauge.
-     */
-    public static void registerGauge(String metricName, final AtomicInteger value) {
-        registerGauge(metricName, value, false);
-    }
-
 
     private static Counter getOrCreateCounter(String metricName, boolean isIndexMetric) {
         MetricRegistry metricRegistry = getMetricRegistry(isIndexMetric);

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metrics/ReadWriteBytesSparkListener.scala
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metrics/ReadWriteBytesSparkListener.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core.metrics
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Collect and emit bytesRead/Written and recordsRead/Written metrics
+ */
+class ReadWriteBytesSparkListener extends SparkListener with Logging {
+  var bytesRead: Long = 0
+  var recordsRead: Long = 0
+  var bytesWritten: Long = 0
+  var recordsWritten: Long = 0
+
+  override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+    val inputMetrics = taskEnd.taskMetrics.inputMetrics
+    val outputMetrics = taskEnd.taskMetrics.outputMetrics
+    val ids = s"(${taskEnd.taskInfo.taskId}, ${taskEnd.taskInfo.partitionId})"
+    logInfo(
+      s"${ids} Input: bytesRead=${inputMetrics.bytesRead}, recordsRead=${inputMetrics.recordsRead}")
+    logInfo(
+      s"${ids} Output: bytesWritten=${outputMetrics.bytesWritten}, recordsWritten=${outputMetrics.recordsWritten}")
+
+    bytesRead += inputMetrics.bytesRead
+    recordsRead += inputMetrics.recordsRead
+    bytesWritten += outputMetrics.bytesWritten
+    recordsWritten += outputMetrics.recordsWritten
+  }
+
+  def emitMetrics(): Unit = {
+    logInfo(s"Input: totalBytesRead=${bytesRead}, totalRecordsRead=${recordsRead}")
+    logInfo(s"Output: totalBytesWritten=${bytesWritten}, totalRecordsWritten=${recordsWritten}")
+    MetricsUtil.addHistoricGauge(MetricConstants.INPUT_TOTAL_BYTES_READ, bytesRead)
+    MetricsUtil.addHistoricGauge(MetricConstants.INPUT_TOTAL_RECORDS_READ, recordsRead)
+    MetricsUtil.addHistoricGauge(MetricConstants.OUTPUT_TOTAL_BYTES_WRITTEN, bytesWritten)
+    MetricsUtil.addHistoricGauge(MetricConstants.OUTPUT_TOTAL_RECORDS_WRITTEN, recordsWritten)
+  }
+}
+
+object ReadWriteBytesSparkListener {
+  def withMetrics[T](spark: SparkSession, lambda: () => T): T = {
+    val listener = new ReadWriteBytesSparkListener()
+    spark.sparkContext.addSparkListener(listener)
+
+    val result = lambda()
+
+    spark.sparkContext.removeSparkListener(listener)
+    listener.emitMetrics()
+
+    result
+  }
+}

--- a/flint-core/src/test/java/org/opensearch/flint/core/metrics/HistoricGaugeTest.java
+++ b/flint-core/src/test/java/org/opensearch/flint/core/metrics/HistoricGaugeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core.metrics;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.opensearch.flint.core.metrics.HistoricGauge.DataPoint;
+
+import java.util.List;
+
+public class HistoricGaugeTest {
+
+  @Test
+  public void testGetValue_EmptyGauge_ShouldReturnNull() {
+    HistoricGauge gauge= new HistoricGauge();
+    assertNull(gauge.getValue());
+  }
+
+  @Test
+  public void testGetValue_WithSingleDataPoint_ShouldReturnFirstValue() {
+    HistoricGauge gauge= new HistoricGauge();
+    Long value = 100L;
+    gauge.addDataPoint(value);
+
+    assertEquals(value, gauge.getValue());
+  }
+
+  @Test
+  public void testGetValue_WithMultipleDataPoints_ShouldReturnFirstValue() {
+    HistoricGauge gauge= new HistoricGauge();
+    Long firstValue = 100L;
+    Long secondValue = 200L;
+    gauge.addDataPoint(firstValue);
+    gauge.addDataPoint(secondValue);
+
+    assertEquals(firstValue, gauge.getValue());
+  }
+
+  @Test
+  public void testPollDataPoints_WithMultipleDataPoints_ShouldReturnAndClearDataPoints() {
+    HistoricGauge gauge= new HistoricGauge();
+    gauge.addDataPoint(100L);
+    gauge.addDataPoint(200L);
+    gauge.addDataPoint(300L);
+
+    List<DataPoint> dataPoints = gauge.pollDataPoints();
+
+    assertEquals(3, dataPoints.size());
+    assertEquals(Long.valueOf(100L), dataPoints.get(0).getValue());
+    assertEquals(Long.valueOf(200L), dataPoints.get(1).getValue());
+    assertEquals(Long.valueOf(300L), dataPoints.get(2).getValue());
+
+    assertTrue(gauge.pollDataPoints().isEmpty());
+  }
+
+  @Test
+  public void testAddDataPoint_ShouldAddDataPointWithCorrectValueAndTimestamp() {
+    HistoricGauge gauge= new HistoricGauge();
+    Long value = 100L;
+    gauge.addDataPoint(value);
+
+    List<DataPoint> dataPoints = gauge.pollDataPoints();
+
+    assertEquals(1, dataPoints.size());
+    assertEquals(value, dataPoints.get(0).getValue());
+    assertTrue(dataPoints.get(0).getTimestamp() > 0);
+  }
+
+  @Test
+  public void testPollDataPoints_EmptyGauge_ShouldReturnEmptyList() {
+    HistoricGauge gauge= new HistoricGauge();
+    List<DataPoint> dataPoints = gauge.pollDataPoints();
+
+    assertTrue(dataPoints.isEmpty());
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/AutoIndexRefresh.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/refresh/AutoIndexRefresh.scala
@@ -7,6 +7,7 @@ package org.opensearch.flint.spark.refresh
 
 import java.util.Collections
 
+import org.opensearch.flint.core.metrics.ReadWriteBytesSparkListener
 import org.opensearch.flint.spark.{FlintSparkIndex, FlintSparkIndexOptions, FlintSparkValidationHelper}
 import org.opensearch.flint.spark.FlintSparkIndex.{quotedTableName, StreamingRefresh}
 import org.opensearch.flint.spark.refresh.FlintSparkIndexRefresh.RefreshMode.{AUTO, RefreshMode}
@@ -67,15 +68,17 @@ class AutoIndexRefresh(indexName: String, index: FlintSparkIndex)
       // Flint index has specialized logic and capability for incremental refresh
       case refresh: StreamingRefresh =>
         logInfo("Start refreshing index in streaming style")
-        val job =
-          refresh
-            .buildStream(spark)
-            .writeStream
-            .queryName(indexName)
-            .format(FLINT_DATASOURCE)
-            .options(flintSparkConf.properties)
-            .addSinkOptions(options, flintSparkConf)
-            .start(indexName)
+        val job = ReadWriteBytesSparkListener.withMetrics(
+          spark,
+          () =>
+            refresh
+              .buildStream(spark)
+              .writeStream
+              .queryName(indexName)
+              .format(FLINT_DATASOURCE)
+              .options(flintSparkConf.properties)
+              .addSinkOptions(options, flintSparkConf)
+              .start(indexName))
         Some(job.id.toString)
 
       // Otherwise, fall back to foreachBatch + batch refresh

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -17,7 +17,7 @@ import com.codahale.metrics.Timer
 import org.opensearch.flint.common.model.{FlintStatement, InteractiveSession, SessionStates}
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.logging.CustomLogging
-import org.opensearch.flint.core.metrics.MetricConstants
+import org.opensearch.flint.core.metrics.{MetricConstants, ReadWriteBytesSparkListener}
 import org.opensearch.flint.core.metrics.MetricsUtil.{getTimerContext, incrementCounter, registerGauge, stopTimer}
 
 import org.apache.spark.SparkConf
@@ -525,12 +525,16 @@ object FlintREPL extends Logging with FlintJobExecutor {
             val statementTimerContext = getTimerContext(
               MetricConstants.STATEMENT_PROCESSING_TIME_METRIC)
             val (dataToWrite, returnedVerificationResult) =
-              processStatementOnVerification(
-                statementExecutionManager,
-                queryResultWriter,
-                flintStatement,
-                state,
-                context)
+              ReadWriteBytesSparkListener.withMetrics(
+                spark,
+                () => {
+                  processStatementOnVerification(
+                    statementExecutionManager,
+                    queryResultWriter,
+                    flintStatement,
+                    state,
+                    context)
+                })
 
             verificationResult = returnedVerificationResult
             finalizeCommand(


### PR DESCRIPTION
### Description
- Add read/write bytes metrics
  - It uses SparkListener to collect read/write bytes/records for each task, and emit the sum once query completes.
- Added HistoricGauge to emit each data points separately with timestamp.
  - Codahale stores metrics and those are emitted periodically. If application emit metrics multiple times within a period, those datapoints would be summarized or simply ignored other than last value. It is not ideal when we want to track each datapoints (such as when we want to gather metrics for each API call, etc.).
  - HistoricGausge stores each data point with timestamp, and emit each data points to CW using those timestamps.
- Replaced QueryExecutionTimeMetric with HistoricGauge

Sample metrics:
![input totalBytesRead](https://github.com/user-attachments/assets/5a2389ae-84fb-48c1-9409-48c0a1644cf7)

### Related Issues
n/a

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
