### PR TITLE
Extract source table names from mv query

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -183,7 +183,7 @@ class FlintSpark(val spark: SparkSession) extends FlintSparkTransactionSupport w
           attachLatestLogEntry(indexName, metadata)
         }
         .toList
-        .flatMap(FlintSparkIndexFactory.create)
+        .flatMap(metadata => FlintSparkIndexFactory.create(spark, metadata))
     } else {
       Seq.empty
     }
@@ -202,7 +202,7 @@ class FlintSpark(val spark: SparkSession) extends FlintSparkTransactionSupport w
     if (flintClient.exists(indexName)) {
       val metadata = flintIndexMetadataService.getIndexMetadata(indexName)
       val metadataWithEntry = attachLatestLogEntry(indexName, metadata)
-      FlintSparkIndexFactory.create(metadataWithEntry)
+      FlintSparkIndexFactory.create(spark, metadataWithEntry)
     } else {
       Option.empty
     }
@@ -327,7 +327,7 @@ class FlintSpark(val spark: SparkSession) extends FlintSparkTransactionSupport w
       val index = describeIndex(indexName)
 
       if (index.exists(_.options.autoRefresh())) {
-        val updatedIndex = FlintSparkIndexFactory.createWithDefaultOptions(index.get).get
+        val updatedIndex = FlintSparkIndexFactory.createWithDefaultOptions(spark, index.get).get
         FlintSparkIndexRefresh
           .create(updatedIndex.name(), updatedIndex)
           .validate(spark)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexBuilder.scala
@@ -92,7 +92,7 @@ abstract class FlintSparkIndexBuilder(flint: FlintSpark) {
     val updatedMetadata = index
       .metadata()
       .copy(options = updatedOptions.options.mapValues(_.asInstanceOf[AnyRef]).asJava)
-    validateIndex(FlintSparkIndexFactory.create(updatedMetadata).get)
+    validateIndex(FlintSparkIndexFactory.create(flint.spark, updatedMetadata).get)
   }
 
   /**

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexFactory.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexFactory.scala
@@ -118,6 +118,7 @@ object FlintSparkIndexFactory extends Logging {
         FlintSparkMaterializedView(
           metadata.name,
           metadata.source,
+          getArrayString(metadata.properties, "sourceTables"),
           metadata.indexedColumns.map { colInfo =>
             getString(colInfo, "columnName") -> getString(colInfo, "columnType")
           }.toMap,
@@ -144,6 +145,14 @@ object FlintSparkIndexFactory extends Logging {
       None
     } else {
       Some(value.asInstanceOf[String])
+    }
+  }
+
+  private def getArrayString(map: java.util.Map[String, AnyRef], key: String): Array[String] = {
+    map.get(key) match {
+      case list: java.util.ArrayList[_] =>
+        list.toArray.map(_.asInstanceOf[String])
+      case _ => Array.empty[String]
     }
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexFactory.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexFactory.scala
@@ -151,7 +151,7 @@ object FlintSparkIndexFactory extends Logging {
   private def getArrayString(map: java.util.Map[String, AnyRef], key: String): Array[String] = {
     map.get(key) match {
       case list: java.util.ArrayList[_] =>
-        list.toArray.map(_.asInstanceOf[String])
+        list.toArray.map(_.toString)
       case _ => Array.empty[String]
     }
   }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkValidationHelper.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkValidationHelper.scala
@@ -31,16 +31,10 @@ trait FlintSparkValidationHelper extends Logging {
    *   true if all non Hive, otherwise false
    */
   def isTableProviderSupported(spark: SparkSession, index: FlintSparkIndex): Boolean = {
-    // Extract source table name (possibly more than one for MV query)
     val tableNames = index match {
       case skipping: FlintSparkSkippingIndex => Seq(skipping.tableName)
       case covering: FlintSparkCoveringIndex => Seq(covering.tableName)
-      case mv: FlintSparkMaterializedView =>
-        spark.sessionState.sqlParser
-          .parsePlan(mv.query)
-          .collect { case relation: UnresolvedRelation =>
-            qualifyTableName(spark, relation.tableName)
-          }
+      case mv: FlintSparkMaterializedView => mv.sourceTables.toSeq
     }
 
     // Validate if any source table is not supported (currently Hive only)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkValidationHelper.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkValidationHelper.scala
@@ -11,9 +11,8 @@ import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.execution.command.DDLUtils
-import org.apache.spark.sql.flint.{loadTable, parseTableName, qualifyTableName}
+import org.apache.spark.sql.flint.{loadTable, parseTableName}
 
 /**
  * Flint Spark validation helper.

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCache.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCache.scala
@@ -10,6 +10,7 @@ import scala.collection.JavaConverters.mapAsScalaMapConverter
 import org.opensearch.flint.common.metadata.FlintMetadata
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.spark.FlintSparkIndexOptions
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.MV_INDEX_TYPE
 import org.opensearch.flint.spark.scheduler.util.IntervalSchedulerParser
 
 /**
@@ -47,8 +48,6 @@ case class FlintMetadataCache(
 object FlintMetadataCache {
 
   val metadataCacheVersion = "1.0"
-  val mockTableName =
-    "dataSourceName.default.logGroups(logGroupIdentifier:['arn:aws:logs:us-east-1:123456:test-llt-xa', 'arn:aws:logs:us-east-1:123456:sample-lg-1'])"
 
   def apply(metadata: FlintMetadata): FlintMetadataCache = {
     val indexOptions = FlintSparkIndexOptions(
@@ -61,6 +60,15 @@ object FlintMetadataCache {
     } else {
       None
     }
+    val sourceTables = metadata.kind match {
+      case MV_INDEX_TYPE =>
+        metadata.properties.get("sourceTables") match {
+          case list: java.util.ArrayList[_] =>
+            list.toArray.map(_.toString)
+          case _ => Array.empty[String]
+        }
+      case _ => Array(metadata.source)
+    }
     val lastRefreshTime: Option[Long] = metadata.latestLogEntry.flatMap { entry =>
       entry.lastRefreshCompleteTime match {
         case FlintMetadataLogEntry.EMPTY_TIMESTAMP => None
@@ -68,11 +76,6 @@ object FlintMetadataCache {
       }
     }
 
-    // TODO: get source tables from metadata
-    FlintMetadataCache(
-      metadataCacheVersion,
-      refreshInterval,
-      Array(mockTableName),
-      lastRefreshTime)
+    FlintMetadataCache(metadataCacheVersion, refreshInterval, sourceTables, lastRefreshTime)
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCache.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCache.scala
@@ -46,7 +46,7 @@ case class FlintMetadataCache(
 
 object FlintMetadataCache {
 
-  // TODO: constant for version
+  val metadataCacheVersion = "1.0"
   val mockTableName =
     "dataSourceName.default.logGroups(logGroupIdentifier:['arn:aws:logs:us-east-1:123456:test-llt-xa', 'arn:aws:logs:us-east-1:123456:sample-lg-1'])"
 
@@ -69,6 +69,10 @@ object FlintMetadataCache {
     }
 
     // TODO: get source tables from metadata
-    FlintMetadataCache("1.0", refreshInterval, Array(mockTableName), lastRefreshTime)
+    FlintMetadataCache(
+      metadataCacheVersion,
+      refreshInterval,
+      Array(mockTableName),
+      lastRefreshTime)
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -197,12 +197,7 @@ object FlintSparkMaterializedView {
     def query(query: String): Builder = {
       this.query = query
       // Extract source table names (possibly more than one)
-      this.sourceTables = flint.spark.sessionState.sqlParser
-        .parsePlan(query)
-        .collect { case relation: UnresolvedRelation =>
-          qualifyTableName(flint.spark, relation.tableName)
-        }
-        .toArray
+      this.sourceTables = extractSourceTableNames(query)
       this
     }
 
@@ -232,6 +227,15 @@ object FlintSparkMaterializedView {
         }
         .toMap
       FlintSparkMaterializedView(mvName, query, sourceTables, outputSchema, indexOptions)
+    }
+
+    private def extractSourceTableNames(query: String): Array[String] = {
+      flint.spark.sessionState.sqlParser
+        .parsePlan(query)
+        .collect { case relation: UnresolvedRelation =>
+          qualifyTableName(flint.spark, relation.tableName)
+        }
+        .toArray
     }
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -16,7 +16,7 @@ import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex, FlintSparkIndexB
 import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, generateSchema, metadataBuilder, StreamingRefresh}
 import org.opensearch.flint.spark.FlintSparkIndexOptions.empty
 import org.opensearch.flint.spark.function.TumbleFunction
-import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.{getFlintIndexName, MV_INDEX_TYPE}
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.{extractSourceTables, getFlintIndexName, MV_INDEX_TYPE}
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
@@ -60,10 +60,12 @@ case class FlintSparkMaterializedView(
         Map[String, AnyRef]("columnName" -> colName, "columnType" -> colType).asJava
       }.toArray
     val schema = generateSchema(outputSchema).asJava
+    val sourceTables = extractSourceTables(query)
 
     metadataBuilder(this)
       .name(mvName)
       .source(query)
+      .addProperty("sourceTables", sourceTables)
       .indexedColumns(indexColumnMaps)
       .schema(schema)
       .build()
@@ -163,6 +165,10 @@ object FlintSparkMaterializedView {
       "Qualified materialized view name catalog.database.mv is required")
 
     flintIndexNamePrefix(mvName)
+  }
+
+  def extractSourceTables(query: String): Array[String] = {
+    Array("mock1.mock2.mock3")
   }
 
   /** Builder class for MV build */

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexFactorySuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexFactorySuite.scala
@@ -14,12 +14,11 @@ import org.apache.spark.FlintSuite
 
 class FlintSparkIndexFactorySuite extends FlintSuite {
 
-  /** Test table, MV name and query */
-  val testTable = "spark_catalog.default.mv_build_test"
-  val testMvName = "spark_catalog.default.mv"
-  val testQuery = s"SELECT * FROM $testTable"
-
   test("create mv should generate source tables if missing in metadata") {
+    val testTable = "spark_catalog.default.mv_build_test"
+    val testMvName = "spark_catalog.default.mv"
+    val testQuery = s"SELECT * FROM $testTable"
+
     val content =
       s""" {
         |    "_meta": {
@@ -31,7 +30,7 @@ class FlintSparkIndexFactorySuite extends FlintSuite {
         |        }
         |      ],
         |      "name": "$testMvName",
-        |      "source": "SELECT age FROM $testTable"
+        |      "source": "$testQuery"
         |    },
         |    "properties": {
         |      "age": {

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexFactorySuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexFactorySuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.opensearch.flint.core.storage.FlintOpenSearchIndexMetadataService
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.MV_INDEX_TYPE
+import org.scalatest.matchers.should.Matchers._
+
+import org.apache.spark.FlintSuite
+
+class FlintSparkIndexFactorySuite extends FlintSuite {
+
+  /** Test table, MV name and query */
+  val testTable = "spark_catalog.default.mv_build_test"
+  val testMvName = "spark_catalog.default.mv"
+  val testQuery = s"SELECT * FROM $testTable"
+
+  test("create mv should generate source tables if missing in metadata") {
+    val content =
+      s""" {
+        |    "_meta": {
+        |      "kind": "$MV_INDEX_TYPE",
+        |      "indexedColumns": [
+        |        {
+        |          "columnType": "int",
+        |          "columnName": "age"
+        |        }
+        |      ],
+        |      "name": "$testMvName",
+        |      "source": "SELECT age FROM $testTable"
+        |    },
+        |    "properties": {
+        |      "age": {
+        |        "type": "integer"
+        |      }
+        |    }
+        | }
+        |""".stripMargin
+
+    val metadata = FlintOpenSearchIndexMetadataService.deserialize(content)
+    val index = FlintSparkIndexFactory.create(spark, metadata)
+    index shouldBe defined
+    index.get
+      .asInstanceOf[FlintSparkMaterializedView]
+      .sourceTables should contain theSameElementsAs Array(testTable)
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCacheSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCacheSuite.scala
@@ -7,6 +7,9 @@ package org.opensearch.flint.spark.metadatacache
 
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.core.storage.FlintOpenSearchIndexMetadataService
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.COVERING_INDEX_TYPE
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.MV_INDEX_TYPE
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.SKIPPING_INDEX_TYPE
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -21,11 +24,12 @@ class FlintMetadataCacheSuite extends AnyFlatSpec with Matchers {
     "",
     Map.empty[String, Any])
 
-  it should "construct from FlintMetadata" in {
+  it should "construct from skipping index FlintMetadata" in {
     val content =
-      """ {
+      s""" {
         |   "_meta": {
-        |     "kind": "test_kind",
+        |     "kind": "$SKIPPING_INDEX_TYPE",
+        |     "source": "spark_catalog.default.test_table",
         |     "options": {
         |       "auto_refresh": "true",
         |       "refresh_interval": "10 Minutes"
@@ -45,16 +49,83 @@ class FlintMetadataCacheSuite extends AnyFlatSpec with Matchers {
     val metadataCache = FlintMetadataCache(metadata)
     metadataCache.metadataCacheVersion shouldBe FlintMetadataCache.metadataCacheVersion
     metadataCache.refreshInterval.get shouldBe 600
-    metadataCache.sourceTables shouldBe Array(FlintMetadataCache.mockTableName)
+    metadataCache.sourceTables shouldBe Array("spark_catalog.default.test_table")
+    metadataCache.lastRefreshTime.get shouldBe 1234567890123L
+  }
+
+  it should "construct from covering index FlintMetadata" in {
+    val content =
+      s""" {
+        |   "_meta": {
+        |     "kind": "$COVERING_INDEX_TYPE",
+        |     "source": "spark_catalog.default.test_table",
+        |     "options": {
+        |       "auto_refresh": "true",
+        |       "refresh_interval": "10 Minutes"
+        |     }
+        |   },
+        |   "properties": {
+        |     "age": {
+        |       "type": "integer"
+        |     }
+        |   }
+        | }
+        |""".stripMargin
+    val metadata = FlintOpenSearchIndexMetadataService
+      .deserialize(content)
+      .copy(latestLogEntry = Some(flintMetadataLogEntry))
+
+    val metadataCache = FlintMetadataCache(metadata)
+    metadataCache.metadataCacheVersion shouldBe FlintMetadataCache.metadataCacheVersion
+    metadataCache.refreshInterval.get shouldBe 600
+    metadataCache.sourceTables shouldBe Array("spark_catalog.default.test_table")
+    metadataCache.lastRefreshTime.get shouldBe 1234567890123L
+  }
+
+  it should "construct from materialized view FlintMetadata" in {
+    val content =
+      s""" {
+        |   "_meta": {
+        |     "kind": "$MV_INDEX_TYPE",
+        |     "source": "spark_catalog.default.wrong_table",
+        |     "options": {
+        |       "auto_refresh": "true",
+        |       "refresh_interval": "10 Minutes"
+        |     },
+        |     "properties": {
+        |       "sourceTables": [
+        |         "spark_catalog.default.test_table",
+        |         "spark_catalog.default.another_table"
+        |       ]
+        |     }
+        |   },
+        |   "properties": {
+        |     "age": {
+        |       "type": "integer"
+        |     }
+        |   }
+        | }
+        |""".stripMargin
+    val metadata = FlintOpenSearchIndexMetadataService
+      .deserialize(content)
+      .copy(latestLogEntry = Some(flintMetadataLogEntry))
+
+    val metadataCache = FlintMetadataCache(metadata)
+    metadataCache.metadataCacheVersion shouldBe FlintMetadataCache.metadataCacheVersion
+    metadataCache.refreshInterval.get shouldBe 600
+    metadataCache.sourceTables shouldBe Array(
+      "spark_catalog.default.test_table",
+      "spark_catalog.default.another_table")
     metadataCache.lastRefreshTime.get shouldBe 1234567890123L
   }
 
   it should "construct from FlintMetadata excluding invalid fields" in {
     // Set auto_refresh = false and lastRefreshCompleteTime = 0
     val content =
-      """ {
+      s""" {
         |   "_meta": {
-        |     "kind": "test_kind",
+        |     "kind": "$SKIPPING_INDEX_TYPE",
+        |     "source": "spark_catalog.default.test_table",
         |     "options": {
         |       "refresh_interval": "10 Minutes"
         |     }
@@ -73,7 +144,7 @@ class FlintMetadataCacheSuite extends AnyFlatSpec with Matchers {
     val metadataCache = FlintMetadataCache(metadata)
     metadataCache.metadataCacheVersion shouldBe FlintMetadataCache.metadataCacheVersion
     metadataCache.refreshInterval shouldBe empty
-    metadataCache.sourceTables shouldBe Array(FlintMetadataCache.mockTableName)
+    metadataCache.sourceTables shouldBe Array("spark_catalog.default.test_table")
     metadataCache.lastRefreshTime shouldBe empty
   }
 }

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCacheSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCacheSuite.scala
@@ -43,7 +43,7 @@ class FlintMetadataCacheSuite extends AnyFlatSpec with Matchers {
       .copy(latestLogEntry = Some(flintMetadataLogEntry))
 
     val metadataCache = FlintMetadataCache(metadata)
-    metadataCache.metadataCacheVersion shouldBe "1.0"
+    metadataCache.metadataCacheVersion shouldBe FlintMetadataCache.metadataCacheVersion
     metadataCache.refreshInterval.get shouldBe 600
     metadataCache.sourceTables shouldBe Array(FlintMetadataCache.mockTableName)
     metadataCache.lastRefreshTime.get shouldBe 1234567890123L
@@ -71,7 +71,7 @@ class FlintMetadataCacheSuite extends AnyFlatSpec with Matchers {
       .copy(latestLogEntry = Some(flintMetadataLogEntry.copy(lastRefreshCompleteTime = 0L)))
 
     val metadataCache = FlintMetadataCache(metadata)
-    metadataCache.metadataCacheVersion shouldBe "1.0"
+    metadataCache.metadataCacheVersion shouldBe FlintMetadataCache.metadataCacheVersion
     metadataCache.refreshInterval shouldBe empty
     metadataCache.sourceTables shouldBe Array(FlintMetadataCache.mockTableName)
     metadataCache.lastRefreshTime shouldBe empty

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters.{mapAsJavaMapConverter, mapAsScalaMapConv
 import org.opensearch.flint.spark.FlintSparkIndexOptions
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.MV_INDEX_TYPE
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedViewSuite.{streamingRelation, StreamingDslLogicalPlan}
-import org.scalatest.matchers.should.Matchers.{contain, convertToAnyShouldWrapper, the}
+import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.spark.FlintSuite
@@ -63,7 +63,8 @@ class FlintSparkMaterializedViewSuite extends FlintSuite {
     metadata.name shouldBe mv.mvName
     metadata.kind shouldBe MV_INDEX_TYPE
     metadata.source shouldBe "SELECT 1"
-    metadata.properties should contain("sourceTables" -> Array.empty)
+    metadata.properties should contain key "sourceTables"
+    metadata.properties.get("sourceTables").asInstanceOf[Array[String]] should have size 0
     metadata.indexedColumns shouldBe Array(
       Map("columnName" -> "test_col", "columnType" -> "integer").asJava)
     metadata.schema shouldBe Map("test_col" -> Map("type" -> "integer").asJava).asJava

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
@@ -63,6 +63,7 @@ class FlintSparkMaterializedViewSuite extends FlintSuite {
     metadata.name shouldBe mv.mvName
     metadata.kind shouldBe MV_INDEX_TYPE
     metadata.source shouldBe "SELECT 1"
+    metadata.properties should contain("sourceTables" -> Array.empty)
     metadata.indexedColumns shouldBe Array(
       Map("columnName" -> "test_col", "columnType" -> "integer").asJava)
     metadata.schema shouldBe Map("test_col" -> Map("type" -> "integer").asJava).asJava

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -91,7 +91,9 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
            |      "scheduler_mode":"internal"
            |    },
            |    "latestId": "$testLatestId",
-           |    "properties": {}
+           |    "properties": {
+           |      "sourceTables": ["$testTable"]
+           |    }
            |  },
            |  "properties": {
            |    "startTime": {

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewITSuite.scala
@@ -17,6 +17,7 @@ import org.opensearch.flint.common.FlintVersion.current
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.storage.{FlintOpenSearchIndexMetadataService, OpenSearchClientUtils}
 import org.opensearch.flint.spark.FlintSparkIndex.quotedTableName
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.getFlintIndexName
 import org.opensearch.flint.spark.scheduler.OpenSearchAsyncQueryScheduler
 import org.scalatest.matchers.must.Matchers.{contain, defined}
@@ -140,12 +141,14 @@ class FlintSparkMaterializedViewITSuite extends FlintSparkSuite {
 
     val index = flint.describeIndex(testFlintIndex)
     index shouldBe defined
-    index.get.metadata.properties should contain
-    "sourceTables" -> Array(
-      "spark_catalog.default.table1",
-      "spark_catalog.default.table2",
-      "spark_catalog.default.table3",
-      "spark_catalog.default.table4")
+    index.get
+      .asInstanceOf[FlintSparkMaterializedView]
+      .sourceTables should contain theSameElementsAs
+      Array(
+        "spark_catalog.default.table1",
+        "spark_catalog.default.table2",
+        "spark_catalog.default.table3",
+        "spark_catalog.default.table4")
   }
 
   test("create materialized view with default checkpoint location successfully") {

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/metadatacache/FlintOpenSearchMetadataCacheWriterITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/metadatacache/FlintOpenSearchMetadataCacheWriterITSuite.scala
@@ -90,7 +90,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       |       "refresh_interval": "10 Minutes"
       |     },
       |     "properties": {
-      |       "metadataCacheVersion": "1.0",
+      |       "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
       |       "refreshInterval": 600,
       |       "sourceTables": ["${FlintMetadataCache.mockTableName}"],
       |       "lastRefreshTime": ${testLastRefreshCompleteTime}
@@ -129,7 +129,9 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
 
     val properties = flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
     properties should have size 3
-    properties should contain allOf (Entry("metadataCacheVersion", "1.0"),
+    properties should contain allOf (Entry(
+      "metadataCacheVersion",
+      FlintMetadataCache.metadataCacheVersion),
     Entry("lastRefreshTime", testLastRefreshCompleteTime))
     properties
       .get("sourceTables")
@@ -162,7 +164,9 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
 
     val properties = flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
     properties should have size 4
-    properties should contain allOf (Entry("metadataCacheVersion", "1.0"),
+    properties should contain allOf (Entry(
+      "metadataCacheVersion",
+      FlintMetadataCache.metadataCacheVersion),
     Entry("refreshInterval", 600),
     Entry("lastRefreshTime", testLastRefreshCompleteTime))
     properties
@@ -195,7 +199,9 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
 
     val properties = flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
     properties should have size 3
-    properties should contain allOf (Entry("metadataCacheVersion", "1.0"),
+    properties should contain allOf (Entry(
+      "metadataCacheVersion",
+      FlintMetadataCache.metadataCacheVersion),
     Entry("lastRefreshTime", testLastRefreshCompleteTime))
     properties
       .get("sourceTables")
@@ -212,7 +218,8 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
 
     val properties = flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
     properties should have size 2
-    properties should contain(Entry("metadataCacheVersion", "1.0"))
+    properties should contain(
+      Entry("metadataCacheVersion", FlintMetadataCache.metadataCacheVersion))
     properties
       .get("sourceTables")
       .asInstanceOf[List[String]]
@@ -246,7 +253,9 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
     flintIndexMetadataService.getIndexMetadata(testFlintIndex).schema should have size 1
     var properties = flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
     properties should have size 3
-    properties should contain allOf (Entry("metadataCacheVersion", "1.0"),
+    properties should contain allOf (Entry(
+      "metadataCacheVersion",
+      FlintMetadataCache.metadataCacheVersion),
     Entry("lastRefreshTime", testLastRefreshCompleteTime))
     properties
       .get("sourceTables")
@@ -278,7 +287,9 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
     flintIndexMetadataService.getIndexMetadata(testFlintIndex).schema should have size 1
     properties = flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
     properties should have size 3
-    properties should contain allOf (Entry("metadataCacheVersion", "1.0"),
+    properties should contain allOf (Entry(
+      "metadataCacheVersion",
+      FlintMetadataCache.metadataCacheVersion),
     Entry("lastRefreshTime", testLastRefreshCompleteTime))
     properties
       .get("sourceTables")
@@ -296,7 +307,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
         "checkpoint_location" -> "s3a://test/"),
       s"""
          | {
-         |   "metadataCacheVersion": "1.0",
+         |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
          |   "refreshInterval": 600,
          |   "sourceTables": ["${FlintMetadataCache.mockTableName}"]
          | }
@@ -306,7 +317,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       Map.empty[String, String],
       s"""
          | {
-         |   "metadataCacheVersion": "1.0",
+         |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
          |   "sourceTables": ["${FlintMetadataCache.mockTableName}"]
          | }
          |""".stripMargin),
@@ -315,7 +326,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       Map("incremental_refresh" -> "true", "checkpoint_location" -> "s3a://test/"),
       s"""
          | {
-         |   "metadataCacheVersion": "1.0",
+         |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
          |   "sourceTables": ["${FlintMetadataCache.mockTableName}"]
          | }
          |""".stripMargin)).foreach { case (refreshMode, optionsMap, expectedJson) =>
@@ -389,7 +400,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
               flintMetadataCacheWriter.serialize(index.get.metadata())) \ "_meta" \ "properties"))
         propertiesJson should matchJson(s"""
             | {
-            |   "metadataCacheVersion": "1.0",
+            |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
             |   "refreshInterval": 600,
             |   "sourceTables": ["${FlintMetadataCache.mockTableName}"]
             | }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/metadatacache/FlintOpenSearchMetadataCacheWriterITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/metadatacache/FlintOpenSearchMetadataCacheWriterITSuite.scala
@@ -17,7 +17,9 @@ import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.storage.{FlintOpenSearchClient, FlintOpenSearchIndexMetadataService}
 import org.opensearch.flint.spark.{FlintSparkIndexOptions, FlintSparkSuite}
-import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
+import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.COVERING_INDEX_TYPE
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.MV_INDEX_TYPE
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.{getSkippingIndexName, SKIPPING_INDEX_TYPE}
 import org.scalatest.Entry
 import org.scalatest.matchers.should.Matchers
 
@@ -78,9 +80,9 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       | {
       |   "_meta": {
       |     "version": "${current()}",
-      |     "name": "${testFlintIndex}",
+      |     "name": "$testFlintIndex",
       |     "kind": "test_kind",
-      |     "source": "test_source_table",
+      |     "source": "$testTable",
       |     "indexedColumns": [
       |     {
       |       "test_field": "spark_type"
@@ -92,10 +94,10 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       |     "properties": {
       |       "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
       |       "refreshInterval": 600,
-      |       "sourceTables": ["${FlintMetadataCache.mockTableName}"],
-      |       "lastRefreshTime": ${testLastRefreshCompleteTime}
+      |       "sourceTables": ["$testTable"],
+      |       "lastRefreshTime": $testLastRefreshCompleteTime
       |     },
-      |     "latestId": "${testLatestId}"
+      |     "latestId": "$testLatestId"
       |   },
       |   "properties": {
       |     "test_field": {
@@ -107,7 +109,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
     val builder = new FlintMetadata.Builder
     builder.name(testFlintIndex)
     builder.kind("test_kind")
-    builder.source("test_source_table")
+    builder.source(testTable)
     builder.addIndexedColumn(Map[String, AnyRef]("test_field" -> "spark_type").asJava)
     builder.options(
       Map("auto_refresh" -> "true", "refresh_interval" -> "10 Minutes")
@@ -133,10 +135,67 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       "metadataCacheVersion",
       FlintMetadataCache.metadataCacheVersion),
     Entry("lastRefreshTime", testLastRefreshCompleteTime))
+  }
+
+  Seq(SKIPPING_INDEX_TYPE, COVERING_INDEX_TYPE).foreach { case kind =>
+    test(s"write metadata cache to $kind index mappings with source tables") {
+      val content =
+        s""" {
+           |   "_meta": {
+           |     "kind": "$kind",
+           |     "source": "$testTable"
+           |   },
+           |   "properties": {
+           |     "age": {
+           |       "type": "integer"
+           |     }
+           |   }
+           | }
+           |""".stripMargin
+      val metadata = FlintOpenSearchIndexMetadataService
+        .deserialize(content)
+        .copy(latestLogEntry = Some(flintMetadataLogEntry))
+      flintClient.createIndex(testFlintIndex, metadata)
+      flintMetadataCacheWriter.updateMetadataCache(testFlintIndex, metadata)
+
+      val properties = flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
+      properties
+        .get("sourceTables")
+        .asInstanceOf[List[String]]
+        .toArray should contain theSameElementsAs Array(testTable)
+    }
+  }
+
+  test(s"write metadata cache to materialized view index mappings with source tables") {
+    val testTable2 = "spark_catalog.default.metadatacache_test2"
+    val content =
+      s""" {
+         |   "_meta": {
+         |     "kind": "$MV_INDEX_TYPE",
+         |     "properties": {
+         |       "sourceTables": [
+         |         "$testTable", "$testTable2"
+         |       ]
+         |     }
+         |   },
+         |   "properties": {
+         |     "age": {
+         |       "type": "integer"
+         |     }
+         |   }
+         | }
+         |""".stripMargin
+    val metadata = FlintOpenSearchIndexMetadataService
+      .deserialize(content)
+      .copy(latestLogEntry = Some(flintMetadataLogEntry))
+    flintClient.createIndex(testFlintIndex, metadata)
+    flintMetadataCacheWriter.updateMetadataCache(testFlintIndex, metadata)
+
+    val properties = flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
     properties
       .get("sourceTables")
       .asInstanceOf[List[String]]
-      .toArray should contain theSameElementsAs Array(FlintMetadataCache.mockTableName)
+      .toArray should contain theSameElementsAs Array(testTable, testTable2)
   }
 
   test("write metadata cache to index mappings with refresh interval") {
@@ -169,10 +228,6 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       FlintMetadataCache.metadataCacheVersion),
     Entry("refreshInterval", 600),
     Entry("lastRefreshTime", testLastRefreshCompleteTime))
-    properties
-      .get("sourceTables")
-      .asInstanceOf[List[String]]
-      .toArray should contain theSameElementsAs Array(FlintMetadataCache.mockTableName)
   }
 
   test("exclude refresh interval in metadata cache when auto refresh is false") {
@@ -203,10 +258,6 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       "metadataCacheVersion",
       FlintMetadataCache.metadataCacheVersion),
     Entry("lastRefreshTime", testLastRefreshCompleteTime))
-    properties
-      .get("sourceTables")
-      .asInstanceOf[List[String]]
-      .toArray should contain theSameElementsAs Array(FlintMetadataCache.mockTableName)
   }
 
   test("exclude last refresh time in metadata cache when index has not been refreshed") {
@@ -220,10 +271,6 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
     properties should have size 2
     properties should contain(
       Entry("metadataCacheVersion", FlintMetadataCache.metadataCacheVersion))
-    properties
-      .get("sourceTables")
-      .asInstanceOf[List[String]]
-      .toArray should contain theSameElementsAs Array(FlintMetadataCache.mockTableName)
   }
 
   test("write metadata cache to index mappings and preserve other index metadata") {
@@ -257,10 +304,6 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       "metadataCacheVersion",
       FlintMetadataCache.metadataCacheVersion),
     Entry("lastRefreshTime", testLastRefreshCompleteTime))
-    properties
-      .get("sourceTables")
-      .asInstanceOf[List[String]]
-      .toArray should contain theSameElementsAs Array(FlintMetadataCache.mockTableName)
 
     val newContent =
       """ {
@@ -291,10 +334,6 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       "metadataCacheVersion",
       FlintMetadataCache.metadataCacheVersion),
     Entry("lastRefreshTime", testLastRefreshCompleteTime))
-    properties
-      .get("sourceTables")
-      .asInstanceOf[List[String]]
-      .toArray should contain theSameElementsAs Array(FlintMetadataCache.mockTableName)
   }
 
   Seq(
@@ -309,7 +348,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
          | {
          |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
          |   "refreshInterval": 600,
-         |   "sourceTables": ["${FlintMetadataCache.mockTableName}"]
+         |   "sourceTables": ["$testTable"]
          | }
          |""".stripMargin),
     (
@@ -318,7 +357,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       s"""
          | {
          |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
-         |   "sourceTables": ["${FlintMetadataCache.mockTableName}"]
+         |   "sourceTables": ["$testTable"]
          | }
          |""".stripMargin),
     (
@@ -327,7 +366,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
       s"""
          | {
          |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
-         |   "sourceTables": ["${FlintMetadataCache.mockTableName}"]
+         |   "sourceTables": ["$testTable"]
          | }
          |""".stripMargin)).foreach { case (refreshMode, optionsMap, expectedJson) =>
     test(s"write metadata cache for $refreshMode") {
@@ -402,7 +441,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
             | {
             |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
             |   "refreshInterval": 600,
-            |   "sourceTables": ["${FlintMetadataCache.mockTableName}"]
+            |   "sourceTables": ["$testTable"]
             | }
             |""".stripMargin)
 


