### PR TITLE
Fix the issue that missing identifiers from ANTLR keywords

### DIFF
--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
@@ -74,12 +74,8 @@ INDEX:                              'INDEX';
 D:                                  'D';
 DESC:                               'DESC';
 DATASOURCES:                        'DATASOURCES';
-VALUE:                              'VALUE';
 USING:                              'USING';
 WITH:                               'WITH';
-
-// CLAUSE KEYWORDS
-SORTBY:                             'SORTBY';
 
 // FIELD KEYWORDS
 AUTO:                               'AUTO';

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -55,6 +55,35 @@ commands
    | fieldsummaryCommand
    ;
 
+commandName
+   : SEARCH
+   | DESCRIBE
+   | SHOW
+   | AD
+   | ML
+   | KMEANS
+   | WHERE
+   | CORRELATE
+   | JOIN
+   | FIELDS
+   | STATS
+   | EVENTSTATS
+   | DEDUP
+   | EXPLAIN
+   | SORT
+   | HEAD
+   | TOP
+   | RARE
+   | EVAL
+   | GROK
+   | PARSE
+   | PATTERNS
+   | LOOKUP
+   | RENAME
+   | FILLNULL
+   | FIELDSUMMARY
+   ;
+
 searchCommand
    : (SEARCH)? fromClause                       # searchFrom
    | (SEARCH)? fromClause logicalExpression     # searchFromFilter
@@ -358,14 +387,6 @@ statsFunctionName
    | MAX
    | STDDEV_SAMP
    | STDDEV_POP
-   ;
-
-takeAggFunction
-   : TAKE LT_PRTHS fieldExpression (COMMA size = integerLiteral)? RT_PRTHS
-   ;
-
-percentileAggFunction
-   : PERCENTILE LESS value = integerLiteral GREATER LT_PRTHS aggField = fieldExpression RT_PRTHS
    ;
 
 // expressions
@@ -999,45 +1020,36 @@ keywordsCanBeId
    | mathematicalFunctionName
    | positionFunctionName
    | cryptographicFunctionName
-   // commands
-   | SEARCH
-   | DESCRIBE
-   | SHOW
-   | FROM
-   | WHERE
-   | CORRELATE
-   | FIELDS
-   | RENAME
-   | STATS
-   | DEDUP
-   | SORT
-   | EVAL
-   | HEAD
-   | TOP
-   | RARE
-   | PARSE
-   | METHOD
-   | REGEX
-   | PUNCT
-   | GROK
-   | PATTERN
-   | PATTERNS
-   | NEW_FIELD
-   | KMEANS
-   | AD
-   | ML
-   | EXPLAIN
+   | singleFieldRelevanceFunctionName
+   | multiFieldRelevanceFunctionName
+   | commandName
+   | comparisonOperator
+   | explainMode
+   | correlationType
    // commands assist keywords
    | SOURCE
    | INDEX
    | DESC
    | DATASOURCES
-   // CLAUSEKEYWORDS
-   | SORTBY
-   // FIELDKEYWORDSAUTO
+   | AUTO
    | STR
    | IP
    | NUM
+   | FROM
+   | PATTERN
+   | NEW_FIELD
+   | SCOPE
+   | MAPPING
+   | WITH
+   | USING
+   | CAST
+   | GET_FORMAT
+   | EXTRACT
+   | INTERVAL
+   | PLUS
+   | MINUS
+   | INCLUDEFIELDS
+   | NULLS
    // ARGUMENT KEYWORDS
    | KEEPEMPTY
    | CONSECUTIVE
@@ -1060,27 +1072,21 @@ keywordsCanBeId
    | TRAINING_DATA_SIZE
    | ANOMALY_SCORE_THRESHOLD
    // AGGREGATIONS
-   | AVG
-   | COUNT
+   | statsFunctionName
    | DISTINCT_COUNT
+   | PERCENTILE
+   | PERCENTILE_APPROX
    | ESTDC
    | ESTDC_ERROR
-   | MAX
    | MEAN
    | MEDIAN
-   | MIN
    | MODE
    | RANGE
    | STDEV
    | STDEVP
-   | SUM
    | SUMSQ
    | VAR_SAMP
    | VAR_POP
-   | STDDEV_SAMP
-   | STDDEV_POP
-   | PERCENTILE
-   | PERCENTILE_APPROX
    | TAKE
    | FIRST
    | LAST
@@ -1098,10 +1104,6 @@ keywordsCanBeId
    | SPARKLINE
    | C
    | DC
-   // FIELD SUMMARY
-   | FIELDSUMMARY
-   | INCLUDEFIELDS
-   | NULLS
    // JOIN TYPE
    | OUTER
    | INNER

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -22,7 +22,6 @@ import org.opensearch.sql.ast.expression.Compare;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.EqualTo;
 import org.opensearch.sql.ast.expression.Field;
-import org.opensearch.sql.ast.expression.FieldList;
 import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.subquery.ExistsSubquery;
 import org.opensearch.sql.ast.expression.subquery.InSubquery;
@@ -41,7 +40,6 @@ import org.opensearch.sql.ast.expression.UnresolvedArgument;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.expression.When;
 import org.opensearch.sql.ast.expression.Xor;
-import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.ppl.utils.ArgumentFactory;
 
@@ -53,8 +51,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.opensearch.flint.spark.ppl.OpenSearchPPLParser.INCLUDEFIELDS;
-import static org.opensearch.flint.spark.ppl.OpenSearchPPLParser.NULLS;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.EQUAL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NOT_NULL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NULL;
@@ -80,7 +76,7 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     /**
      * The function name mapping between fronted and core engine.
      */
-    private static Map<String, String> FUNCTION_NAME_MAPPING =
+    private static final Map<String, String> FUNCTION_NAME_MAPPING =
             new ImmutableMap.Builder<String, String>()
                     .put("isnull", IS_NULL.getName().getFunctionName())
                     .put("isnotnull", IS_NOT_NULL.getName().getFunctionName())
@@ -214,14 +210,6 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     @Override
     public UnresolvedExpression visitDistinctCountFunctionCall(OpenSearchPPLParser.DistinctCountFunctionCallContext ctx) {
         return new AggregateFunction("count", visit(ctx.valueExpression()), true);
-    }
-
-    @Override
-    public UnresolvedExpression visitPercentileAggFunction(OpenSearchPPLParser.PercentileAggFunctionContext ctx) {
-        return new AggregateFunction(
-                ctx.PERCENTILE().getText(),
-                visit(ctx.aggField),
-                Collections.singletonList(new Argument("rank", (Literal) visit(ctx.value))));
     }
 
     @Override


### PR DESCRIPTION
### Description
This PR is sourcing from fixing the problem introduced by https://github.com/opensearch-project/opensearch-spark/pull/723:
`| stats sum(1) as value` failed due to https://github.com/opensearch-project/opensearch-spark/pull/723 introduced a keyword `VALUE` but not marked as Id in ANTLR file.

Then I identified there are not only `VALUE`, but also more invalid keywords as identifier in g4 file.


### Related Issues
Resolves https://github.com/opensearch-project/opensearch-spark/issues/820

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
