### PR TITLE
Add index state metrics

### DIFF
--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -161,9 +161,9 @@ public final class MetricConstants {
     public static final String CHECKPOINT_DELETE_TIME_METRIC = "checkpoint.delete.processingTime";
 
     /**
-     * Metric for tracking the index state transitions
+     * Metric prefix for tracking the index state transitions
      */
-    public static final String INDEX_STATE_METRIC_PREFIX = "indexState.";
+    public static final String INDEX_STATE_UPDATED_TO_PREFIX = "indexState.updatedTo.";
 
     /**
      * Metric for tracking the index state transitions

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -160,6 +160,16 @@ public final class MetricConstants {
      */
     public static final String CHECKPOINT_DELETE_TIME_METRIC = "checkpoint.delete.processingTime";
 
+    /**
+     * Metric for tracking the index state transitions
+     */
+    public static final String INDEX_STATE_METRIC_PREFIX = "indexState.";
+
+    /**
+     * Metric for tracking the index state transitions
+     */
+    public static final String INITIAL_CONDITION_CHECK_FAILED_PREFIX = "initialConditionCheck.failed.";
+
     private MetricConstants() {
         // Private constructor to prevent instantiation
     }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransaction.java
@@ -127,6 +127,6 @@ public class DefaultOptimisticTransaction<T> implements OptimisticTransaction<T>
   }
 
   private void emitFinalLogStateMetric(FlintMetadataLogEntry finalLog) {
-    MetricsUtil.addHistoricGauge(MetricConstants.INDEX_STATE_METRIC_PREFIX + finalLog.state() + ".count", 1);
+    MetricsUtil.addHistoricGauge(MetricConstants.INDEX_STATE_UPDATED_TO_PREFIX + finalLog.state() + ".count", 1);
   }
 }

--- a/flint-core/src/test/java/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransactionMetricTest.java
+++ b/flint-core/src/test/java/org/opensearch/flint/core/metadata/log/DefaultOptimisticTransactionMetricTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core.metadata.log;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLog;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry;
+
+import java.util.Optional;
+import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState$;
+import org.opensearch.flint.core.metrics.MetricsTestUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultOptimisticTransactionMetricTest {
+
+  @Mock
+  private FlintMetadataLog<FlintMetadataLogEntry> metadataLog;
+
+  @Mock
+  private FlintMetadataLogEntry logEntry;
+
+  @InjectMocks
+  private DefaultOptimisticTransaction<String> transaction;
+
+  @Test
+  void testCommitWithValidInitialCondition() throws Exception {
+    MetricsTestUtil.withMetricEnv(verifier -> {
+      when(metadataLog.getLatest()).thenReturn(Optional.of(logEntry));
+      when(logEntry.state()).thenReturn(IndexState$.MODULE$.ACTIVE());
+
+      transaction.initialLog(entry -> true)
+          .transientLog(entry -> logEntry)
+          .finalLog(entry -> logEntry)
+          .commit(entry -> "Success");
+
+      verify(metadataLog, times(2)).add(logEntry);
+
+      verifier.assertHistoricGauge("indexState.updatedTo.active.count", 1);
+    });
+  }
+
+  @Test
+  void testConditionCheckFailed() throws Exception {
+    MetricsTestUtil.withMetricEnv(verifier -> {
+      when(metadataLog.getLatest()).thenReturn(Optional.of(logEntry));
+      when(logEntry.state()).thenReturn(IndexState$.MODULE$.DELETED());
+
+      transaction.initialLog(entry -> false)
+          .finalLog(entry -> logEntry);
+
+      assertThrows(IllegalStateException.class, () -> {
+        transaction.commit(entry -> "Should Fail");
+      });
+
+      verifier.assertHistoricGauge("initialConditionCheck.failed.deleted.count", 1);
+    });
+  }
+}


### PR DESCRIPTION
### Description
- Add index state metrics
  - `indexState. updatedTo.{state}.count`: count for the index's final log state. emitted after optimistic transaction when it is successful.
  - `initialConditionCheck.failed.{state}.count`: count for initial condition check failure per index state.

Tested with creating auto refresh MV, and trying manual refresh:
![indexState metrics](https://github.com/user-attachments/assets/55b1f03d-c973-48b4-9117-87ea443f209f)


### Related Issues
n/a

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
