### PR TITLE
Support flatten with alias

### DIFF
--- a/docs/ppl-lang/PPL-Example-Commands.md
+++ b/docs/ppl-lang/PPL-Example-Commands.md
@@ -140,6 +140,7 @@ Assumptions: `a`, `b`, `c`, `d`, `e` are existing fields in `table`
 Assumptions: `bridges`, `coor` are existing fields in `table`, and the field's types are `struct<?,?>` or `array<struct<?,?>>`  
 - `source = table | flatten bridges`
 - `source = table | flatten coor`
+- `source = table | flatten coor as (altitude, latitude, longitude)`
 - `source = table | flatten bridges | flatten coor`
 - `source = table | fields bridges | flatten bridges`
 - `source = table | fields country, bridges | flatten bridges | fields country, length | stats avg(length) as avg by country`

--- a/docs/ppl-lang/ppl-flatten-command.md
+++ b/docs/ppl-lang/ppl-flatten-command.md
@@ -7,9 +7,10 @@ Using `flatten` command to flatten a field of type:
 
 
 ### Syntax
-`flatten <field>`
+`flatten <field> [As alias]`
 
 * field: to be flattened. The field must be of supported type.
+* alias: to be used as alias for the flattened-output fields. Need to put the alias in brace if there is more than one field.
 
 ### Test table
 #### Schema
@@ -88,3 +89,17 @@ PPL query:
 | 2024-09-13T12:00:00 | Budapest| Hungary       | 375    | Chain Bridge      | 96   | 47.4979| 19.0402|
 | 2024-09-13T12:00:00 | Budapest| Hungary       | 333    | Liberty Bridge    | 96   | 47.4979| 19.0402|
 | 1990-09-13T12:00:00 | Warsaw  | Poland        | NULL   | NULL              | NULL | NULL   | NULL   |
+
+### Example 4: flatten with alias
+This example shows how to flatten with alias.
+PPL query:
+    - `source=table | flatten coor as (altitude, latitude, longitude)`
+
+| \_time              | bridges                                      | city    | country       | altitude | latitude | longtitude |
+|---------------------|----------------------------------------------|---------|---------------|----------|----------|------------|
+| 2024-09-13T12:00:00 | [{801, Tower Bridge}, {928, London Bridge}]  | London  | England       | 35       | 51.5074  | -0.1278    |
+| 2024-09-13T12:00:00 | [{232, Pont Neuf}, {160, Pont Alexandre III}]| Paris   | France        | 35       | 48.8566  | 2.3522     |
+| 2024-09-13T12:00:00 | [{48, Rialto Bridge}, {11, Bridge of Sighs}] | Venice  | Italy         | 2        | 45.4408  | 12.3155    |
+| 2024-09-13T12:00:00 | [{516, Charles Bridge}, {343, Legion Bridge}]| Prague  | Czech Republic| 200      | 50.0755  | 14.4378    |
+| 2024-09-13T12:00:00 | [{375, Chain Bridge}, {333, Liberty Bridge}] | Budapest| Hungary       | 96       | 47.4979  | 19.0402    |
+| 1990-09-13T12:00:00 | NULL                                         | Warsaw  | Poland        | NULL     | NULL     | NULL       |

--- a/docs/ppl-lang/ppl-flatten-command.md
+++ b/docs/ppl-lang/ppl-flatten-command.md
@@ -7,10 +7,10 @@ Using `flatten` command to flatten a field of type:
 
 
 ### Syntax
-`flatten <field> [As alias]`
+`flatten <field> [As aliasSequence]`
 
 * field: to be flattened. The field must be of supported type.
-* alias: to be used as alias for the flattened-output fields. Need to put the alias in brace if there is more than one field.
+* aliasSequence: to be used as aliasSequence for the flattened-output fields. Better to put the aliasSequence in brace if there is more than one field.
 
 ### Test table
 #### Schema
@@ -90,8 +90,8 @@ PPL query:
 | 2024-09-13T12:00:00 | Budapest| Hungary       | 333    | Liberty Bridge    | 96   | 47.4979| 19.0402|
 | 1990-09-13T12:00:00 | Warsaw  | Poland        | NULL   | NULL              | NULL | NULL   | NULL   |
 
-### Example 4: flatten with alias
-This example shows how to flatten with alias.
+### Example 4: flatten with aliasSequence
+This example shows how to flatten with aliasSequence.
 PPL query:
     - `source=table | flatten coor as (altitude, latitude, longitude)`
 

--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -259,7 +259,7 @@ expandCommand
     ;
     
 flattenCommand
-    : FLATTEN fieldExpression
+    : FLATTEN fieldExpression (AS alias = identifierSeq)?
     ;
 
 trendlineCommand
@@ -1030,6 +1030,11 @@ valueList
 
 qualifiedName
    : ident (DOT ident)* # identsAsQualifiedName
