### PR TITLE
Add `sample` parameter to `top` & `rare` command

### DIFF
--- a/docs/ppl-lang/PPL-Example-Commands.md
+++ b/docs/ppl-lang/PPL-Example-Commands.md
@@ -246,13 +246,15 @@ source = table |  where ispresent(a) |
 
 - `source=accounts | rare gender`
 - `source=accounts | rare age by gender`
+- `source=accounts | rare age by gender sample(50 percent)`
 
 #### **Top**
 [See additional command details](ppl-top-command.md)
 
 - `source=accounts | top gender`
 - `source=accounts | top 1 gender`
-- `source=accounts | top 1 age by gender`
+- `source=accounts | top 5 gender sample(50 percent)`
+- `source=accounts | top 5 age by gender`
 
 #### **Parse**
 [See additional command details](ppl-parse-command.md)

--- a/docs/ppl-lang/ppl-rare-command.md
+++ b/docs/ppl-lang/ppl-rare-command.md
@@ -6,10 +6,11 @@ Using ``rare`` command to find the least common tuple of values of all fields in
 **Note**: A maximum of 10 results is returned for each distinct tuple of values of the group-by fields.
 
 **Syntax**
-`rare <field-list> [by-clause]`
+`rare <field-list> [by-clause] [sample(? percent)]`
 
 * field-list: mandatory. comma-delimited list of field names.
 * by-clause: optional. one or more fields to group the results by.
+* sample: optional. allows reducing the amount of fields being scanned using table sample strategy favour velocity over precision
 
 
 ### Example 1: Find the least common values in a field
@@ -44,3 +45,10 @@ PPL query:
     | M        | 33    |
     | M        | 36    |
     +----------+-------+
+
+### Example 3: Find the least common values using 50 % sampling strategy
+
+PPL query:
+
+    os> source=accounts | rare age sample(50 percent);
+    fetched rows / total rows = 2/4

--- a/docs/ppl-lang/ppl-top-command.md
+++ b/docs/ppl-lang/ppl-top-command.md
@@ -5,11 +5,12 @@ Using ``top`` command to find the most common tuple of values of all fields in t
 
 
 ### Syntax
-`top [N] <field-list> [by-clause]`
+`top [N] <field-list> [by-clause] [sample(? percent)]`
 
 * N: number of results to return. **Default**: 10
 * field-list: mandatory. comma-delimited list of field names.
 * by-clause: optional. one or more fields to group the results by.
+* sample: optional. allows reducing the amount of fields being scanned using table sample strategy favour velocity over precision 
 
 
 ### Example 1: Find the most common values in a field
@@ -55,4 +56,13 @@ PPL query:
     | F        | 28    |
     | M        | 32    |
     +----------+-------+
+
+## Example 2: Find the most common values organized by gender using sample strategy
+
+The example finds most common age of all the accounts group by gender sample only 50 % of rows.
+
+PPL query:
+
+    os> source=accounts | top 1 age by gender sample(50 percent);
+    fetched rows / total rows = 1/2
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLGrokITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLGrokITSuite.scala
@@ -35,7 +35,7 @@ class FlintSparkPPLGrokITSuite
       job.awaitTermination()
     }
   }
