### PR TITLE
Fallback to internal scheduler when index creation failed

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -56,7 +56,7 @@ class FlintSpark(val spark: SparkSession) extends FlintSparkTransactionSupport w
   }
 
   private val flintAsyncQueryScheduler: AsyncQueryScheduler = {
-    AsyncQuerySchedulerBuilder.build(flintSparkConf.flintOptions())
+    AsyncQuerySchedulerBuilder.build(spark, flintSparkConf.flintOptions())
   }
 
   override protected val flintMetadataLogService: FlintMetadataLogService = {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/AsyncQuerySchedulerBuilder.java
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/scheduler/AsyncQuerySchedulerBuilder.java
@@ -7,6 +7,8 @@ package org.opensearch.flint.spark.scheduler;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.flint.config.FlintSparkConf;
 import org.opensearch.flint.common.scheduler.AsyncQueryScheduler;
 import org.opensearch.flint.core.FlintOptions;
 
@@ -28,11 +30,27 @@ public class AsyncQuerySchedulerBuilder {
     REMOVE
   }
 
-  public static AsyncQueryScheduler build(FlintOptions options) {
+  public static AsyncQueryScheduler build(SparkSession sparkSession, FlintOptions options) {
+    return new AsyncQuerySchedulerBuilder().doBuild(sparkSession, options);
+  }
+
+  /**
+   * Builds an AsyncQueryScheduler based on the provided options.
+   *
+   * @param sparkSession The SparkSession to be used.
+   * @param options The FlintOptions containing configuration details.
+   * @return An instance of AsyncQueryScheduler.
+   */
+  protected AsyncQueryScheduler doBuild(SparkSession sparkSession, FlintOptions options) {
     String className = options.getCustomAsyncQuerySchedulerClass();
 
     if (className.isEmpty()) {
-      return new OpenSearchAsyncQueryScheduler(options);
+      OpenSearchAsyncQueryScheduler scheduler = createOpenSearchAsyncQueryScheduler(options);
+      // Check if the scheduler has access to the required index. Disable the external scheduler otherwise.
+      if (!hasAccessToSchedulerIndex(scheduler)){
+        setExternalSchedulerEnabled(sparkSession, false);
+      }
+      return scheduler;
     }
 
     // Attempts to instantiate AsyncQueryScheduler using reflection
@@ -44,5 +62,17 @@ public class AsyncQuerySchedulerBuilder {
     } catch (Exception e) {
       throw new RuntimeException("Failed to instantiate AsyncQueryScheduler: " + className, e);
     }
+  }
+
+  protected OpenSearchAsyncQueryScheduler createOpenSearchAsyncQueryScheduler(FlintOptions options) {
+    return new OpenSearchAsyncQueryScheduler(options);
+  }
+
+  protected boolean hasAccessToSchedulerIndex(OpenSearchAsyncQueryScheduler scheduler) {
+    return scheduler.hasAccessToSchedulerIndex();
+  }
+
+  protected void setExternalSchedulerEnabled(SparkSession sparkSession, boolean enabled) {
+    sparkSession.sqlContext().setConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED().key(), String.valueOf(enabled));
   }
 }

--- a/flint-spark-integration/src/test/java/org/opensearch/flint/core/scheduler/AsyncQuerySchedulerBuilderTest.java
+++ b/flint-spark-integration/src/test/java/org/opensearch/flint/core/scheduler/AsyncQuerySchedulerBuilderTest.java
@@ -5,7 +5,13 @@
 
 package org.opensearch.flint.core.scheduler;
 
+import org.apache.spark.FlintSuite;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.SQLContext;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.opensearch.flint.common.scheduler.AsyncQueryScheduler;
 import org.opensearch.flint.common.scheduler.model.AsyncQuerySchedulerRequest;
 import org.opensearch.flint.core.FlintOptions;
@@ -13,26 +19,56 @@ import org.opensearch.flint.spark.scheduler.AsyncQuerySchedulerBuilder;
 import org.opensearch.flint.spark.scheduler.OpenSearchAsyncQueryScheduler;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class AsyncQuerySchedulerBuilderTest {
+    @Mock
+    private SparkSession sparkSession;
+
+    @Mock
+    private SQLContext sqlContext;
+
+    private AsyncQuerySchedulerBuilderForLocalTest testBuilder;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(sparkSession.sqlContext()).thenReturn(sqlContext);
+    }
 
     @Test