+   ;
+
+identifierSeq
+   : qualifiedName (COMMA qualifiedName)* # identsAsQualifiedNameSeq
+   | LT_PRTHS qualifiedName (COMMA qualifiedName)* RT_PRTHS # identsAsQualifiedNameSeq
    ;
 
 tableQualifiedName

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Flatten.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Flatten.java
@@ -17,7 +17,7 @@ public class Flatten extends UnresolvedPlan {
     @Getter
     private final Field field;
     @Getter
-    private final List<UnresolvedExpression> aliases;
+    private final List<UnresolvedExpression> aliasSequence;
 
     @Override
     public UnresolvedPlan attach(UnresolvedPlan child) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Flatten.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Flatten.java
@@ -7,6 +7,7 @@ import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.Field;
 
 import java.util.List;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
 @RequiredArgsConstructor
 public class Flatten extends UnresolvedPlan {
@@ -15,6 +16,8 @@ public class Flatten extends UnresolvedPlan {
 
     @Getter
     private final Field field;
+    @Getter
+    private final List<UnresolvedExpression> alias;
 
     @Override
     public UnresolvedPlan attach(UnresolvedPlan child) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Flatten.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/tree/Flatten.java
@@ -17,7 +17,7 @@ public class Flatten extends UnresolvedPlan {
     @Getter
     private final Field field;
     @Getter
-    private final List<UnresolvedExpression> alias;
+    private final List<UnresolvedExpression> aliases;
 
     @Override
     public UnresolvedPlan attach(UnresolvedPlan child) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
@@ -10,7 +10,6 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedStar$;
 import org.apache.spark.sql.catalyst.expressions.Ascending$;
-import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.Descending$;
 import org.apache.spark.sql.catalyst.expressions.Explode;
 import org.apache.spark.sql.catalyst.expressions.Expression;
@@ -85,12 +84,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.List.of;
-import static org.opensearch.sql.ppl.CatalystPlanContext.findRelation;
 import static org.opensearch.sql.ppl.utils.DataTypeTransformer.seq;
 import static org.opensearch.sql.ppl.utils.DedupeTransformer.retainMultipleDuplicateEvents;
 import static org.opensearch.sql.ppl.utils.DedupeTransformer.retainMultipleDuplicateEventsAndKeepEmpty;
@@ -463,7 +460,7 @@ public class CatalystQueryPlanVisitor extends AbstractNodeVisitor<LogicalPlan, C
             context.getNamedParseExpressions().push(UnresolvedStar$.MODULE$.apply(Option.<Seq<String>>empty()));
         }
         Expression field = visitExpression(flatten.getField(), context);
-        List<Expression> alias = flatten.getAlias().stream()
+        List<Expression> alias = flatten.getAliases().stream()
             .map(aliasNode -> visitExpression(aliasNode, context))
             .collect(Collectors.toList());
         context.retainAllNamedParseExpressions(p -> (NamedExpression) p);

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
@@ -460,7 +460,7 @@ public class CatalystQueryPlanVisitor extends AbstractNodeVisitor<LogicalPlan, C
             context.getNamedParseExpressions().push(UnresolvedStar$.MODULE$.apply(Option.<Seq<String>>empty()));
         }
         Expression field = visitExpression(flatten.getField(), context);
-        List<Expression> alias = flatten.getAliases().stream()
+        List<Expression> alias = flatten.getAliasSequence().stream()
             .map(aliasNode -> visitExpression(aliasNode, context))
             .collect(Collectors.toList());
         context.retainAllNamedParseExpressions(p -> (NamedExpression) p);

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -18,6 +18,7 @@ import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.And;
 import org.opensearch.sql.ast.expression.Argument;
+import org.opensearch.sql.ast.expression.AttributeList;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.EqualTo;
 import org.opensearch.sql.ast.expression.Field;
@@ -605,7 +606,8 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   @Override
   public UnresolvedPlan visitFlattenCommand(OpenSearchPPLParser.FlattenCommandContext ctx) {
     Field unresolvedExpression = (Field) internalVisitExpression(ctx.fieldExpression());
-    return new Flatten(unresolvedExpression);
+    List<UnresolvedExpression> alias = ctx.alias == null ? emptyList() : ((AttributeList) internalVisitExpression(ctx.alias)).getAttrList();
+    return new Flatten(unresolvedExpression, alias);
   }
 
   /** AD command. */

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -330,6 +330,11 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     }
 
     @Override
+    public UnresolvedExpression visitIdentsAsQualifiedNameSeq(OpenSearchPPLParser.IdentsAsQualifiedNameSeqContext ctx) {
+        return new AttributeList(ctx.qualifiedName().stream().map(this::visit).collect(Collectors.toList()));
+    }
+
+    @Override
     public UnresolvedExpression visitIdentsAsTableQualifiedName(
             OpenSearchPPLParser.IdentsAsTableQualifiedNameContext ctx) {
         return visitIdentifiers(


### PR DESCRIPTION
### Description
Support flatten with alias. e.g.
```
source=table | flatten coor as (altitude, latitude, longitude)

source=table | flatten struct as subfield 
```

### Related Issues
Resolve #911 

We can use alias to avoid duplicate column name in the final result.

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
