### PR TITLE
Rethrow exception in writeData()

### DIFF
--- a/flint-core/src/main/java/org/opensearch/flint/core/IRestHighLevelClient.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/IRestHighLevelClient.java
@@ -98,15 +98,15 @@ public interface IRestHighLevelClient extends Closeable {
      * Otherwise, it increments a general failure metric counter based on the status code category (e.g., 4xx, 5xx).
      *
      * @param metricNamePrefix the prefix for the metric name which is used to construct the full metric name for failure
-     * @param e                the exception encountered during the operation, used to determine the type of failure
+     * @param t                the exception encountered during the operation, used to determine the type of failure
      */
-    static void recordOperationFailure(String metricNamePrefix, Exception e) {
-        OpenSearchException openSearchException = extractOpenSearchException(e);
+    static void recordOperationFailure(String metricNamePrefix, Throwable t) {
+        OpenSearchException openSearchException = extractOpenSearchException(t);
         int statusCode = openSearchException != null ? openSearchException.status().getStatus() : 500;
         if (openSearchException != null) {
             CustomLogging.logError(new OperationMessage("OpenSearch Operation failed.", statusCode), openSearchException);
         } else {
-            CustomLogging.logError("OpenSearch Operation failed with an exception.", e);
+            CustomLogging.logError("OpenSearch Operation failed with an exception.", t);
         }
         if (statusCode == 403) {
             String forbiddenErrorMetricName = metricNamePrefix + ".403.count";

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -168,10 +168,12 @@ trait FlintJobExecutor {
       IRestHighLevelClient.recordOperationSuccess(
         MetricConstants.RESULT_METADATA_WRITE_METRIC_PREFIX)
     } catch {
-      case e: Exception =>
+      case t: Throwable =>
         IRestHighLevelClient.recordOperationFailure(
           MetricConstants.RESULT_METADATA_WRITE_METRIC_PREFIX,
-          e)
+          t)
+        // Re-throw the exception
+        throw t
     }
   }
 


### PR DESCRIPTION
### Description
Rethrow exception in writeData() so that this can be recorded at top level

```
      try {
        dataToWrite.foreach(df => writeDataFrameToOpensearch(df, resultIndex, osClient))
      } catch {
        case t: Throwable =>
          throwableHandler.recordThrowable(
            s"Failed to write to result index. originalError='${throwableHandler.error}'",
            t)
      }
```

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