### PR DESCRIPTION
### Description
Extract source table names from mv query and add to `_meta.properties.sourceTables`

This is actually already introduced in #297, but we used it only for validation and didn't store the table names

#### Example

```
CREATE MATERIALIZED VIEW myglue_test.default.mv_test_source_tables
AS SELECT status FROM myglue_test.default.http_logs
WITH (
  auto_refresh = true,
  checkpoint_location = 's3://test/'
)

GET flint_myglue_test_default_mv_test_source_tables/_mappings
{
  "flint_myglue_test_default_mv_test_source_tables": {
    "mappings": {
      "_meta": {
        "latestId": "ZmxpbnRfbXlnbHVlX3Rlc3RfZGVmYXVsdF9tdl90ZXN0X3NvdXJjZV90YWJsZXM=",
        "kind": "mv",
        "indexedColumns": [
          {
            "columnType": "int",
            "columnName": "status"
          }
        ],
        "name": "myglue_test.default.mv_test_source_tables",
        "options": {
          "auto_refresh": "true",
          "refresh_interval": "5 minutes",
          "scheduler_mode": "external",
          "incremental_refresh": "false",
          "checkpoint_location": "s3://test/"
        },
        "source": "SELECT status FROM myglue_test.default.http_logs",
        "version": "0.6.0",
        "properties": {
          "sourceTables": [
            "myglue_test.default.http_logs"
          ],
          "env": {
            "SERVERLESS_EMR_VIRTUAL_CLUSTER_ID": "****",
            "SERVERLESS_EMR_JOB_ID": "****"
          }
        }
      },
      "properties": {
        "status": {
          "type": "integer"
        }
      }
    }
  }
}
```

### Related Issues
* #746 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
