### PR TITLE
Join side aliases should be optional

### DIFF
--- a/docs/ppl-lang/PPL-Example-Commands.md
+++ b/docs/ppl-lang/PPL-Example-Commands.md
@@ -298,7 +298,11 @@ source = table |  where ispresent(a) |
 - `source = table1 | left semi join left = l right = r on l.a = r.a table2`
 - `source = table1 | left anti join left = l right = r on l.a = r.a table2`
 - `source = table1 | join left = l right = r [ source = table2 | where d > 10 | head 5 ]`
-
+- `source = table1 | inner join on table1.a = table2.a table2 | fields table1.a, table2.a, table1.b, table1.c` (directly refer table name)
+- `source = table1 | inner join on a = c table2 | fields a, b, c, d` (ignore side aliases as long as no ambiguous)
+- `source = table1 as t1 | join left = l right = r on l.a = r.a table2 as t2 | fields l.a, r.a` (side alias overrides table alias)
+- `source = table1 as t1 | join left = l right = r on l.a = r.a table2 as t2 | fields t1.a, t2.a` (error, side alias overrides table alias)
+- `source = table1 | join left = l right = r on l.a = r.a [ source = table2 ] as s | fields l.a, s.a` (error, side alias overrides subquery alias)
 
 #### **Lookup**
 [See additional command details](ppl-lookup-command.md)

--- a/docs/ppl-lang/ppl-join-command.md
+++ b/docs/ppl-lang/ppl-join-command.md
@@ -65,8 +65,8 @@ WHERE t1.serviceName = `order`
 SEARCH source=<left-table>
 | <other piped command>
 | [joinType] JOIN
-    leftAlias
-    rightAlias
+    [leftAlias]
+    [rightAlias]
     [joinHints]
     ON joinCriteria
     <right-table>
@@ -79,12 +79,12 @@ SEARCH source=<left-table>
 
 **leftAlias**
 - Syntax: `left = <leftAlias>`
-- Required
+- Optional
 - Description: The subquery alias to use with the left join side, to avoid ambiguous naming.
 
 **rightAlias**
 - Syntax: `right = <rightAlias>`
-- Required
+- Optional
 - Description: The subquery alias to use with the right join side, to avoid ambiguous naming.
 
 **joinHints**
@@ -138,11 +138,11 @@ Rewritten by PPL Join query:
 ```sql
 SEARCH source=customer
 | FIELDS c_custkey
-| LEFT OUTER JOIN left = c, right = o
-    ON c.c_custkey = o.o_custkey AND o_comment NOT LIKE '%unusual%packages%'
+| LEFT OUTER JOIN
+    ON c_custkey = o_custkey AND o_comment NOT LIKE '%unusual%packages%'
     orders
-| STATS count(o_orderkey) AS c_count BY c.c_custkey
-| STATS count(1) AS custdist BY c_count
+| STATS count(o_orderkey) AS c_count BY c_custkey
+| STATS count() AS custdist BY c_count
 | SORT - custdist, - c_count
 ```
 _- **Limitation: sub-searches is unsupported in join right side**_
@@ -151,14 +151,15 @@ If sub-searches is supported, above ppl query could be rewritten as:
 ```sql
 SEARCH source=customer
 | FIELDS c_custkey
-| LEFT OUTER JOIN left = c, right = o ON c.c_custkey = o.o_custkey
+| LEFT OUTER JOIN
+   ON c_custkey = o_custkey
    [
       SEARCH source=orders
       | WHERE o_comment NOT LIKE '%unusual%packages%'
       | FIELDS o_orderkey, o_custkey
    ]
-| STATS count(o_orderkey) AS c_count BY c.c_custkey
-| STATS count(1) AS custdist BY c_count
+| STATS count(o_orderkey) AS c_count BY c_custkey
+| STATS count() AS custdist BY c_count
 | SORT - custdist, - c_count
 ```
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBasicITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBasicITSuite.scala
@@ -616,7 +616,7 @@ class FlintSparkPPLBasicITSuite
 
     val logicalPlan: LogicalPlan = frame.queryExecution.logical
     val table1 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test1"))
