### PR TITLE
Enable HTML test report

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -27,3 +27,10 @@ jobs:
 
       - name: Integ Test
         run: sbt integtest/integration
+
+      - name: Upload test report
+        if: always() # Ensures the artifact is saved even if tests fail
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-reports
+          path: target/test-reports # Adjust this path if necessary

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -26,6 +26,7 @@ jobs:
         run: sbt scalafmtCheckAll
 
       - name: Set SBT_OPTS
+        # Needed to extend the JVM memory size to avoid OutOfMemoryError for HTML test report
         run: echo "SBT_OPTS=-Xmx2G" >> $GITHUB_ENV
 
       - name: Integ Test

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Style check
         run: sbt scalafmtCheckAll
 
+      - name: Set SBT_OPTS
+        run: echo "SBT_OPTS=-Xmx2G" >> $GITHUB_ENV
+
       - name: Integ Test
         run: sbt integtest/integration
 

--- a/build.sbt
+++ b/build.sbt
@@ -181,8 +181,6 @@ lazy val pplSparkIntegration = (project in file("ppl-spark-integration"))
         val oldStrategy = (assembly / assemblyMergeStrategy).value
         oldStrategy(x)
     },
-    Test / fork := true,
-    Test / javaOptions += "-Xmx2G",
     assembly / test := (Test / test).value)
 
 lazy val flintSparkIntegration = (project in file("flint-spark-integration"))

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,6 @@ lazy val commonSettings = Seq(
   // Enable HTML report and output to separate folder per package
   Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-h", s"target/test-reports/${name.value}"),
   Test / test := ((Test / test) dependsOn testScalastyle).value,
-  Test / javaOptions += "-Xmx2G",
   // Needed for HTML report
   libraryDependencies += "com.vladsch.flexmark" % "flexmark-all" % "0.64.8",
   dependencyOverrides ++= Seq(
@@ -182,6 +181,8 @@ lazy val pplSparkIntegration = (project in file("ppl-spark-integration"))
         val oldStrategy = (assembly / assemblyMergeStrategy).value
         oldStrategy(x)
     },
+    Test / fork := true,
+    Test / javaOptions += "-Xmx2G",
     assembly / test := (Test / test).value)
 
 lazy val flintSparkIntegration = (project in file("flint-spark-integration"))

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ lazy val commonSettings = Seq(
   Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-h", s"target/test-reports/${name.value}"),
   Test / test := ((Test / test) dependsOn testScalastyle).value,
   // Needed for HTML report
-  libraryDependencies += "com.vladsch.flexmark" % "flexmark-all" % "0.64.8",
+  libraryDependencies += "com.vladsch.flexmark" % "flexmark-all" % "0.64.8" % "test",
   dependencyOverrides ++= Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,11 @@ lazy val commonSettings = Seq(
   compileScalastyle := (Compile / scalastyle).toTask("").value,
   Compile / compile := ((Compile / compile) dependsOn compileScalastyle).value,
   testScalastyle := (Test / scalastyle).toTask("").value,
+  // Enable HTML report and output to separate folder per package
+  Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-h", s"target/test-reports/${name.value}"),
   Test / test := ((Test / test) dependsOn testScalastyle).value,
+  // Needed for HTML report
+  libraryDependencies += "com.vladsch.flexmark" % "flexmark-all" % "0.64.8",
   dependencyOverrides ++= Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ lazy val commonSettings = Seq(
   // Enable HTML report and output to separate folder per package
   Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-h", s"target/test-reports/${name.value}"),
   Test / test := ((Test / test) dependsOn testScalastyle).value,
+  Test / javaOptions += "-Xmx2G",
   // Needed for HTML report
   libraryDependencies += "com.vladsch.flexmark" % "flexmark-all" % "0.64.8",
   dependencyOverrides ++= Seq(


### PR DESCRIPTION
### Description
- Enable HTML test report for easier debug in case of test failure
  - Test output will be available in the page for failed test cases.
- The result would be uploaded as artifact and can be downloaded as ZIP file
- The report will be stored in separate folder per package

Sample Image:
<img width="996" alt="Screenshot 2024-11-12 at 16 38 26" src="https://github.com/user-attachments/assets/c37f9fab-63fb-4eaf-9433-1a32c9aca7f1">

### Related Issues
n/a

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
