### PR TITLE
[followup] Refactor JSON function and add TO_JSON_STRING, ARRAY_LENGHT functions

### DIFF
--- a/docs/ppl-lang/functions/ppl-json.md
+++ b/docs/ppl-lang/functions/ppl-json.md
@@ -4,11 +4,11 @@
 
 **Description**
 
-`json(value)` Evaluates whether a value can be parsed as JSON. Returns the json string if valid, null otherwise.
+`json(value)` Evaluates whether a string can be parsed as JSON format. Returns the string value if valid, null otherwise.
 
-**Argument type:** STRING/JSON_ARRAY/JSON_OBJECT
+**Argument type:** STRING
 
-**Return type:** STRING
+**Return type:** STRING/NULL
 
 A STRING expression of a valid JSON object format.
 
@@ -47,7 +47,7 @@ A StructType expression of a valid JSON object.
 
 Example:
 
-    os> source=people | eval result = json(json_object('key', 123.45)) | fields result
+    os> source=people | eval result = json_object('key', 123.45) | fields result
     fetched rows / total rows = 1/1
     +------------------+
     | result           |
@@ -55,7 +55,7 @@ Example:
     | {"key":123.45}   |
     +------------------+
 
-    os> source=people | eval result = json(json_object('outer', json_object('inner', 123.45))) | fields result
+    os> source=people | eval result = json_object('outer', json_object('inner', 123.45)) | fields result
     fetched rows / total rows = 1/1
     +------------------------------+
     | result                       |
@@ -81,13 +81,13 @@ Example:
 
     os> source=people | eval `json_array` = json_array(1, 2, 0, -1, 1.1, -0.11)
     fetched rows / total rows = 1/1
-    +----------------------------+
-    | json_array                 |
-    +----------------------------+
-    | 1.0,2.0,0.0,-1.0,1.1,-0.11 |
-    +----------------------------+
+    +------------------------------+
+    | json_array                   |
+    +------------------------------+
+    | [1.0,2.0,0.0,-1.0,1.1,-0.11] |
+    +------------------------------+
 
-    os> source=people | eval `json_array_object` = json(json_object("array", json_array(1, 2, 0, -1, 1.1, -0.11)))
+    os> source=people | eval `json_array_object` = json_object("array", json_array(1, 2, 0, -1, 1.1, -0.11))
     fetched rows / total rows = 1/1
     +----------------------------------------+
     | json_array_object                      |
@@ -95,15 +95,44 @@ Example:
     | {"array":[1.0,2.0,0.0,-1.0,1.1,-0.11]} |
     +----------------------------------------+
 
+### `TO_JSON_STRING`
+
+**Description**
+
+`to_json_string(jsonObject)` Returns a JSON string with a given json object value.
+
+**Argument type:** JSON_OBJECT (Spark StructType/ArrayType)
+
+**Return type:** STRING
+
+Example:
+
+    os> source=people | eval `json_string` = to_json_string(json_array(1, 2, 0, -1, 1.1, -0.11)) | fields json_string
+    fetched rows / total rows = 1/1
+    +--------------------------------+
+    | json_string                    |
+    +--------------------------------+
+    | [1.0,2.0,0.0,-1.0,1.1,-0.11]   |
+    +--------------------------------+
+
+    os> source=people | eval `json_string` = to_json_string(json_object('key', 123.45)) | fields json_string
+    fetched rows / total rows = 1/1
+    +-----------------+
+    | json_string     |
+    +-----------------+
+    | {'key', 123.45} |
+    +-----------------+
+
+
 ### `JSON_ARRAY_LENGTH`
 
 **Description**
 
-`json_array_length(jsonArray)` Returns the number of elements in the outermost JSON array.
+`json_array_length(jsonArrayString)` Returns the number of elements in the outermost JSON array string.
 
-**Argument type:** STRING/JSON_ARRAY
+**Argument type:** STRING
 
-A STRING expression of a valid JSON array format, or JSON_ARRAY object.
+A STRING expression of a valid JSON array format.
 
 **Return type:** INTEGER
 
@@ -119,6 +148,21 @@ Example:
     | 4         | 5         | null        |
     +-----------+-----------+-------------+
 
+
+### `ARRAY_LENGTH`
+
+**Description**
+
+`array_length(jsonArray)` Returns the number of elements in the outermost array.
+
+**Argument type:** ARRAY
+
+ARRAY or JSON_ARRAY object.
+
+**Return type:** INTEGER
+
+Example:
+
     os> source=people | eval `json_array` = json_array_length(json_array(1,2,3,4)), `empty_array` = json_array_length(json_array())
     fetched rows / total rows = 1/1
     +--------------+---------------+