-  
+
   test("test grok email expressions parsing") {
     val frame = sql(s"""
          | source = $testTable| grok email '.+@%{HOSTNAME:host}' | fields email, host

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLGrokITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLGrokITSuite.scala
@@ -35,49 +35,7 @@ class FlintSparkPPLGrokITSuite
       job.awaitTermination()
     }
   }
-
-  test("test grok hostname | head ") {
-    val frame = sql(s"""
-         | source = $testTable| grok email '.+@%{HOSTNAME:host}'| sort host | head 5
-         | """.stripMargin)
-
-    // Retrieve the results
-    val results: Array[Row] = frame.collect()
-    // Define the expected results
-    val expectedResults: Array[Row] = Array(
-      Row("david@anotherdomain.com", "anotherdomain.com"),
-      Row("grace@demo.net", "demo.net"),
-      Row("hank@demonstration.com", "demonstration.com"),
-      Row("charlie@domain.net", "domain.net"),
-      Row("alice@example.com", "example.com"))
-
-    // Compare the results
-    implicit val rowOrdering: Ordering[Row] = Ordering.by[Row, String](_.getAs[String](0))
-    assert(results.sorted.sameElements(expectedResults.sorted))
-
-    // Retrieve the logical plan
-    val logicalPlan: LogicalPlan = frame.queryExecution.logical
-
-    val emailAttribute = UnresolvedAttribute("email")
-    val hostExpression = Alias(
-      RegExpExtract(
-        emailAttribute,
-        Literal(
-          ".+@(?<name0>\\b(?:[0-9A-Za-z][0-9A-Za-z-]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-]{0,62}))*(\\.?|\\b))"),
-        Literal("1")),
-      "host")()
-    val expectedPlan = Project(
-      Seq(UnresolvedStar(None)),
-      GlobalLimit(
-        Literal(1000),
-        LocalLimit(
-          Literal(1000),
-          Project(
-            Seq(emailAttribute, hostExpression, UnresolvedStar(None)),
-            UnresolvedRelation(Seq("accounts"))))))
-    assert(compareByString(expectedPlan) === compareByString(logicalPlan))
-  }
-
+  
   test("test grok email expressions parsing") {
     val frame = sql(s"""
          | source = $testTable| grok email '.+@%{HOSTNAME:host}' | fields email, host

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLGrokITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLGrokITSuite.scala
@@ -38,7 +38,7 @@ class FlintSparkPPLGrokITSuite
 
   test("test grok hostname | head ") {
     val frame = sql(s"""
-         | source = $testTable| grok email '.+@%{HOSTNAMES:host}'| sort host | head 5
+         | source = $testTable| grok email '.+@%{HOSTNAME:host}'| sort host | head 5
          | """.stripMargin)
 
     // Retrieve the results

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLTopAndRareITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLTopAndRareITSuite.scala
@@ -83,7 +83,7 @@ class FlintSparkPPLTopAndRareITSuite
     val expectedPlan = Project(projectList, sortedPlan)
     comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
   }
-  
+
   test("create ppl rare address field query test sample 75 %") {
     val frame = sql(s"""
          | source = $testTable| rare address sample(75 percent)
@@ -159,10 +159,7 @@ class FlintSparkPPLTopAndRareITSuite
     val aggregateExpressions = Seq(countExpr, addressField, ageAlias)
     val table = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test"))
     val aggregatePlan =
-      Aggregate(
-        Seq(addressField, ageAlias),
-        aggregateExpressions,
-        table)
+      Aggregate(Seq(addressField, ageAlias), aggregateExpressions, table)
 
     val sortedPlan: LogicalPlan =
       Sort(
@@ -178,7 +175,7 @@ class FlintSparkPPLTopAndRareITSuite
     val expectedPlan = Project(projectList, sortedPlan)
     comparePlans(expectedPlan, logicalPlan, false)
   }
-  
+
   test("create ppl rare address by age field query test sample 75 %") {
     val frame = sql(s"""
          | source = $testTable| rare address by age sample(75 percent)
@@ -321,7 +318,7 @@ class FlintSparkPPLTopAndRareITSuite
     val expectedPlan = Project(Seq(UnresolvedStar(None)), planWithLimit)
     comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
   }
-  
+
   test("create ppl top 3 countries query test sample 75 %") {
     val frame = sql(s"""
          | source = $newTestTable| top 3 country sample(75 percent)
@@ -392,10 +389,7 @@ class FlintSparkPPLTopAndRareITSuite
     val aggregateExpressions = Seq(countExpr, countryField, occupationFieldAlias)
     val table = UnresolvedRelation(Seq("spark_catalog", "default", "new_flint_ppl_test"))
     val aggregatePlan =
-      Aggregate(
-        Seq(countryField, occupationFieldAlias),
-        aggregateExpressions,
-        table)
+      Aggregate(Seq(countryField, occupationFieldAlias), aggregateExpressions, table)
 
     val sortedPlan: LogicalPlan =
       Sort(
@@ -414,7 +408,7 @@ class FlintSparkPPLTopAndRareITSuite
     comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
 
   }
-  
+
   test("create ppl top 2 countries by occupation field query test sample 85 %") {
     val frame = sql(s"""
          | source = $newTestTable| top 3 country by occupation sample(85 percent)
@@ -423,7 +417,7 @@ class FlintSparkPPLTopAndRareITSuite
     // Retrieve the results
     val results: Array[Row] = frame.collect()
     assert(results.length == 3)
-    
+
     // Retrieve the logical plan
     val logicalPlan: LogicalPlan = frame.queryExecution.logical
     val countryField = UnresolvedAttribute("country")

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLLexer.g4
@@ -24,6 +24,7 @@ SORT:                               'SORT';
 EVAL:                               'EVAL';
 HEAD:                               'HEAD';
 TOP:                                'TOP';
+SAMPLE:                             'SAMPLE';
 RARE:                               'RARE';
 PARSE:                              'PARSE';
 METHOD:                             'METHOD';
@@ -78,6 +79,7 @@ DESC:                               'DESC';
 DATASOURCES:                        'DATASOURCES';
 USING:                              'USING';
 WITH:                               'WITH';
+PERCENT:                            'PERCENT';
 
 // FIELD KEYWORDS
 AUTO:                               'AUTO';

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -177,12 +177,16 @@ headCommand
    : HEAD (number = integerLiteral)? (FROM from = integerLiteral)?
    ;
 
+sampleClause
+   : SAMPLE '(' (percentage = integerLiteral PERCENT ) ')'
+   ;
+
 topCommand
-   : TOP (number = integerLiteral)? fieldList (byClause)?
+   : TOP (number = integerLiteral)? fieldList (byClause)? (sampleClause)?
    ;
 
 rareCommand
-   : RARE fieldList (byClause)?
+   : RARE fieldList (byClause)? (sampleClause)?
    ;
 
 grokCommand

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Aggregation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Aggregation.java
@@ -31,7 +31,7 @@ public class Aggregation extends UnresolvedPlan {
   private UnresolvedExpression span;
   private List<Argument> argExprList;
   private UnresolvedPlan child;
-  private Optional<TablesampleContext> sample;
+  private Optional<TablesampleContext> sample = Optional.empty();
   
   /** Aggregation Constructor without span and argument. */
   public Aggregation(

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Aggregation.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Aggregation.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,6 +17,7 @@ import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /** Logical plan node of Aggregation, the interface for building aggregation actions in queries. */
 @Getter
@@ -29,7 +31,8 @@ public class Aggregation extends UnresolvedPlan {
   private UnresolvedExpression span;
   private List<Argument> argExprList;
   private UnresolvedPlan child;
-
+  private Optional<TablesampleContext> sample;
+  
   /** Aggregation Constructor without span and argument. */
   public Aggregation(
       List<UnresolvedExpression> aggExprList,
@@ -71,4 +74,14 @@ public class Aggregation extends UnresolvedPlan {
   public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
     return nodeVisitor.visitAggregation(this, context);
   }
+
+  @Getter
+  @Setter
+  @ToString
+  @EqualsAndHashCode(callSuper = false)
+  @AllArgsConstructor
+  public static class TablesampleContext {
+    public int percentage;
+  }
+
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
@@ -326,10 +326,10 @@ public class CatalystQueryPlanVisitor extends AbstractNodeVisitor<LogicalPlan, C
         if ((node instanceof TopAggregation) && ((TopAggregation) node).getResults().isPresent()) {
             context.apply(p -> (LogicalPlan) Limit.apply(new org.apache.spark.sql.catalyst.expressions.Literal(
                     ((TopAggregation) node).getResults().get().getValue(), org.apache.spark.sql.types.DataTypes.IntegerType), p));
-            //add sample context (if exists) to the plan context
-            if(node.getSample().isPresent()) {
-                context.withSamplePercentage(node.getSample().get().getPercentage());
-            }
+        }
+        //add sample context (if exists) to the plan context
+        if(node.getSample().isPresent()) {
+            context.withSamplePercentage(node.getSample().get().getPercentage());
         }
         return logicalPlan;
     }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
@@ -136,7 +136,7 @@ public class CatalystQueryPlanVisitor extends AbstractNodeVisitor<LogicalPlan, C
 
     @Override
     public LogicalPlan visitExplain(Explain node, CatalystPlanContext context) {
-        visitChild(node, context);
+        node.getStatement().accept(this, context);
         return context.apply(p -> new ExplainCommand(p, ExplainMode.fromString(node.getExplainMode().name())));
     }
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -21,6 +21,7 @@ import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.EqualTo;
 import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.tree.Aggregation.TablesampleContext;
 import org.opensearch.sql.ast.tree.FieldSummary;
 import org.opensearch.sql.ast.expression.FieldsMapping;
 import org.opensearch.sql.ast.expression.Let;
@@ -448,6 +449,10 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
                     aggListBuilder.build(),
                     aggListBuilder.build(),
                     groupListBuilder.build());
+    if(ctx.sampleClause()!=null) {
+      int percentage = Integer.parseInt(ctx.sampleClause().percentage.getText());
+      aggregation.setSample(Optional.of(new TablesampleContext(percentage)));
+    }
     return aggregation;
   }
 
@@ -493,6 +498,10 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
                     aggListBuilder.build(),
                     aggListBuilder.build(),
                     groupListBuilder.build());
+    if(ctx.sampleClause()!=null) {
+      int percentage = Integer.parseInt(ctx.sampleClause().percentage.getText());
+      aggregation.setSample(Optional.of(new TablesampleContext(percentage)));
+    }
     return aggregation;
   }
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/RelationUtils.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/RelationUtils.java
@@ -13,6 +13,7 @@ import scala.Option$;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface RelationUtils {
     /**

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanTopAndRareQueriesTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanTopAndRareQueriesTranslatorTestSuite.scala
@@ -97,12 +97,14 @@ class PPLLogicalPlanTopAndRareQueriesTranslatorTestSuite
     val expectedPlan = Project(projectList, sortedPlan)
     comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
   }
-  
+
   test("test simple rare command with a by field test percentage") {
     // if successful build ppl logical plan and translate to catalyst logical plan
     val context = new CatalystPlanContext
     val logicalPlan =
-      planTransformer.visit(plan(pplParser, "source=accounts | rare address by age sample(50 percent)"), context)
+      planTransformer.visit(
+        plan(pplParser, "source=accounts | rare address by age sample(50 percent)"),
+        context)
     // Retrieve the logical plan
     // Define the expected logical plan
     val addressField = UnresolvedAttribute("address")
@@ -120,13 +122,7 @@ class PPLLogicalPlanTopAndRareQueriesTranslatorTestSuite
       Aggregate(
         Seq(addressField, ageAlias),
         aggregateExpressions,
-        Sample(
-          0,
-          0.5,
-          withReplacement = false,
-          0,
-          UnresolvedRelation(Seq("accounts")))
-      )
+        Sample(0, 0.5, withReplacement = false, 0, UnresolvedRelation(Seq("accounts"))))
 
     val sortedPlan: LogicalPlan =
       Sort(
@@ -250,12 +246,14 @@ class PPLLogicalPlanTopAndRareQueriesTranslatorTestSuite
     val expectedPlan = Project(Seq(UnresolvedStar(None)), planWithLimit)
     comparePlans(expectedPlan, logPlan, false)
   }
-  
+
   test("test simple top 5 command by age field sample(25 percent)") {
     // if successful build ppl logical plan and translate to catalyst logical plan
     val context = new CatalystPlanContext
     val logPlan =
-      planTransformer.visit(plan(pplParser, "source=accounts | top 5 address by age sample(25 percent)"), context)
+      planTransformer.visit(
+        plan(pplParser, "source=accounts | top 5 address by age sample(25 percent)"),
+        context)
 
     val addressField = UnresolvedAttribute("address")
     val ageField = UnresolvedAttribute("age")
@@ -269,13 +267,7 @@ class PPLLogicalPlanTopAndRareQueriesTranslatorTestSuite
       Aggregate(
         Seq(addressField, ageAlias),
         aggregateExpressions,
-        Sample(
-          0,
-          0.25,
-          withReplacement = false,
-          0,
-          UnresolvedRelation(Seq("accounts")))
-      )
+        Sample(0, 0.25, withReplacement = false, 0, UnresolvedRelation(Seq("accounts"))))
 
     val sortedPlan: LogicalPlan =
       Sort(


### PR DESCRIPTION
### Description
Add a new sample command (`sample`) to reduce amount of scanned data points and allow approximation of a `top` or `rare` statements when faster sample based results if favour of exact long running results 

```sql
source = testTable  | rare address sample(50 percent)
source = testTable  | top 5 address by country sample(25 percent)
```

### Issues Resolved
- https://github.com/opensearch-project/opensearch-spark/issues/740

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
