### PR TITLE
`All-fields` as an argument of aggregator such as count() can be resolved after other `field`

### DIFF
--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
@@ -662,11 +662,7 @@ public class CatalystQueryPlanVisitor extends AbstractNodeVisitor<LogicalPlan, C
 
         @Override
         public Expression visitAllFields(AllFields node, CatalystPlanContext context) {
-            // Case of aggregation step - no start projection can be added
-            if (context.getNamedParseExpressions().isEmpty()) {
-                // Create an UnresolvedStar for all-fields projection
-                context.getNamedParseExpressions().push(UnresolvedStar$.MODULE$.apply(Option.<Seq<String>>empty()));
-            }
+            context.getNamedParseExpressions().push(UnresolvedStar$.MODULE$.apply(Option.<Seq<String>>empty()));
             return context.getNamedParseExpressions().peek();
         }
 

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanAggregationQueriesTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanAggregationQueriesTranslatorTestSuite.scala
@@ -959,4 +959,58 @@ class PPLLogicalPlanAggregationQueriesTranslatorTestSuite
 
     comparePlans(expectedPlan, logPlan, false)
   }
+
+  test("test count() as the last aggregator in stats clause") {
+    val context = new CatalystPlanContext
+    val logPlan = planTransformer.visit(
+      plan(
+        pplParser,
+        "source = table | eval a = 1 | stats sum(a) as sum, avg(a) as avg, count() as cnt"),
+      context)
+    val tableRelation = UnresolvedRelation(Seq("table"))
+    val eval = Project(Seq(UnresolvedStar(None), Alias(Literal(1), "a")()), tableRelation)
+    val sum =
+      Alias(
+        UnresolvedFunction(Seq("SUM"), Seq(UnresolvedAttribute("a")), isDistinct = false),
+        "sum")()
+    val avg =
+      Alias(
+        UnresolvedFunction(Seq("AVG"), Seq(UnresolvedAttribute("a")), isDistinct = false),
+        "avg")()
+    val count =
+      Alias(
+        UnresolvedFunction(Seq("COUNT"), Seq(UnresolvedStar(None)), isDistinct = false),
+        "cnt")()
+    val aggregate = Aggregate(Seq.empty, Seq(sum, avg, count), eval)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), aggregate)
+    comparePlans(expectedPlan, logPlan, checkAnalysis = false)
+  }
+
+  test("test count() as the last aggregator in stats by clause") {
+    val context = new CatalystPlanContext
+    val logPlan = planTransformer.visit(
+      plan(
+        pplParser,
+        "source = table | eval a = 1 | stats sum(a) as sum, avg(a) as avg, count() as cnt by country"),
+      context)
+    val tableRelation = UnresolvedRelation(Seq("table"))
+    val eval = Project(Seq(UnresolvedStar(None), Alias(Literal(1), "a")()), tableRelation)
+    val sum =
+      Alias(
+        UnresolvedFunction(Seq("SUM"), Seq(UnresolvedAttribute("a")), isDistinct = false),
+        "sum")()
+    val avg =
+      Alias(
+        UnresolvedFunction(Seq("AVG"), Seq(UnresolvedAttribute("a")), isDistinct = false),
+        "avg")()
+    val count =
+      Alias(
+        UnresolvedFunction(Seq("COUNT"), Seq(UnresolvedStar(None)), isDistinct = false),
+        "cnt")()
+    val grouping =
+      Alias(UnresolvedAttribute("country"), "country")()
+    val aggregate = Aggregate(Seq(grouping), Seq(sum, avg, count, grouping), eval)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), aggregate)
+    comparePlans(expectedPlan, logPlan, checkAnalysis = false)
+  }
 }


### PR DESCRIPTION
### Description
`Count()`, as is `count(*)` in SQL, cannot be resolved correctly when it located after other fields resolution.
For example:
```
source = $testTable | eval a = 1 | stats sum(a) as sum, avg(a) as avg, count() as cnt by country
```
Throws 
> [NESTED_AGGREGATE_FUNCTION] It is not allowed to use an aggregate function in the argument of another aggregate function. Please use the inner aggregate function in a sub-query.;
> Project [sum#31L, cnt#33L, country#34]
> +- Aggregate [country#38], [sum(a#30) AS sum#31L, count(avg(a#30)) AS cnt#33L, country#38 AS country#34]
>    +- Project [name#35, age#36, state#37, country#38, year#39, month#40, 1 AS a#30]
>       +- SubqueryAlias spark_catalog.default.flint_ppl_test
>          +- Relation spark_catalog.default.flint_ppl_test[name#35,age#36,state#37,country#38,year#39,month#40] csv

But 
```
source = $testTable | eval a = 1 | stats count() as cnt, sum(a) as sum, avg(a) as avg by country
```
works as expected.

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-spark/issues/811

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