@@ -126,6 +170,7 @@ Example:
     +--------------+---------------+
     | 4            | 0             |
     +--------------+---------------+
+
 
 ### `JSON_EXTRACT`
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLJsonFunctionITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLJsonFunctionITSuite.scala
@@ -163,30 +163,32 @@ class FlintSparkPPLJsonFunctionITSuite
     assert(ex.getMessage().contains("should all be the same type"))
   }
 
-  test("test json_array() with json()") {
+  test("test json_array() with to_json_tring()") {
     val frame = sql(s"""
-                       | source = $testTable | eval result = json(json_array(1,2,0,-1,1.1,-0.11)) | head 1 | fields result
+                       | source = $testTable | eval result = to_json_string(json_array(1,2,0,-1,1.1,-0.11)) | head 1 | fields result
                        | """.stripMargin)
     assertSameRows(Seq(Row("""[1.0,2.0,0.0,-1.0,1.1,-0.11]""")), frame)
   }
 
-  test("test json_array_length()") {
+  test("test array_length()") {
     var frame = sql(s"""
-                   | source = $testTable | eval result = json_array_length(json_array('this', 'is', 'a', 'string', 'array')) | head 1 | fields result
-                   | """.stripMargin)
+         | source = $testTable| eval result = array_length(json_array('this', 'is', 'a', 'string', 'array')) | head 1 | fields result
+         | """.stripMargin)
     assertSameRows(Seq(Row(5)), frame)
 
     frame = sql(s"""
-                   | source = $testTable | eval result = json_array_length(json_array(1, 2, 0, -1, 1.1, -0.11)) | head 1 | fields result
-                   | """.stripMargin)
+         | source = $testTable| eval result = array_length(json_array(1, 2, 0, -1, 1.1, -0.11)) | head 1 | fields result
+         | """.stripMargin)
     assertSameRows(Seq(Row(6)), frame)
 
     frame = sql(s"""
-                   | source = $testTable | eval result = json_array_length(json_array()) | head 1 | fields result
-                   | """.stripMargin)
+         | source = $testTable| eval result = array_length(json_array()) | head 1 | fields result
+         | """.stripMargin)
     assertSameRows(Seq(Row(0)), frame)
+  }
 
-    frame = sql(s"""
+  test("test json_array_length()") {
+    var frame = sql(s"""
                    | source = $testTable | eval result = json_array_length('[]') | head 1 | fields result
                    | """.stripMargin)
     assertSameRows(Seq(Row(0)), frame)
@@ -211,24 +213,24 @@ class FlintSparkPPLJsonFunctionITSuite
   test("test json_object()") {
     // test value is a string
     var frame = sql(s"""
-         | source = $testTable| eval result = json(json_object('key', 'string_value')) | head 1 | fields result
+         | source = $testTable| eval result = to_json_string(json_object('key', 'string_value')) | head 1 | fields result
          | """.stripMargin)
     assertSameRows(Seq(Row("""{"key":"string_value"}""")), frame)
 
     // test value is a number
     frame = sql(s"""
-         | source = $testTable| eval result = json(json_object('key', 123.45)) | head 1 | fields result
+         | source = $testTable| eval result = to_json_string(json_object('key', 123.45)) | head 1 | fields result
          | """.stripMargin)
     assertSameRows(Seq(Row("""{"key":123.45}""")), frame)
 
     // test value is a boolean
     frame = sql(s"""
-         | source = $testTable| eval result = json(json_object('key', true)) | head 1 | fields result
+         | source = $testTable| eval result = to_json_string(json_object('key', true)) | head 1 | fields result
          | """.stripMargin)
     assertSameRows(Seq(Row("""{"key":true}""")), frame)
 
     frame = sql(s"""
-         | source = $testTable| eval result = json(json_object("a", 1, "b", 2, "c", 3)) | head 1 | fields result
+         | source = $testTable| eval result = to_json_string(json_object("a", 1, "b", 2, "c", 3)) | head 1 | fields result
          | """.stripMargin)
     assertSameRows(Seq(Row("""{"a":1,"b":2,"c":3}""")), frame)
   }
@@ -236,13 +238,13 @@ class FlintSparkPPLJsonFunctionITSuite
   test("test json_object() and json_array()") {
     // test value is an empty array
     var frame = sql(s"""
-         | source = $testTable| eval result = json(json_object('key', array())) | head 1 | fields result
+         | source = $testTable| eval result = to_json_string(json_object('key', array())) | head 1 | fields result
          | """.stripMargin)
     assertSameRows(Seq(Row("""{"key":[]}""")), frame)
 
     // test value is an array
     frame = sql(s"""
-         | source = $testTable| eval result = json(json_object('key', array(1, 2, 3))) | head 1 | fields result
+         | source = $testTable| eval result = to_json_string(json_object('key', array(1, 2, 3))) | head 1 | fields result
          | """.stripMargin)
     assertSameRows(Seq(Row("""{"key":[1,2,3]}""")), frame)
 
@@ -272,14 +274,14 @@ class FlintSparkPPLJsonFunctionITSuite
 
   test("test json_object() nested") {
     val frame = sql(s"""
-                   | source = $testTable | eval result = json(json_object('outer', json_object('inner', 123.45))) | head 1 | fields result
+                   | source = $testTable | eval result = to_json_string(json_object('outer', json_object('inner', 123.45))) | head 1 | fields result
                    | """.stripMargin)
     assertSameRows(Seq(Row("""{"outer":{"inner":123.45}}""")), frame)
   }
 
   test("test json_object(), json_array() and json()") {
     val frame = sql(s"""
-                       | source = $testTable | eval result = json(json_object("array", json_array(1,2,0,-1,1.1,-0.11))) | head 1 | fields result
+                       | source = $testTable | eval result = to_json_string(json_object("array", json_array(1,2,0,-1,1.1,-0.11))) | head 1 | fields result
                        | """.stripMargin)
     assertSameRows(Seq(Row("""{"array":[1.0,2.0,0.0,-1.0,1.1,-0.11]}""")), frame)
   }

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
@@ -377,6 +377,7 @@ JSON:                               'JSON';
 JSON_OBJECT:                        'JSON_OBJECT';
 JSON_ARRAY:                         'JSON_ARRAY';
 JSON_ARRAY_LENGTH:                  'JSON_ARRAY_LENGTH';
+TO_JSON_STRING:                     'TO_JSON_STRING';
 JSON_EXTRACT:                       'JSON_EXTRACT';
 JSON_KEYS:                          'JSON_KEYS';
 JSON_VALID:                         'JSON_VALID';
@@ -392,6 +393,7 @@ JSON_VALID:                         'JSON_VALID';
 
 // COLLECTION FUNCTIONS
 ARRAY:                              'ARRAY';
+ARRAY_LENGTH:                       'ARRAY_LENGTH';
 
 // BOOL FUNCTIONS
 LIKE:                               'LIKE';

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -857,6 +857,7 @@ jsonFunctionName
    | JSON_OBJECT
    | JSON_ARRAY
    | JSON_ARRAY_LENGTH
+   | TO_JSON_STRING
    | JSON_EXTRACT
    | JSON_KEYS
    | JSON_VALID
@@ -873,6 +874,7 @@ jsonFunctionName
 
 collectionFunctionName
    : ARRAY
+   | ARRAY_LENGTH
    ;
 
 positionFunctionName

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -213,6 +213,7 @@ public enum BuiltinFunctionName {
   JSON_OBJECT(FunctionName.of("json_object")),
   JSON_ARRAY(FunctionName.of("json_array")),
   JSON_ARRAY_LENGTH(FunctionName.of("json_array_length")),
+  TO_JSON_STRING(FunctionName.of("to_json_string")),
   JSON_EXTRACT(FunctionName.of("json_extract")),
   JSON_KEYS(FunctionName.of("json_keys")),
   JSON_VALID(FunctionName.of("json_valid")),
@@ -228,6 +229,7 @@ public enum BuiltinFunctionName {
 
   /** COLLECTION Functions **/
   ARRAY(FunctionName.of("array")),
+  ARRAY_LENGTH(FunctionName.of("array_length")),
 
   /** NULL Test. */
   IS_NULL(FunctionName.of("is null")),

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/BuiltinFunctionTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/BuiltinFunctionTransformer.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.ADD;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.ADDDATE;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.ARRAY_LENGTH;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DATEDIFF;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DATE_ADD;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DATE_SUB;
@@ -58,6 +59,7 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.SUBDATE
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.SYSDATE;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.TIMESTAMPADD;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.TIMESTAMPDIFF;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.TO_JSON_STRING;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.TRIM;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.UTC_TIMESTAMP;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.WEEK;
@@ -102,7 +104,9 @@ public interface BuiltinFunctionTransformer {
             .put(COALESCE, "coalesce")
             .put(LENGTH, "length")
             .put(TRIM, "trim")
+            .put(ARRAY_LENGTH, "array_size")
             // json functions
+            .put(TO_JSON_STRING, "to_json")
             .put(JSON_KEYS, "json_object_keys")
             .put(JSON_EXTRACT, "get_json_object")
             .build();
@@ -126,26 +130,12 @@ public interface BuiltinFunctionTransformer {
         .put(
             JSON_ARRAY_LENGTH,
             args -> {
-                // Check if the input is an array (from json_array()) or a JSON string
-                if (args.get(0) instanceof UnresolvedFunction) {
-                    // Input is a JSON array
-                    return UnresolvedFunction$.MODULE$.apply("json_array_length",
-                        seq(UnresolvedFunction$.MODULE$.apply("to_json", seq(args), false)), false);
-                } else {
-                    // Input is a JSON string
-                    return UnresolvedFunction$.MODULE$.apply("json_array_length", seq(args.get(0)), false);
-                }
+                return UnresolvedFunction$.MODULE$.apply("json_array_length", seq(args.get(0)), false);
             })
         .put(
             JSON,
             args -> {
-                // Check if the input is a named_struct (from json_object()) or a JSON string
-                if (args.get(0) instanceof UnresolvedFunction) {
-                    return UnresolvedFunction$.MODULE$.apply("to_json", seq(args.get(0)), false);
-                } else {
-                    return UnresolvedFunction$.MODULE$.apply("get_json_object",
-                        seq(args.get(0), Literal$.MODULE$.apply("$")), false);
-                }
+                return UnresolvedFunction$.MODULE$.apply("get_json_object", seq(args.get(0), Literal$.MODULE$.apply("$")), false);
             })
         .put(
             JSON_VALID,

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanJsonFunctionsTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanJsonFunctionsTranslatorTestSuite.scala
@@ -48,7 +48,7 @@ class PPLLogicalPlanJsonFunctionsTranslatorTestSuite
     val context = new CatalystPlanContext
     val logPlan =
       planTransformer.visit(
-        plan(pplParser, """source=t a = json(json_object('key', array(1, 2, 3)))"""),
+        plan(pplParser, """source=t a = to_json_string(json_object('key', array(1, 2, 3)))"""),
         context)
 
     val table = UnresolvedRelation(Seq("t"))
@@ -97,7 +97,9 @@ class PPLLogicalPlanJsonFunctionsTranslatorTestSuite
     val context = new CatalystPlanContext
     val logPlan =
       planTransformer.visit(
-        plan(pplParser, """source=t a = json(json_object('key', json_array(1, 2, 3)))"""),
+        plan(
+          pplParser,
+          """source=t a = to_json_string(json_object('key', json_array(1, 2, 3)))"""),
         context)
 
     val table = UnresolvedRelation(Seq("t"))
@@ -139,25 +141,21 @@ class PPLLogicalPlanJsonFunctionsTranslatorTestSuite
     comparePlans(expectedPlan, logPlan, false)
   }
 
-  test("test json_array_length(json_array())") {
+  test("test array_length(json_array())") {
     val context = new CatalystPlanContext
     val logPlan =
       planTransformer.visit(
-        plan(pplParser, """source=t a = json_array_length(json_array(1,2,3))"""),
+        plan(pplParser, """source=t a = array_length(json_array(1,2,3))"""),
         context)
 
     val table = UnresolvedRelation(Seq("t"))
     val jsonFunc =
       UnresolvedFunction(
-        "json_array_length",
+        "array_size",
         Seq(
           UnresolvedFunction(
-            "to_json",
-            Seq(
-              UnresolvedFunction(
-                "array",
-                Seq(Literal(1), Literal(2), Literal(3)),
-                isDistinct = false)),
+            "array",
+            Seq(Literal(1), Literal(2), Literal(3)),
             isDistinct = false)),
         isDistinct = false)
     val filterExpr = EqualTo(UnresolvedAttribute("a"), jsonFunc)


### PR DESCRIPTION
### Description

This is a followup of PR https://github.com/opensearch-project/opensearch-spark/pull/780

1. Refactor `JSON`: Currently the `JSON` can evaluate STRING/JSON_ARRAY/JSON_OBJECT. It brings many confusions and bugs. It because in Splunk or OpenSearch, the data could be stored as JSON object, `JSON` function evaluates JSON object and return its value or null if invalid. But in Spark, there is no JSON object, but it contains STRING, StructType and ArrayType. So to evaluate a json string, `JSON` function should accept STRING type only.

 2. Add `ARRAY_LENGHT`: for the same reason, the original `JSON_ARRAY_LENGHT` accepts both STRINGand JSON_ARRAY(ArrayType). We separate `JSON_ARRAY_LENGHT` to `JSON_ARRAY_LENGHT` and `ARRAY_LENGHT`. The `JSON_ARRAY_LENGHT` only accepts STRING type, `ARRAY_LENGHT` only accepts ArrayType.

3. Add `TO_JSON_STRING`: After the refactor of (1), we still need a method to convert JSON_ARRAY/JSON_OBJECT to valid JSON STRING. `TO_JSON_STRING` accepts both StructType and ArrayType as input and returns JSON formatted string.

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-spark/issues/869

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
