### PR TITLE
Enhance CV and MV idempotency via deterministic ID generation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -394,6 +394,7 @@ User can provide the following options in `WITH` clause of create statement:
 + `watermark_delay`: a string as time expression for how late data can come and still be processed, e.g. 1 minute, 10 seconds. This is required by auto and incremental refresh on materialized view if it has aggregation in the query.
 + `output_mode`: a mode string that describes how data will be written to streaming sink. If unspecified, default append mode will be applied.
 + `index_settings`: a JSON string as index settings for OpenSearch index that will be created. Please follow the format in OpenSearch documentation. If unspecified, default OpenSearch index settings will be applied.
++ `id_expression`: an expression string that generates an ID column to avoid duplicate data when index refresh job restart or any retry attempt during an index refresh. If an empty string is provided, no ID column will be generated.
 + `extra_options`: a JSON string as extra options that can be passed to Spark streaming source and sink API directly. Use qualified source table name (because there could be multiple) and "sink", e.g. '{"sink": "{key: val}", "table1": {key: val}}'
 
 Note that the index option name is case-sensitive. Here is an example:
@@ -406,6 +407,7 @@ WITH (
   watermark_delay = '1 Second',
   output_mode = 'complete',
   index_settings = '{"number_of_shards": 2, "number_of_replicas": 3}',
+  id_expression = 'uuid()',
   extra_options = '{"spark_catalog.default.alb_logs": {"maxFilesPerTrigger": "1"}}'
 )
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -394,7 +394,7 @@ User can provide the following options in `WITH` clause of create statement:
 + `watermark_delay`: a string as time expression for how late data can come and still be processed, e.g. 1 minute, 10 seconds. This is required by auto and incremental refresh on materialized view if it has aggregation in the query.
 + `output_mode`: a mode string that describes how data will be written to streaming sink. If unspecified, default append mode will be applied.
 + `index_settings`: a JSON string as index settings for OpenSearch index that will be created. Please follow the format in OpenSearch documentation. If unspecified, default OpenSearch index settings will be applied.
-+ `id_expression`: an expression string that generates an ID column to avoid duplicate data when index refresh job restart or any retry attempt during an index refresh. If an empty string is provided, no ID column will be generated.
++ `id_expression`: an expression string that generates an ID column to guarantee idempotency when index refresh job restart or any retry attempt during an index refresh. If an empty string is provided, no ID column will be generated.
 + `extra_options`: a JSON string as extra options that can be passed to Spark streaming source and sink API directly. Use qualified source table name (because there could be multiple) and "sink", e.g. '{"sink": "{key: val}", "table1": {key: val}}'
 
 Note that the index option name is case-sensitive. Here is an example:
@@ -407,7 +407,7 @@ WITH (
   watermark_delay = '1 Second',
   output_mode = 'complete',
   index_settings = '{"number_of_shards": 2, "number_of_replicas": 3}',
-  id_expression = 'uuid()',
+  id_expression = "sha1(concat_ws('\0',startTime,status))",
   extra_options = '{"spark_catalog.default.alb_logs": {"maxFilesPerTrigger": "1"}}'
 )
 ```

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -155,7 +155,7 @@ object FlintSparkIndex {
           }
         }
 
-        // TODO: use only grouping columns
+        // TODO: 1) use only grouping columns; 2) ensure aggregation is on top level
         df.withColumn(ID_COLUMN, sha1(concat_ws("\0", allOutputCols: _*)))
 
       case _ => df

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -14,6 +14,7 @@ import org.opensearch.flint.core.metadata.FlintJsonHelper._
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate
+import org.apache.spark.sql.catalyst.util.quoteIfNeeded
 import org.apache.spark.sql.flint.datatype.FlintDataType
 import org.apache.spark.sql.functions.{col, concat_ws, expr, sha1, to_json}
 import org.apache.spark.sql.types.{MapType, StructType}
@@ -150,9 +151,9 @@ object FlintSparkIndex extends Logging {
         val allOutputCols = df.schema.fields.map { field =>
           field.dataType match {
             case _: StructType | _: MapType =>
-              to_json(col(field.name))
+              to_json(col(quoteIfNeeded(field.name)))
             case _ =>
-              col(field.name)
+              col(quoteIfNeeded(field.name))
           }
         }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -120,12 +120,7 @@ object FlintSparkIndex extends Logging {
   }
 
   /**
-   * Generate an ID column in the precedence below:
-   * ```
-   * 1. Use ID expression provided in the index option;
-   * 2. SHA-1 based on all output columns if aggregated;
-   * 3. Otherwise, no ID column generated.
-   * ```
+   * Generate an ID column using ID expression provided in the index option.
    *
    * @param df
    *   which DataFrame to generate ID column

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -11,8 +11,9 @@ import org.opensearch.flint.common.metadata.FlintMetadata
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.core.metadata.FlintJsonHelper._
 
-import org.apache.spark.sql.{Column, DataFrame, SparkSession}
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate
 import org.apache.spark.sql.flint.datatype.FlintDataType
 import org.apache.spark.sql.functions.{col, concat_ws, expr, sha1, to_json}
 import org.apache.spark.sql.types.{MapType, StructType}
@@ -64,7 +65,7 @@ trait FlintSparkIndex {
   def build(spark: SparkSession, df: Option[DataFrame]): DataFrame
 }
 
-object FlintSparkIndex {
+object FlintSparkIndex extends Logging {
 
   /**
    * Interface indicates a Flint index has custom streaming refresh capability other than foreach
@@ -134,13 +135,13 @@ object FlintSparkIndex {
    * @return
    *   DataFrame with/without ID column
    */
-  def generateIdColumn(df: DataFrame, options: FlintSparkIndexOptions): DataFrame = {
-    // Assume output rows must be unique if a simple query plan has aggregate operator
+  def addIdColumn(df: DataFrame, options: FlintSparkIndexOptions): DataFrame = {
     def isAggregated: Boolean =
       df.queryExecution.logical.exists(_.isInstanceOf[Aggregate])
 
     options.idExpression() match {
       case Some(idExpr) if idExpr.nonEmpty =>
+        logInfo(s"Using user-provided ID expression: $idExpr")
         df.withColumn(ID_COLUMN, expr(idExpr))
 
       case None if isAggregated =>
@@ -156,7 +157,9 @@ object FlintSparkIndex {
         }
 
         // TODO: 1) use only grouping columns; 2) ensure aggregation is on top level
-        df.withColumn(ID_COLUMN, sha1(concat_ws("\0", allOutputCols: _*)))
+        val idCol = sha1(concat_ws("\0", allOutputCols: _*))
+        logInfo(s"Generated ID column for aggregated query: $idCol")
+        df.withColumn(ID_COLUMN, idCol)
 
       case _ => df
     }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
@@ -10,7 +10,7 @@ import java.util.{Collections, UUID}
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.native.JsonMethods._
 import org.json4s.native.Serialization
-import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.{AUTO_REFRESH, CHECKPOINT_LOCATION, EXTRA_OPTIONS, INCREMENTAL_REFRESH, INDEX_SETTINGS, OptionName, OUTPUT_MODE, REFRESH_INTERVAL, SCHEDULER_MODE, WATERMARK_DELAY}
+import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName.{AUTO_REFRESH, CHECKPOINT_LOCATION, EXTRA_OPTIONS, ID_EXPRESSION, INCREMENTAL_REFRESH, INDEX_SETTINGS, OptionName, OUTPUT_MODE, REFRESH_INTERVAL, SCHEDULER_MODE, WATERMARK_DELAY}
 import org.opensearch.flint.spark.FlintSparkIndexOptions.validateOptionNames
 import org.opensearch.flint.spark.refresh.FlintSparkIndexRefresh.SchedulerMode
 import org.opensearch.flint.spark.scheduler.util.IntervalSchedulerParser
@@ -95,6 +95,14 @@ case class FlintSparkIndexOptions(options: Map[String, String]) {
    *   index setting JSON
    */
   def indexSettings(): Option[String] = getOptionValue(INDEX_SETTINGS)
+
+  /**
+   * An expression that generates unique value as source data row ID.
+   *
+   * @return
+   *   ID expression
+   */
+  def idExpression(): Option[String] = getOptionValue(ID_EXPRESSION)
 
   /**
    * Extra streaming source options that can be simply passed to DataStreamReader or
@@ -187,6 +195,7 @@ object FlintSparkIndexOptions {
     val WATERMARK_DELAY: OptionName.Value = Value("watermark_delay")
     val OUTPUT_MODE: OptionName.Value = Value("output_mode")
     val INDEX_SETTINGS: OptionName.Value = Value("index_settings")
+    val ID_EXPRESSION: OptionName.Value = Value("id_expression")
     val EXTRA_OPTIONS: OptionName.Value = Value("extra_options")
   }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndexOptions.scala
@@ -97,7 +97,7 @@ case class FlintSparkIndexOptions(options: Map[String, String]) {
   def indexSettings(): Option[String] = getOptionValue(INDEX_SETTINGS)
 
   /**
-   * An expression that generates unique value as source data row ID.
+   * An expression that generates unique value as index data row ID.
    *
    * @return
    *   ID expression

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters.mapAsJavaMapConverter
 import org.opensearch.flint.common.metadata.FlintMetadata
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.spark._
-import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, generateSchema, metadataBuilder, quotedTableName}
+import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, generateIdColumn, generateSchema, metadataBuilder, quotedTableName, ID_COLUMN}
 import org.opensearch.flint.spark.FlintSparkIndexOptions.empty
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.{getFlintIndexName, COVERING_INDEX_TYPE}
 
@@ -71,10 +71,13 @@ case class FlintSparkCoveringIndex(
     val job = df.getOrElse(spark.read.table(quotedTableName(tableName)))
 
     // Add optional filtering condition
-    filterCondition
-      .map(job.where)
-      .getOrElse(job)
-      .select(colNames.head, colNames.tail: _*)
+    val batchDf =
+      filterCondition
+        .map(job.where)
+        .getOrElse(job)
+        .select(colNames.head, colNames.tail: _*)
+
+    generateIdColumn(batchDf, options)
   }
 }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndex.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters.mapAsJavaMapConverter
 import org.opensearch.flint.common.metadata.FlintMetadata
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.spark._
-import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, generateIdColumn, generateSchema, metadataBuilder, quotedTableName, ID_COLUMN}
+import org.opensearch.flint.spark.FlintSparkIndex.{addIdColumn, flintIndexNamePrefix, generateSchema, metadataBuilder, quotedTableName}
 import org.opensearch.flint.spark.FlintSparkIndexOptions.empty
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.{getFlintIndexName, COVERING_INDEX_TYPE}
 
@@ -77,7 +77,7 @@ case class FlintSparkCoveringIndex(
         .getOrElse(job)
         .select(colNames.head, colNames.tail: _*)
 
-    generateIdColumn(batchDf, options)
+    addIdColumn(batchDf, options)
   }
 }
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -13,7 +13,7 @@ import scala.collection.convert.ImplicitConversions.`map AsScala`
 import org.opensearch.flint.common.metadata.FlintMetadata
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex, FlintSparkIndexBuilder, FlintSparkIndexOptions}
-import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, generateSchema, metadataBuilder, StreamingRefresh}
+import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, generateIdColumn, generateSchema, metadataBuilder, ID_COLUMN, StreamingRefresh}
 import org.opensearch.flint.spark.FlintSparkIndexOptions.empty
 import org.opensearch.flint.spark.function.TumbleFunction
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.{getFlintIndexName, MV_INDEX_TYPE}
@@ -81,7 +81,8 @@ case class FlintSparkMaterializedView(
   override def build(spark: SparkSession, df: Option[DataFrame]): DataFrame = {
     require(df.isEmpty, "materialized view doesn't support reading from other data frame")
 
-    spark.sql(query)
+    val batchDf = spark.sql(query)
+    generateIdColumn(batchDf, options)
   }
 
   override def buildStream(spark: SparkSession): DataFrame = {
@@ -99,7 +100,9 @@ case class FlintSparkMaterializedView(
       case relation: UnresolvedRelation if !relation.isStreaming =>
         relation.copy(isStreaming = true, options = optionsWithExtra(spark, relation))
     }
-    logicalPlanToDataFrame(spark, streamingPlan)
+
+    val streamingDf = logicalPlanToDataFrame(spark, streamingPlan)
+    generateIdColumn(streamingDf, options)
   }
 
   private def watermark(timeCol: Attribute, child: LogicalPlan) = {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedView.scala
@@ -13,7 +13,7 @@ import scala.collection.convert.ImplicitConversions.`map AsScala`
 import org.opensearch.flint.common.metadata.FlintMetadata
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndex, FlintSparkIndexBuilder, FlintSparkIndexOptions}
-import org.opensearch.flint.spark.FlintSparkIndex.{flintIndexNamePrefix, generateIdColumn, generateSchema, metadataBuilder, ID_COLUMN, StreamingRefresh}
+import org.opensearch.flint.spark.FlintSparkIndex.{addIdColumn, flintIndexNamePrefix, generateSchema, metadataBuilder, ID_COLUMN, StreamingRefresh}
 import org.opensearch.flint.spark.FlintSparkIndexOptions.empty
 import org.opensearch.flint.spark.function.TumbleFunction
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.{getFlintIndexName, MV_INDEX_TYPE}
@@ -82,7 +82,7 @@ case class FlintSparkMaterializedView(
     require(df.isEmpty, "materialized view doesn't support reading from other data frame")
 
     val batchDf = spark.sql(query)
-    generateIdColumn(batchDf, options)
+    addIdColumn(batchDf, options)
   }
 
   override def buildStream(spark: SparkSession): DataFrame = {
@@ -102,7 +102,7 @@ case class FlintSparkMaterializedView(
     }
 
     val streamingDf = logicalPlanToDataFrame(spark, streamingPlan)
-    generateIdColumn(streamingDf, options)
+    addIdColumn(streamingDf, options)
   }
 
   private def watermark(timeCol: Attribute, child: LogicalPlan) = {

--- a/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
@@ -72,8 +72,20 @@ trait FlintSuite extends SharedSparkSession {
     }
   }
 
+  /**
+   * Implicit class to extend DataFrame functionality with additional utilities.
+   *
+   * @param df
+   *   the DataFrame to which the additional methods are added
+   */
   protected implicit class DataFrameExtensions(val df: DataFrame) {
 
+    /**
+     * Retrieves the ID column expression from the logical plan of the DataFrame, if it exists.
+     *
+     * @return
+     *   an `Option` containing the `Expression` for the ID column if present, or `None` otherwise
+     */
     def idColumn(): Option[Expression] = {
       df.queryExecution.logical.collectFirst { case Project(projectList, _) =>
         projectList.collectFirst { case Alias(child, ID_COLUMN) =>

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexOptionsSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexOptionsSuite.scala
@@ -6,7 +6,6 @@
 package org.opensearch.flint.spark
 
 import org.opensearch.flint.spark.FlintSparkIndexOptions.OptionName._
-import org.opensearch.flint.spark.refresh.FlintSparkIndexRefresh.SchedulerMode
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.FlintSuite
@@ -22,6 +21,7 @@ class FlintSparkIndexOptionsSuite extends FlintSuite with Matchers {
     WATERMARK_DELAY.toString shouldBe "watermark_delay"
     OUTPUT_MODE.toString shouldBe "output_mode"
     INDEX_SETTINGS.toString shouldBe "index_settings"
+    ID_EXPRESSION.toString shouldBe "id_expression"
     EXTRA_OPTIONS.toString shouldBe "extra_options"
   }
 
@@ -36,6 +36,7 @@ class FlintSparkIndexOptionsSuite extends FlintSuite with Matchers {
         "watermark_delay" -> "30 Seconds",
         "output_mode" -> "complete",
         "index_settings" -> """{"number_of_shards": 3}""",
+        "id_expression" -> """sha1(col("timestamp"))""",
         "extra_options" ->
           """ {
             |   "alb_logs": {
@@ -55,6 +56,7 @@ class FlintSparkIndexOptionsSuite extends FlintSuite with Matchers {
     options.watermarkDelay() shouldBe Some("30 Seconds")
     options.outputMode() shouldBe Some("complete")
     options.indexSettings() shouldBe Some("""{"number_of_shards": 3}""")
+    options.idExpression() shouldBe Some("""sha1(col("timestamp"))""")
     options.extraSourceOptions("alb_logs") shouldBe Map("opt1" -> "val1")
     options.extraSinkOptions() shouldBe Map("opt2" -> "val2", "opt3" -> "val3")
   }
@@ -83,6 +85,7 @@ class FlintSparkIndexOptionsSuite extends FlintSuite with Matchers {
     options.watermarkDelay() shouldBe empty
     options.outputMode() shouldBe empty
     options.indexSettings() shouldBe empty
+    options.idExpression() shouldBe empty
     options.extraSourceOptions("alb_logs") shouldBe empty
     options.extraSinkOptions() shouldBe empty
     options.optionsWithDefault should contain("auto_refresh" -> "false")

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSuite.scala
@@ -10,7 +10,11 @@ import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.FlintSuite
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.{Add, ConcatWs, Literal, Sha1, StructsToJson}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{StringType, StructType}
+import org.apache.spark.unsafe.types.UTF8String
 
 class FlintSparkIndexSuite extends QueryTest with FlintSuite with Matchers {
 
@@ -19,6 +23,7 @@ class FlintSparkIndexSuite extends QueryTest with FlintSuite with Matchers {
     val options = new FlintSparkIndexOptions(Map("id_expression" -> "id + 10"))
 
     val resultDf = addIdColumn(df, options)
+    resultDf.idColumn() shouldBe Some(Add(UnresolvedAttribute("id"), Literal(10)))
     checkAnswer(resultDf.select(ID_COLUMN), Seq(Row(11), Row(12)))
   }
 
@@ -47,7 +52,37 @@ class FlintSparkIndexSuite extends QueryTest with FlintSuite with Matchers {
     val options = FlintSparkIndexOptions.empty
 
     val resultDf = addIdColumn(df, options)
-    resultDf.columns should contain(ID_COLUMN)
+    resultDf.idColumn() shouldBe Some(
+      Sha1(
+        ConcatWs(
+          Seq(
+            Literal(UTF8String.fromString("\0"), StringType),
+            UnresolvedAttribute(Seq("name")),
+            UnresolvedAttribute(Seq("count"))))))
+    resultDf.select(ID_COLUMN).distinct().count() shouldBe 2
+  }
+
+  test("should add ID column for aggregated query with quoted alias") {
+    val df = spark
+      .createDataFrame(
+        sparkContext.parallelize(
+          Seq(
+            Row(1, "Alice", Row("WA", "Seattle")),
+            Row(2, "Bob", Row("OR", "Portland")),
+            Row(3, "Alice", Row("WA", "Seattle")))),
+        StructType.fromDDL("id INT, name STRING, address STRUCT<state: STRING, city: String>"))
+      .toDF("id", "name", "address")
+      .groupBy(col("name").as("test.name"), col("address").as("test.address"))
+      .count()
+    val options = FlintSparkIndexOptions.empty
+
+    val resultDf = addIdColumn(df, options)
+    resultDf.idColumn() shouldBe Some(
+      Sha1(ConcatWs(Seq(
+        Literal(UTF8String.fromString("\0"), StringType),
+        UnresolvedAttribute(Seq("test.name")),
+        new StructsToJson(UnresolvedAttribute(Seq("test.address"))),
+        UnresolvedAttribute(Seq("count"))))))
     resultDf.select(ID_COLUMN).distinct().count() shouldBe 2
   }
 
@@ -92,7 +127,20 @@ class FlintSparkIndexSuite extends QueryTest with FlintSuite with Matchers {
     val options = FlintSparkIndexOptions.empty
 
     val resultDf = addIdColumn(aggregatedDf, options)
-    resultDf.columns should contain(ID_COLUMN)
+    resultDf.idColumn() shouldBe Some(
+      Sha1(ConcatWs(Seq(
+        Literal(UTF8String.fromString("\0"), StringType),
+        UnresolvedAttribute(Seq("boolean_col")),
+        UnresolvedAttribute(Seq("string_col")),
+        UnresolvedAttribute(Seq("long_col")),
+        UnresolvedAttribute(Seq("int_col")),
+        UnresolvedAttribute(Seq("double_col")),
+        UnresolvedAttribute(Seq("float_col")),
+        UnresolvedAttribute(Seq("timestamp_col")),
+        UnresolvedAttribute(Seq("date_col")),
+        new StructsToJson(UnresolvedAttribute(Seq("struct_col"))),
+        UnresolvedAttribute(Seq("subfield2")),
+        UnresolvedAttribute(Seq("count"))))))
     resultDf.select(ID_COLUMN).distinct().count() shouldBe 1
   }
 }

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSuite.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.opensearch.flint.spark.FlintSparkIndex.{generateIdColumn, ID_COLUMN}
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.FlintSuite
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.types.StructType
+
+class FlintSparkIndexSuite extends QueryTest with FlintSuite with Matchers {
+
+  test("should generate ID column if ID expression is provided") {
+    val df = spark.createDataFrame(Seq((1, "Alice"), (2, "Bob"))).toDF("id", "name")
+    val options = new FlintSparkIndexOptions(Map("id_expression" -> "id + 10"))
+
+    val resultDf = generateIdColumn(df, options)
+    checkAnswer(resultDf.select(ID_COLUMN), Seq(Row(11), Row(12)))
+  }
+
+  test("should not generate ID column if ID expression is empty") {
+    val df = spark.createDataFrame(Seq((1, "Alice"), (2, "Bob"))).toDF("id", "name")
+    val options = FlintSparkIndexOptions.empty
+
+    val resultDf = generateIdColumn(df, options)
+    resultDf.columns should not contain ID_COLUMN
+  }
+
+  test("should generate ID column for aggregated query") {
+    val df = spark
+      .createDataFrame(Seq((1, "Alice"), (2, "Bob"), (3, "Alice")))
+      .toDF("id", "name")
+      .groupBy("name")
+      .count()
+    val options = FlintSparkIndexOptions.empty
+
+    val resultDf = generateIdColumn(df, options)
+    resultDf.select(ID_COLUMN).distinct().count() shouldBe 2
+  }
+
+  test("should not generate ID column for aggregated query if ID expression is empty") {
+    val df = spark.createDataFrame(Seq((1, "Alice"), (2, "Bob"))).toDF("id", "name")
+    val options = FlintSparkIndexOptions.empty
+
+    val resultDf = generateIdColumn(df, options)
+    resultDf.columns should not contain ID_COLUMN
+  }
+
+  test("should not generate ID column if ID expression is not provided") {
+    val df = spark.createDataFrame(Seq((1, "Alice"), (2, "Bob"))).toDF("id", "name")
+    val options = FlintSparkIndexOptions.empty
+
+    val resultDf = generateIdColumn(df, options)
+    resultDf.columns should not contain ID_COLUMN
+  }
+
+  test("should generate ID column for aggregated query with multiple columns") {
+    val schema = StructType.fromDDL("""
+      boolean_col BOOLEAN,
+      string_col STRING,
+      long_col LONG,
+      int_col INT,
+      double_col DOUBLE,
+      float_col FLOAT,
+      timestamp_col TIMESTAMP,
+      date_col DATE,
+      struct_col STRUCT<subfield1: STRING, subfield2: INT>
+    """)
+    val data = Seq(
+      Row(
+        true,
+        "Alice",
+        100L,
+        10,
+        10.5,
+        3.14f,
+        java.sql.Timestamp.valueOf("2024-01-01 10:00:00"),
+        java.sql.Date.valueOf("2024-01-01"),
+        Row("sub1", 1)))
+
+    val aggregatedDf = spark
+      .createDataFrame(sparkContext.parallelize(data), schema)
+      .groupBy(
+        "boolean_col",
+        "string_col",
+        "long_col",
+        "int_col",
+        "double_col",
+        "float_col",
+        "timestamp_col",
+        "date_col",
+        "struct_col.subfield1",
+        "struct_col.subfield2")
+      .count()
+
+    val options = FlintSparkIndexOptions.empty
+    val resultDf = generateIdColumn(aggregatedDf, options)
+    resultDf.select(ID_COLUMN).distinct().count() shouldBe 1
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/FlintSparkIndexSuite.scala
@@ -5,9 +5,7 @@
 
 package org.opensearch.flint.spark
 
-import java.sql.Timestamp
-
-import org.opensearch.flint.spark.FlintSparkIndex.{generateIdColumn, ID_COLUMN}
+import org.opensearch.flint.spark.FlintSparkIndex.{addIdColumn, ID_COLUMN}
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.FlintSuite
@@ -16,31 +14,31 @@ import org.apache.spark.sql.types.StructType
 
 class FlintSparkIndexSuite extends QueryTest with FlintSuite with Matchers {
 
-  test("should generate ID column if ID expression is provided") {
+  test("should add ID column if ID expression is provided") {
     val df = spark.createDataFrame(Seq((1, "Alice"), (2, "Bob"))).toDF("id", "name")
     val options = new FlintSparkIndexOptions(Map("id_expression" -> "id + 10"))
 
-    val resultDf = generateIdColumn(df, options)
+    val resultDf = addIdColumn(df, options)
     checkAnswer(resultDf.select(ID_COLUMN), Seq(Row(11), Row(12)))
   }
 
-  test("should not generate ID column if ID expression is not provided") {
+  test("should not add ID column if ID expression is not provided") {
     val df = spark.createDataFrame(Seq((1, "Alice"), (2, "Bob"))).toDF("id", "name")
     val options = FlintSparkIndexOptions.empty
 
-    val resultDf = generateIdColumn(df, options)
+    val resultDf = addIdColumn(df, options)
     resultDf.columns should not contain ID_COLUMN
   }
 
-  test("should not generate ID column if ID expression is empty") {
+  test("should not add ID column if ID expression is empty") {
     val df = spark.createDataFrame(Seq((1, "Alice"), (2, "Bob"))).toDF("id", "name")
     val options = FlintSparkIndexOptions.empty
 
-    val resultDf = generateIdColumn(df, options)
+    val resultDf = addIdColumn(df, options)
     resultDf.columns should not contain ID_COLUMN
   }
 
-  test("should generate ID column for aggregated query") {
+  test("should add ID column for aggregated query") {
     val df = spark
       .createDataFrame(Seq((1, "Alice"), (2, "Bob"), (3, "Alice")))
       .toDF("id", "name")
@@ -48,7 +46,7 @@ class FlintSparkIndexSuite extends QueryTest with FlintSuite with Matchers {
       .count()
     val options = FlintSparkIndexOptions.empty
 
-    val resultDf = generateIdColumn(df, options)
+    val resultDf = addIdColumn(df, options)
     resultDf.columns should contain(ID_COLUMN)
     resultDf.select(ID_COLUMN).distinct().count() shouldBe 2
   }
@@ -93,7 +91,7 @@ class FlintSparkIndexSuite extends QueryTest with FlintSuite with Matchers {
       .count()
     val options = FlintSparkIndexOptions.empty
 
-    val resultDf = generateIdColumn(aggregatedDf, options)
+    val resultDf = addIdColumn(aggregatedDf, options)
     resultDf.columns should contain(ID_COLUMN)
     resultDf.select(ID_COLUMN).distinct().count() shouldBe 1
   }

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndexSuite.scala
@@ -14,7 +14,6 @@ import org.apache.spark.FlintSuite
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.Alias
 import org.apache.spark.sql.catalyst.plans.logical.Project
-import org.apache.spark.sql.functions.{col, expr}
 
 class FlintSparkCoveringIndexSuite extends FlintSuite {
 

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/covering/FlintSparkCoveringIndexSuite.scala
@@ -73,11 +73,7 @@ class FlintSparkCoveringIndexSuite extends FlintSuite {
           options = FlintSparkIndexOptions(Map("id_expression" -> "name")))
 
       val batchDf = index.build(spark, None)
-      batchDf.queryExecution.logical.collectFirst { case Project(projectList, _) =>
-        projectList.collectFirst { case Alias(child, ID_COLUMN) =>
-          child
-        }
-      }.flatten shouldBe Some(UnresolvedAttribute(Seq("name")))
+      batchDf.idColumn() shouldBe Some(UnresolvedAttribute(Seq("name")))
     }
   }
 
@@ -92,11 +88,7 @@ class FlintSparkCoveringIndexSuite extends FlintSuite {
           FlintSparkIndexOptions(Map("auto_refresh" -> "true", "id_expression" -> "name")))
 
       val streamDf = index.build(spark, Some(spark.table(testTable)))
-      streamDf.queryExecution.logical.collectFirst { case Project(projectList, _) =>
-        projectList.collectFirst { case Alias(child, ID_COLUMN) =>
-          child
-        }
-      }.flatten shouldBe Some(UnresolvedAttribute(Seq("name")))
+      streamDf.idColumn() shouldBe Some(UnresolvedAttribute(Seq("name")))
     }
   }
 }

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/mv/FlintSparkMaterializedViewSuite.scala
@@ -7,10 +7,9 @@ package org.opensearch.flint.spark.mv
 
 import scala.collection.JavaConverters.{mapAsJavaMapConverter, mapAsScalaMapConverter}
 
-import org.opensearch.flint.spark.FlintSparkIndex.ID_COLUMN
 import org.opensearch.flint.spark.FlintSparkIndexOptions
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.MV_INDEX_TYPE
-import org.opensearch.flint.spark.mv.FlintSparkMaterializedViewSuite.{streamingRelation, DataFrameIdColumnExtractor, StreamingDslLogicalPlan}
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedViewSuite.{streamingRelation, StreamingDslLogicalPlan}
 import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar.mock
 
@@ -19,8 +18,8 @@ import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.dsl.expressions.{intToLiteral, stringToLiteral, DslAttr, DslExpression, StringToAttributeConversionHelper}
 import org.apache.spark.sql.catalyst.dsl.plans.DslLogicalPlan
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, ConcatWs, Expression, Literal, Sha1}
-import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, ConcatWs, Literal, Sha1}
+import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, LogicalPlan}
 import org.apache.spark.sql.catalyst.util.IntervalUtils
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -383,17 +382,6 @@ object FlintSparkMaterializedViewSuite {
         colName,
         IntervalUtils.stringToInterval(UTF8String.fromString(interval)),
         logicalPlan)
-    }
-  }
-
-  implicit class DataFrameIdColumnExtractor(val df: DataFrame) {
-
-    def idColumn(): Option[Expression] = {
-      df.queryExecution.logical.collectFirst { case Project(projectList, _) =>
-        projectList.collectFirst { case Alias(child, ID_COLUMN) =>
-          child
-        }
-      }.flatten
     }
   }
 }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -119,6 +119,10 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
 
     val indexData = flint.queryIndex(testFlintTimeSeriesIndex)
     indexData.count() shouldBe 3 // only 3 rows left due to same ID
+
+    // Rerun should not generate duplicate data
+    sql(s"REFRESH INDEX $testIndex ON $testTimeSeriesTable")
+    indexData.count() shouldBe 3
   }
 
   test("create covering index with index settings") {

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkCoveringIndexSqlITSuite.scala
@@ -28,19 +28,23 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
   private val testTable = "spark_catalog.default.covering_sql_test"
   private val testIndex = "name_and_age"
   private val testFlintIndex = getFlintIndexName(testIndex, testTable)
+  private val testTimeSeriesTable = "spark_catalog.default.covering_sql_ts_test"
+  private val testFlintTimeSeriesIndex = getFlintIndexName(testIndex, testTimeSeriesTable)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
 
     createPartitionedAddressTable(testTable)
+    createTimeSeriesTable(testTimeSeriesTable)
   }
 
   override def afterEach(): Unit = {
     super.afterEach()
 
     // Delete all test indices
-    deleteTestIndex(testFlintIndex)
+    deleteTestIndex(testFlintIndex, testFlintTimeSeriesIndex)
     sql(s"DROP TABLE $testTable")
+    sql(s"DROP TABLE $testTimeSeriesTable")
   }
 
   test("create covering index with auto refresh") {
@@ -84,6 +88,37 @@ class FlintSparkCoveringIndexSqlITSuite extends FlintSparkSuite {
       index.get.options.refreshInterval() shouldBe Some("5 Seconds")
       index.get.options.checkpointLocation() shouldBe Some(checkpointDir.getAbsolutePath)
     }
+  }
+
+  test("create covering index with auto refresh and ID expression") {
+    sql(s"""
+           | CREATE INDEX $testIndex ON $testTimeSeriesTable
+           | (time, age, address)
+           | WITH (
+           |   auto_refresh = true,
+           |   id_expression = 'address'
+           | )
+           |""".stripMargin)
+
+    val job = spark.streams.active.find(_.name == testFlintTimeSeriesIndex)
+    awaitStreamingComplete(job.get.id.toString)
+
+    val indexData = flint.queryIndex(testFlintTimeSeriesIndex)
+    indexData.count() shouldBe 3 // only 3 rows left due to same ID
+  }
+
+  test("create covering index with full refresh and ID expression") {
+    sql(s"""
+           | CREATE INDEX $testIndex ON $testTimeSeriesTable
+           | (time, age, address)
+           | WITH (
+           |   id_expression = 'address'
+           | )
+           |""".stripMargin)
+    sql(s"REFRESH INDEX $testIndex ON $testTimeSeriesTable")
+
+    val indexData = flint.queryIndex(testFlintTimeSeriesIndex)
+    indexData.count() shouldBe 3 // only 3 rows left due to same ID
   }
 
   test("create covering index with index settings") {

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -154,6 +154,47 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
     }
   }
 
+  test("create materialized view with auto refresh and ID expression") {
+    withTempDir { checkpointDir =>
+      sql(s"""
+             | CREATE MATERIALIZED VIEW $testMvName
+             | AS $testQuery
+             | WITH (
+             |   auto_refresh = true,
+             |   checkpoint_location = '${checkpointDir.getAbsolutePath}',
+             |   watermark_delay = '1 Second',
+             |   id_expression = 'count'
+             | )
+             |""".stripMargin)
+
+      // Wait for streaming job complete current micro batch
+      val job = spark.streams.active.find(_.name == testFlintIndex)
+      job shouldBe defined
+      failAfter(streamingTimeout) {
+        job.get.processAllAvailable()
+      }
+
+      // 1 row missing due to ID conflict intentionally
+      flint.queryIndex(testFlintIndex).count() shouldBe 2
+    }
+  }
+
+  test("create materialized view with full refresh and ID expression") {
+    sql(s"""
+           | CREATE MATERIALIZED VIEW $testMvName
+           | AS $testQuery
+           | WITH (
+           |   id_expression = 'count'
+           | )
+           |""".stripMargin)
+
+    sql(s"REFRESH MATERIALIZED VIEW $testMvName")
+
+    // 2 rows missing due to ID conflict intentionally
+    val indexData = spark.read.format(FLINT_DATASOURCE).load(testFlintIndex)
+    indexData.count() shouldBe 2
+  }
+
   test("create materialized view with index settings") {
     sql(s"""
              | CREATE MATERIALIZED VIEW $testMvName

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -163,7 +163,7 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
              |   auto_refresh = true,
              |   checkpoint_location = '${checkpointDir.getAbsolutePath}',
              |   watermark_delay = '1 Second',
-             |   id_expression = 'count'
+             |   id_expression = "sha1(concat_ws('\0',startTime))"
              | )
              |""".stripMargin)
 
@@ -174,8 +174,7 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
         job.get.processAllAvailable()
       }
 
-      // 1 row missing due to ID conflict intentionally
-      flint.queryIndex(testFlintIndex).count() shouldBe 2
+      flint.queryIndex(testFlintIndex).count() shouldBe 3
     }
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -191,7 +191,11 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
     sql(s"REFRESH MATERIALIZED VIEW $testMvName")
 
     // 2 rows missing due to ID conflict intentionally
-    val indexData = spark.read.format(FLINT_DATASOURCE).load(testFlintIndex)
+    val indexData = flint.queryIndex(testFlintIndex)
+    indexData.count() shouldBe 2
+
+    // Rerun should not generate duplicate data
+    sql(s"REFRESH MATERIALIZED VIEW $testMvName")
     indexData.count() shouldBe 2
   }
 


### PR DESCRIPTION
### Description

This PR enhances the Covering Index (CV) and Materialized View (MV) write operations by introducing deterministic ID generation. Deterministic IDs uniquely identify each document in a CV/MV based on its data, enabling idempotency. This ensures consistent results during retries or restarts of index refreshes. By eliminating duplicates, this approach maintains data integrity and operational consistency, even in failure scenarios.

### Algorithm

The ID generation logic follows the precedence below:

1. **User-Provided ID Expression**
    - Enables users to define custom ID generation logic based on specific columns or expressions.
    - If empty, no ID column is generated, which is useful for testing or disabling the feature.
2. ~**Aggregated MV**~
    - ~If MV queries involves aggregation, IDs are generated using SHA-1 on concatenated output columns.~
    - ~SHA-1 is chosen for balancing collision resistance, performance, and space efficiency, compared to other options in Spark such as  `hash`, `xxhash64`, `md5` and `sha-2`.~
3. **Default Behavior**
    - Otherwise, no ID column is generated and idempotency is not guaranteed.

### Side Effects

This deterministic document ID approach introduces these impacts and requires further exploration to determine if a better solution is viable for long-term scalability and performance.

1. **Spark Computation Overhead**
    - The SHA-1 hash and string concat operations adds computation overhead on Spark side.
2. **OpenSearch Ingestion Overhead**
    - Each document write involves a document ID lookup to identify and deduplicate existing documents.
3. **OpenSearch Document Size**
    - The SHA-1 hash used for document IDs (160 bits) consumes more space compared to OpenSearch's default UUID-based IDs (128 bits).
4. **Possibility of Collision**
    - While the likelihood of collisions with SHA-1 is extremely low (e.g., negligible even at PB-scale data), a collision could result in data loss by overwriting an existing document.

### Documentation

https://github.com/dai-chen/opensearch-spark/blob/support-covering-index-and-mv-idempotency-rework/docs/index.md#create-index-options

### Related Issues

https://github.com/opensearch-project/opensearch-spark/issues/88

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