-    val table2 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test1"))
+    val table2 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test2"))
 
     val allFields1 = UnresolvedStar(None)
     val allFields2 = UnresolvedStar(None)

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBasicITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBasicITSuite.scala
@@ -597,4 +597,68 @@ class FlintSparkPPLBasicITSuite
           | """.stripMargin))
     assert(ex.getMessage().contains("Invalid table name"))
   }
+
+  test("Search multiple tables - translated into union call with fields") {
+    val frame = sql(s"""
+                       | source = $t1, $t2
+                       | """.stripMargin)
+    assertSameRows(
+      Seq(
+        Row("Hello", 30, "New York", "USA", 2023, 4),
+        Row("Hello", 30, "New York", "USA", 2023, 4),
+        Row("Jake", 70, "California", "USA", 2023, 4),
+        Row("Jake", 70, "California", "USA", 2023, 4),
+        Row("Jane", 20, "Quebec", "Canada", 2023, 4),
+        Row("Jane", 20, "Quebec", "Canada", 2023, 4),
+        Row("John", 25, "Ontario", "Canada", 2023, 4),
+        Row("John", 25, "Ontario", "Canada", 2023, 4)),
+      frame)
+
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+    val table1 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test1"))
+    val table2 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test1"))
+
+    val allFields1 = UnresolvedStar(None)
+    val allFields2 = UnresolvedStar(None)
+
+    val projectedTable1 = Project(Seq(allFields1), table1)
+    val projectedTable2 = Project(Seq(allFields2), table2)
+
+    val expectedPlan =
+      Union(Seq(projectedTable1, projectedTable2), byName = true, allowMissingCol = true)
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
+
+  test("Search multiple tables - with table alias") {
+    val frame = sql(s"""
+                       | source = $t1, $t2 as t | where t.country = "USA"
+                       | """.stripMargin)
+    assertSameRows(
+      Seq(
+        Row("Hello", 30, "New York", "USA", 2023, 4),
+        Row("Hello", 30, "New York", "USA", 2023, 4),
+        Row("Jake", 70, "California", "USA", 2023, 4),
+        Row("Jake", 70, "California", "USA", 2023, 4)),
+      frame)
+
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+    val table1 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test1"))
+    val table2 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test2"))
+
+    val plan1 = Filter(
+      EqualTo(UnresolvedAttribute("t.country"), Literal("USA")),
+      SubqueryAlias("t", table1))
+    val plan2 = Filter(
+      EqualTo(UnresolvedAttribute("t.country"), Literal("USA")),
+      SubqueryAlias("t", table2))
+
+    val projectedTable1 = Project(Seq(UnresolvedStar(None)), plan1)
+    val projectedTable2 = Project(Seq(UnresolvedStar(None)), plan2)
+
+    val expectedPlan =
+      Union(Seq(projectedTable1, projectedTable2), byName = true, allowMissingCol = true)
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
 }

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -326,7 +326,7 @@ joinType
    ;
 
 sideAlias
-   : LEFT EQUAL leftAlias = ident COMMA? RIGHT EQUAL rightAlias = ident
+   : (LEFT EQUAL leftAlias = ident)? COMMA? (RIGHT EQUAL rightAlias = ident)?
    ;
 
 joinCriteria

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/DescribeRelation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/DescribeRelation.java
@@ -8,12 +8,14 @@ package org.opensearch.sql.ast.tree;
 import lombok.ToString;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
+import java.util.Collections;
+
 /**
  * Extend Relation to describe the table itself
  */
 @ToString
 public class DescribeRelation extends Relation{
     public DescribeRelation(UnresolvedExpression tableName) {
-        super(tableName);
+        super(Collections.singletonList(tableName));
     }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Join.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Join.java
@@ -25,15 +25,15 @@ import org.opensearch.sql.ast.expression.UnresolvedExpression;
 public class Join extends UnresolvedPlan {
     private UnresolvedPlan left;
     private final UnresolvedPlan right;
-    private final String leftAlias;
-    private final String rightAlias;
+    private final Optional<String> leftAlias;
+    private final Optional<String> rightAlias;
     private final JoinType joinType;
     private final Optional<UnresolvedExpression> joinCondition;
     private final JoinHint joinHint;
 
     @Override
     public UnresolvedPlan attach(UnresolvedPlan child) {
-        this.left = new SubqueryAlias(leftAlias, child);
+        this.left = leftAlias.isEmpty() ? child : new SubqueryAlias(leftAlias.get(), child);
         return this;
     }
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Relation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Relation.java
@@ -6,7 +6,6 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -26,10 +25,15 @@ import java.util.stream.Collectors;
 public class Relation extends UnresolvedPlan {
   private static final String COMMA = ",";
 
-  private final List<UnresolvedExpression> tableName;
+  // A relation could contain more than one table/index names, such as
+  // source=account1, account2
+  // source=`account1`,`account2`
+  // source=`account*`
+  // They translated into union call with fields.
+  private final List<UnresolvedExpression> tableNames;
 
   public List<QualifiedName> getQualifiedNames() {
-    return tableName.stream().map(t -> (QualifiedName) t).collect(Collectors.toList());
+    return tableNames.stream().map(t -> (QualifiedName) t).collect(Collectors.toList());
   }
 
   /**
@@ -40,11 +44,11 @@ public class Relation extends UnresolvedPlan {
    * @return TableQualifiedName.
    */
   public QualifiedName getTableQualifiedName() {
-    if (tableName.size() == 1) {
-      return (QualifiedName) tableName.get(0);
+    if (tableNames.size() == 1) {
+      return (QualifiedName) tableNames.get(0);
     } else {
       return new QualifiedName(
-          tableName.stream()
+          tableNames.stream()
               .map(UnresolvedExpression::toString)
               .collect(Collectors.joining(COMMA)));
     }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Relation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Relation.java
@@ -10,46 +10,23 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 /** Logical plan node of Relation, the interface for building the searching sources. */
-@AllArgsConstructor
 @ToString
+@Getter
 @EqualsAndHashCode(callSuper = false)
 @RequiredArgsConstructor
 public class Relation extends UnresolvedPlan {
   private static final String COMMA = ",";
 
   private final List<UnresolvedExpression> tableName;
-
-  public Relation(UnresolvedExpression tableName) {
-    this(tableName, null);
-  }
-
-  public Relation(UnresolvedExpression tableName, String alias) {
-    this.tableName = Arrays.asList(tableName);
-    this.alias = alias;
-  }
-
-  /** Optional alias name for the relation. */
-  @Setter @Getter private String alias;
-
-  /**
-   * Return table name.
-   *
-   * @return table name
-   */
-  public List<String> getTableName() {
-    return tableName.stream().map(Object::toString).collect(Collectors.toList());
-  }
 
   public List<QualifiedName> getQualifiedNames() {
     return tableName.stream().map(t -> (QualifiedName) t).collect(Collectors.toList());

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/SubqueryAlias.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/SubqueryAlias.java
@@ -6,19 +6,14 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 import java.util.List;
-import java.util.Objects;
 
-@AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
 @ToString
 public class SubqueryAlias extends UnresolvedPlan {
     @Getter private final String alias;
@@ -29,6 +24,11 @@ public class SubqueryAlias extends UnresolvedPlan {
      */
     public SubqueryAlias(UnresolvedPlan child, String suffix) {
         this.alias = "__auto_generated_subquery_name" + suffix;
+        this.child = child;
+    }
+
+    public SubqueryAlias(String alias, UnresolvedPlan child) {
+        this.alias = alias;
         this.child = child;
     }
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
@@ -278,7 +278,8 @@ public class CatalystQueryPlanVisitor extends AbstractNodeVisitor<LogicalPlan, C
         node.getChild().get(0).accept(this, context);
         return context.apply(left -> {
             LogicalPlan right = node.getRight().accept(this, context);
-            Optional<Expression> joinCondition = node.getJoinCondition().map(c -> visitExpression(c, context));
+            Optional<Expression> joinCondition = node.getJoinCondition()
+                .map(c -> expressionAnalyzer.analyzeJoinCondition(c, context));
             context.retainAllNamedParseExpressions(p -> p);
             context.retainAllPlans(p -> p);
             return join(left, right, node.getJoinType(), joinCondition, node.getJoinHint());

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -165,15 +165,14 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     }
 
     UnresolvedPlan rightRelation = visit(ctx.tableOrSubqueryClause());
+    // Add a SubqueryAlias to the right plan when the right alias is present and no duplicated alias existing in right.
     UnresolvedPlan right;
-    if (rightAlias.isPresent()
-        && rightRelation instanceof SubqueryAlias
-        && rightAlias.get().equals(((SubqueryAlias) rightRelation).getAlias())) {
+    if (rightAlias.isEmpty() ||
+        (rightRelation instanceof SubqueryAlias &&
+            rightAlias.get().equals(((SubqueryAlias) rightRelation).getAlias()))) {
       right = rightRelation;
-    } else if (rightAlias.isPresent()) {
-      right = new SubqueryAlias(rightAlias.get(), rightRelation);
     } else {
-      right = rightRelation;
+      right = new SubqueryAlias(rightAlias.get(), rightRelation);
     }
     Optional<UnresolvedExpression> joinCondition =
         ctx.joinCriteria() == null ? Optional.empty() : Optional.of(expressionBuilder.visitJoinCriteria(ctx.joinCriteria()));


### PR DESCRIPTION
### Description
Imaging a case as following: Assume table1, table2, and table3 all contain a column `id`.
```sql
select
  *
from
  table1 t1,
  table2 t2,
  table3 t3
where
 t1.id = t2.id
 and t1.id = t3.id
```
To rewrite above SQL query to PPL query, we will get
```sql
source = table1
| join left = t1 right = t2 ON t1.id = t2.id table2
| join left = l1 right = t3 ON t1.id = t3.id table3 // <------ issue here! 
```

The PPL query throws an exception with message:
> `t1`.`id` cannot be resolved, Did you mean one of the following? [`l1`.`id`, `l1`.`id`, `t3`.`id`].

It because the **required left side alias** `l1` overrides the table alias `t1` and `t2`.

Its logical plan looks
```
'Project [*]
+- 'Filter (('t1.id = 't2.id) AND ('t1.id = 't3.id)) <------ t1.id cannot be resolved
   +- 'Join Inner
      :- 'SubqueryAlias l1  <------ issue root cause
      :  +- 'Join Inner
      :    :- 'SubqueryAlias t1
      :    :  +- 'UnresolvedRelation [table1], [], false
      :    +- 'SubqueryAlias t2
      :       +- 'UnresolvedRelation [table2], [], false
      +- 'SubqueryAlias t3
         +- 'UnresolvedRelation [table3], [], false
```

Check #857 for details

### Related Issues
Resolves #857 

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