-    public void testBuildWithEmptyClassName() {
+    public void testBuildWithEmptyClassNameAndAccessibleIndex() {
         FlintOptions options = mock(FlintOptions.class);
         when(options.getCustomAsyncQuerySchedulerClass()).thenReturn("");
+        OpenSearchAsyncQueryScheduler mockScheduler = mock(OpenSearchAsyncQueryScheduler.class);
 
-        AsyncQueryScheduler scheduler = AsyncQuerySchedulerBuilder.build(options);
+        AsyncQueryScheduler scheduler = testBuilder.build(mockScheduler, true, sparkSession, options);
         assertTrue(scheduler instanceof OpenSearchAsyncQueryScheduler);
+        verify(sqlContext, never()).setConf(anyString(), anyString());
+    }
+
+    @Test
+    public void testBuildWithEmptyClassNameAndInaccessibleIndex() {
+        FlintOptions options = mock(FlintOptions.class);
+        when(options.getCustomAsyncQuerySchedulerClass()).thenReturn("");
+        OpenSearchAsyncQueryScheduler mockScheduler = mock(OpenSearchAsyncQueryScheduler.class);
+
+        AsyncQueryScheduler scheduler = testBuilder.build(mockScheduler, false, sparkSession, options);
+        assertTrue(scheduler instanceof OpenSearchAsyncQueryScheduler);
+        verify(sqlContext).setConf("spark.flint.job.externalScheduler.enabled", "false");
     }
 
     @Test
     public void testBuildWithCustomClassName() {
         FlintOptions options = mock(FlintOptions.class);
-        when(options.getCustomAsyncQuerySchedulerClass()).thenReturn("org.opensearch.flint.core.scheduler.AsyncQuerySchedulerBuilderTest$AsyncQuerySchedulerForLocalTest");
+        when(options.getCustomAsyncQuerySchedulerClass())
+                .thenReturn("org.opensearch.flint.core.scheduler.AsyncQuerySchedulerBuilderTest$AsyncQuerySchedulerForLocalTest");
 
-        AsyncQueryScheduler scheduler = AsyncQuerySchedulerBuilder.build(options);
+        AsyncQueryScheduler scheduler = AsyncQuerySchedulerBuilder.build(sparkSession, options);
         assertTrue(scheduler instanceof AsyncQuerySchedulerForLocalTest);
     }
 
@@ -41,7 +77,7 @@ public class AsyncQuerySchedulerBuilderTest {
         FlintOptions options = mock(FlintOptions.class);
         when(options.getCustomAsyncQuerySchedulerClass()).thenReturn("invalid.ClassName");
 
-        AsyncQuerySchedulerBuilder.build(options);
+        AsyncQuerySchedulerBuilder.build(sparkSession, options);
     }
 
     public static class AsyncQuerySchedulerForLocalTest implements AsyncQueryScheduler {
@@ -63,6 +99,37 @@ public class AsyncQuerySchedulerBuilderTest {
         @Override
         public void removeJob(AsyncQuerySchedulerRequest asyncQuerySchedulerRequest) {
             // Custom implementation
+        }
+    }
+
+    public static class OpenSearchAsyncQuerySchedulerForLocalTest extends OpenSearchAsyncQueryScheduler {
+        @Override
+        public boolean hasAccessToSchedulerIndex() {
+            return true;
+        }
+    }
+
+    public static class AsyncQuerySchedulerBuilderForLocalTest extends AsyncQuerySchedulerBuilder {
+        private OpenSearchAsyncQueryScheduler mockScheduler;
+        private Boolean mockHasAccess;
+
+        public AsyncQuerySchedulerBuilderForLocalTest(OpenSearchAsyncQueryScheduler mockScheduler, Boolean mockHasAccess) {
+            this.mockScheduler = mockScheduler;
+            this.mockHasAccess = mockHasAccess;
+        }
+
+        @Override
+        protected OpenSearchAsyncQueryScheduler createOpenSearchAsyncQueryScheduler(FlintOptions options) {
+            return mockScheduler != null ? mockScheduler : super.createOpenSearchAsyncQueryScheduler(options);
+        }
+
+        @Override
+        protected boolean hasAccessToSchedulerIndex(OpenSearchAsyncQueryScheduler scheduler) {
+            return mockHasAccess != null ? mockHasAccess : super.hasAccessToSchedulerIndex(scheduler);
+        }
+
+        public static AsyncQueryScheduler build(OpenSearchAsyncQueryScheduler asyncQueryScheduler, Boolean hasAccess, SparkSession sparkSession, FlintOptions options) {
+            return new AsyncQuerySchedulerBuilderForLocalTest(asyncQueryScheduler, hasAccess).doBuild(sparkSession, options);
         }
     }
 }

--- a/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
@@ -9,7 +9,7 @@ import org.opensearch.flint.spark.FlintSparkExtensions
 
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation
-import org.apache.spark.sql.flint.config.FlintConfigEntry
+import org.apache.spark.sql.flint.config.{FlintConfigEntry, FlintSparkConf}
 import org.apache.spark.sql.flint.config.FlintSparkConf.HYBRID_SCAN_ENABLED
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -26,6 +26,10 @@ trait FlintSuite extends SharedSparkSession {
       // ConstantPropagation etc.
       .set(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, ConvertToLocalRelation.ruleName)
       .set("spark.sql.extensions", classOf[FlintSparkExtensions].getName)
+      // Override scheduler class for unit testing
+      .set(
+        FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key,
+        "org.opensearch.flint.core.scheduler.AsyncQuerySchedulerBuilderTest$AsyncQuerySchedulerForLocalTest")
     conf
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -23,6 +23,7 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.spark.{FlintSuite, SparkConf}
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.flint.config.FlintSparkConf
 import org.apache.spark.sql.flint.config.FlintSparkConf.{CHECKPOINT_MANDATORY, HOST_ENDPOINT, HOST_PORT, REFRESH_POLICY}
 import org.apache.spark.sql.streaming.StreamTest
 
@@ -49,6 +50,8 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    // Revoke override in FlintSuite on IT
+    conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
 
     // Replace executor to avoid impact on IT.
     // TODO: Currently no IT test scheduler so no need to restore it back.


### PR DESCRIPTION
### Description
_Describe what this change achieves._

### Related Issues
_List any issues this PR will resolve, e.g. Resolves [...]._

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
