### PR TITLE
Add external scheduler metrics

### DIFF
--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -160,6 +160,11 @@ public final class MetricConstants {
      */
     public static final String CHECKPOINT_DELETE_TIME_METRIC = "checkpoint.delete.processingTime";
 
+    /**
+     * Prefix for externalScheduler metrics
+     */
+    public static final String EXTERNAL_SCHEDULER_METRIC_PREFIX = "externalScheduler.";
+
     private MetricConstants() {
         // Private constructor to prevent instantiation
     }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
@@ -18,6 +18,7 @@ import org.opensearch.flint.spark.scheduler.util.RefreshQueryGenerator
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.flint.config.FlintSparkConf
+import org.opensearch.flint.core.metrics.{MetricConstants, MetricsUtil}
 
 /**
  * External scheduling service for Flint Spark jobs.
@@ -83,8 +84,14 @@ class FlintSparkJobExternalSchedulingService(
         case AsyncQuerySchedulerAction.REMOVE => flintAsyncQueryScheduler.removeJob(request)
         case _ => throw new IllegalArgumentException(s"Unsupported action: $action")
       }
+      addExternalSchedulerMetrics(action)
 
       None // Return None for all cases
     }
+  }
+
+  private def addExternalSchedulerMetrics(action: AsyncQuerySchedulerAction): Unit = {
+    val actionName = action.name().toLowerCase()
+    MetricsUtil.addHistoricGauge(MetricConstants.EXTERNAL_SCHEDULER_METRIC_PREFIX + actionName + ".count", 1)
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/FlintSparkJobExternalSchedulingService.scala
@@ -10,6 +10,7 @@ import java.time.Instant
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry.IndexState
 import org.opensearch.flint.common.scheduler.AsyncQueryScheduler
 import org.opensearch.flint.common.scheduler.model.{AsyncQuerySchedulerRequest, LangType}
+import org.opensearch.flint.core.metrics.{MetricConstants, MetricsUtil}
 import org.opensearch.flint.core.storage.OpenSearchClientUtils
 import org.opensearch.flint.spark.FlintSparkIndex
 import org.opensearch.flint.spark.refresh.util.RefreshMetricsAspect
@@ -18,7 +19,6 @@ import org.opensearch.flint.spark.scheduler.util.RefreshQueryGenerator
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.flint.config.FlintSparkConf
-import org.opensearch.flint.core.metrics.{MetricConstants, MetricsUtil}
 
 /**
  * External scheduling service for Flint Spark jobs.
@@ -92,6 +92,8 @@ class FlintSparkJobExternalSchedulingService(
 
   private def addExternalSchedulerMetrics(action: AsyncQuerySchedulerAction): Unit = {
     val actionName = action.name().toLowerCase()
-    MetricsUtil.addHistoricGauge(MetricConstants.EXTERNAL_SCHEDULER_METRIC_PREFIX + actionName + ".count", 1)
+    MetricsUtil.addHistoricGauge(
+      MetricConstants.EXTERNAL_SCHEDULER_METRIC_PREFIX + actionName + ".count",
+      1)
   }
 }


### PR DESCRIPTION
### Description
- Add external scheduler metrics
  - externalScheduler.{action}.count

Tested in my dev environment:
![externalScheduler metrics](https://github.com/user-attachments/assets/aff43a14-94f5-49d9-bc47-bdfcb16b410f)

### Related Issues
n/a

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
