### PR TITLE
Optimize prepareStatementExecution request freq

### DIFF
--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -1387,7 +1387,8 @@ class FlintREPLTest
 
     val expectedCalls =
       Math.ceil(inactivityLimit.toDouble / DEFAULT_QUERY_LOOP_EXECUTION_FREQUENCY).toInt
-    verify(mockOSClient, Mockito.atMost(expectedCalls)).getIndexMetadata(*)
+    verify(mockOSClient, times(1)).getIndexMetadata(*)
+    verify(mockOSClient, Mockito.atMost(expectedCalls)).createQueryReader(*, *, *, *)
   }
 
   val testCases = Table(


### PR DESCRIPTION
### Description
Optimize prepareStatementExecution request freq. 

Before the change:

- prepareStatementExecution will run k times, depends dynamically on session duration and query execution time.
- getNext will run k times to create new reader clients

After the change:

- prepareStatementExecution will run 1 time before the query loop
- getNext will behave the same, to avoid concurrent issue of using one reader client within same session 

Also tested on EMR to verify number of times.

### Related Issues
https://github.com/opensearch-project/opensearch-spark/issues/804

### Check List
- [X] Implemented unit tests
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
