### PR TITLE
Add support for serializing Spark's DecimalType

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -577,6 +577,10 @@ The following table define the data type mapping between Flint data type and Spa
 * Spark data types VarcharType(length) and CharType(length) are both currently mapped to Flint data
   type *keyword*, dropping their length property. On the other hand, Flint data type *keyword* only
   maps to StringType.
+* Spark data type MapType is mapped to an empty OpenSearch object. The inner fields then rely on 
+  dynamic mapping. On the other hand, Flint data type *object* only maps to StructType.
+* Spark data type DecimalType is mapped to an OpenSearch double. On the other hand, Flint data type 
+  *double* only maps to DoubleType.
 
 Unsupported Spark data types:
 * DecimalType

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -142,6 +142,7 @@ object FlintDataType {
       case ByteType => JObject("type" -> JString("byte"))
       case DoubleType => JObject("type" -> JString("double"))
       case FloatType => JObject("type" -> JString("float"))
+      case DecimalType() => JObject("type" -> JString("double"))
 
       // Date
       case TimestampType | _: TimestampNTZType =>

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
@@ -143,6 +143,20 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
                                                                     |}""".stripMargin)
   }
 
+  test("spark decimal type serialize") {
+    val sparkStructType = StructType(
+      StructField("decimalField", DecimalType(1, 1), true) ::
+        Nil)
+
+    FlintDataType.serialize(sparkStructType) shouldBe compactJson("""{
+                                                                    |  "properties": {
+                                                                    |    "decimalField": {
+                                                                    |      "type": "double"
+                                                                    |    }
+                                                                    |  }
+                                                                    |}""".stripMargin)
+  }
+
   test("spark varchar and char type serialize") {
     val flintDataType = """{
                           |  "properties": {

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewSqlITSuite.scala
@@ -523,5 +523,45 @@ class FlintSparkMaterializedViewSqlITSuite extends FlintSparkSuite {
     }
   }
 
+  test("create materialized view with decimal and map types") {
+    val decimalAndMapTable = s"$catalogName.default.mv_test_decimal_map"
+    val decimalAndMapMv = s"$catalogName.default.mv_test_decimal_map_ser"
+    withTable(decimalAndMapTable) {
+      createMapAndDecimalTimeSeriesTable(decimalAndMapTable)
+
+      withTempDir { checkpointDir =>
+        sql(s"""
+             | CREATE MATERIALIZED VIEW $decimalAndMapMv
+             | AS
+             | SELECT
+             |   base_score, mymap
+             | FROM $decimalAndMapTable
+             | WITH (
+             |   auto_refresh = true,
+             |   checkpoint_location = '${checkpointDir.getAbsolutePath}'
+             | )
+             |""".stripMargin)
+
+        // Wait for streaming job complete current micro batch
+        val flintIndex = getFlintIndexName(decimalAndMapMv)
+        val job = spark.streams.active.find(_.name == flintIndex)
+        job shouldBe defined
+        failAfter(streamingTimeout) {
+          job.get.processAllAvailable()
+        }
+
+        flint.describeIndex(flintIndex) shouldBe defined
+        checkAnswer(
+          flint.queryIndex(flintIndex).select("base_score", "mymap"),
+          Seq(
+            Row(3.1415926, Row(null, null, null, null, "mapvalue1")),
+            Row(4.1415926, Row("mapvalue2", null, null, null, null)),
+            Row(5.1415926, Row(null, null, "mapvalue3", null, null)),
+            Row(6.1415926, Row(null, null, null, "mapvalue4", null)),
+            Row(7.1415926, Row(null, "mapvalue5", null, null, null))))
+      }
+    }
+  }
+
   private def timestamp(ts: String): Timestamp = Timestamp.valueOf(ts)
 }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -445,7 +445,10 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
     sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 03:00:00', 'E', 15, 'Vancouver')")
   }
 
-  protected def createIcebergTimeSeriesTable(testTable: String): Unit = {
+  protected def createMapAndDecimalTimeSeriesTable(testTable: String): Unit = {
+    // CSV tables do not support MAP types so we use JSON instead
+    val finalTableType = if (tableType == "CSV") "JSON" else tableType
+
     sql(s"""
            | CREATE TABLE $testTable
            | (
@@ -455,7 +458,7 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
            |   base_score DECIMAL(8, 7),
            |   mymap MAP<STRING, STRING>
            | )
-           | USING ICEBERG
+           | USING $finalTableType $tableOptions
            |""".stripMargin)
 
     sql(

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -458,11 +458,16 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
            | USING ICEBERG
            |""".stripMargin)
 
-    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:01:00', 'A', 30, 3.1415926, Map('mapkey1', 'mapvalue1'))")
-    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:10:00', 'B', 20, 4.1415926, Map('mapkey2', 'mapvalue2'))")
-    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:15:00', 'C', 35, 5.1415926, Map('mapkey3', 'mapvalue3'))")
-    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 01:00:00', 'D', 40, 6.1415926, Map('mapkey4', 'mapvalue4'))")
-    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 03:00:00', 'E', 15, 7.1415926, Map('mapkey5', 'mapvalue5'))")
+    sql(
+      s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:01:00', 'A', 30, 3.1415926, Map('mapkey1', 'mapvalue1'))")
+    sql(
+      s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:10:00', 'B', 20, 4.1415926, Map('mapkey2', 'mapvalue2'))")
+    sql(
+      s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:15:00', 'C', 35, 5.1415926, Map('mapkey3', 'mapvalue3'))")
+    sql(
+      s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 01:00:00', 'D', 40, 6.1415926, Map('mapkey4', 'mapvalue4'))")
+    sql(
+      s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 03:00:00', 'E', 15, 7.1415926, Map('mapkey5', 'mapvalue5'))")
   }
 
   protected def createTimeSeriesTransactionTable(testTable: String): Unit = {

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkSuite.scala
@@ -445,6 +445,26 @@ trait FlintSparkSuite extends QueryTest with FlintSuite with OpenSearchSuite wit
     sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 03:00:00', 'E', 15, 'Vancouver')")
   }
 
+  protected def createIcebergTimeSeriesTable(testTable: String): Unit = {
+    sql(s"""
+           | CREATE TABLE $testTable
+           | (
+           |   time TIMESTAMP,
+           |   name STRING,
+           |   age INT,
+           |   base_score DECIMAL(8, 7),
+           |   mymap MAP<STRING, STRING>
+           | )
+           | USING ICEBERG
+           |""".stripMargin)
+
+    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:01:00', 'A', 30, 3.1415926, Map('mapkey1', 'mapvalue1'))")
+    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:10:00', 'B', 20, 4.1415926, Map('mapkey2', 'mapvalue2'))")
+    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 00:15:00', 'C', 35, 5.1415926, Map('mapkey3', 'mapvalue3'))")
+    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 01:00:00', 'D', 40, 6.1415926, Map('mapkey4', 'mapvalue4'))")
+    sql(s"INSERT INTO $testTable VALUES (TIMESTAMP '2023-10-01 03:00:00', 'E', 15, 7.1415926, Map('mapkey5', 'mapvalue5'))")
+  }
+
   protected def createTimeSeriesTransactionTable(testTable: String): Unit = {
     sql(s"""
       | CREATE TABLE $testTable

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
@@ -6,7 +6,67 @@
 package org.opensearch.flint.spark.iceberg
 
 import org.opensearch.flint.spark.FlintSparkMaterializedViewSqlITSuite
+import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.getFlintIndexName
+import org.scalatest.matchers.must.Matchers.defined
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.flint.config.FlintSparkConf
 
 class FlintSparkIcebergMaterializedViewITSuite
     extends FlintSparkMaterializedViewSqlITSuite
-    with FlintSparkIcebergSuite {}
+      with FlintSparkIcebergSuite{
+
+  private val testTable = s"$catalogName.default.mv_test_iceberg"
+  private val testMvName = s"$catalogName.default.mv_test_iceberg_metrics"
+  private val testFlintIndex = getFlintIndexName(testMvName)
+  private val testQuery =
+    s"""
+       | SELECT
+       |   base_score, mymap
+       | FROM $testTable
+       |""".stripMargin
+
+  override def beforeEach(): Unit = {
+    super.beforeAll()
+    createIcebergTimeSeriesTable(testTable)
+  }
+
+  override def afterEach(): Unit = {
+    deleteTestIndex(testFlintIndex)
+    sql(s"DROP TABLE $testTable")
+    conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
+    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
+  }
+
+  test("create materialized view with map type") {
+    withTempDir { checkpointDir =>
+      sql(s"""
+             | CREATE MATERIALIZED VIEW $testMvName
+             | AS $testQuery
+             | WITH (
+             |   auto_refresh = true,
+             |   checkpoint_location = '${checkpointDir.getAbsolutePath}'
+             | )
+             |""".stripMargin)
+
+      // Wait for streaming job complete current micro batch
+      val job = spark.streams.active.find(_.name == testFlintIndex)
+      job shouldBe defined
+      failAfter(streamingTimeout) {
+        job.get.processAllAvailable()
+      }
+
+      flint.describeIndex(testFlintIndex) shouldBe defined
+      checkAnswer(
+        flint.queryIndex(testFlintIndex).select("base_score", "mymap"),
+        Seq(
+          Row(3.1415926, Row(null, null, null, null, "mapvalue1")),
+          Row(4.1415926, Row("mapvalue2", null, null, null, null)),
+          Row(5.1415926, Row(null, null, "mapvalue3", null, null)),
+          Row(6.1415926, Row(null, null, null, "mapvalue4", null)),
+          Row(7.1415926, Row(null, "mapvalue5", null, null, null)),
+        ))
+    }
+  }
+}

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
@@ -15,7 +15,7 @@ import org.apache.spark.sql.flint.config.FlintSparkConf
 
 class FlintSparkIcebergMaterializedViewITSuite
     extends FlintSparkMaterializedViewSqlITSuite
-      with FlintSparkIcebergSuite{
+    with FlintSparkIcebergSuite {
 
   private val testTable = s"$catalogName.default.mv_test_iceberg"
   private val testMvName = s"$catalogName.default.mv_test_iceberg_metrics"
@@ -39,7 +39,7 @@ class FlintSparkIcebergMaterializedViewITSuite
     conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
   }
 
-  test("create materialized view with map type") {
+  test("create materialized view with decimal and map types") {
     withTempDir { checkpointDir =>
       sql(s"""
              | CREATE MATERIALIZED VIEW $testMvName
@@ -65,8 +65,7 @@ class FlintSparkIcebergMaterializedViewITSuite
           Row(4.1415926, Row("mapvalue2", null, null, null, null)),
           Row(5.1415926, Row(null, null, "mapvalue3", null, null)),
           Row(6.1415926, Row(null, null, null, "mapvalue4", null)),
-          Row(7.1415926, Row(null, "mapvalue5", null, null, null)),
-        ))
+          Row(7.1415926, Row(null, "mapvalue5", null, null, null))))
     }
   }
 }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
@@ -27,12 +27,13 @@ class FlintSparkIcebergMaterializedViewITSuite
        | FROM $testTable
        |""".stripMargin
 
-  override def beforeEach(): Unit = {
+  override def beforeAll(): Unit = {
     super.beforeAll()
     createIcebergTimeSeriesTable(testTable)
   }
 
-  override def afterEach(): Unit = {
+  override def afterAll(): Unit = {
+    super.afterAll()
     deleteTestIndex(testFlintIndex)
     sql(s"DROP TABLE $testTable")
     conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
@@ -6,67 +6,7 @@
 package org.opensearch.flint.spark.iceberg
 
 import org.opensearch.flint.spark.FlintSparkMaterializedViewSqlITSuite
-import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.getFlintIndexName
-import org.scalatest.matchers.must.Matchers.defined
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.flint.config.FlintSparkConf
 
 class FlintSparkIcebergMaterializedViewITSuite
     extends FlintSparkMaterializedViewSqlITSuite
-    with FlintSparkIcebergSuite {
-
-  private val testTable = s"$catalogName.default.mv_test_iceberg"
-  private val testMvName = s"$catalogName.default.mv_test_iceberg_metrics"
-  private val testFlintIndex = getFlintIndexName(testMvName)
-  private val testQuery =
-    s"""
-       | SELECT
-       |   base_score, mymap
-       | FROM $testTable
-       |""".stripMargin
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    createIcebergTimeSeriesTable(testTable)
-  }
-
-  override def afterAll(): Unit = {
-    deleteTestIndex(testFlintIndex)
-    sql(s"DROP TABLE $testTable")
-    conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
-    conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
-    super.afterAll()
-  }
-
-  test("create materialized view with decimal and map types") {
-    withTempDir { checkpointDir =>
-      sql(s"""
-             | CREATE MATERIALIZED VIEW $testMvName
-             | AS $testQuery
-             | WITH (
-             |   auto_refresh = true,
-             |   checkpoint_location = '${checkpointDir.getAbsolutePath}'
-             | )
-             |""".stripMargin)
-
-      // Wait for streaming job complete current micro batch
-      val job = spark.streams.active.find(_.name == testFlintIndex)
-      job shouldBe defined
-      failAfter(streamingTimeout) {
-        job.get.processAllAvailable()
-      }
-
-      flint.describeIndex(testFlintIndex) shouldBe defined
-      checkAnswer(
-        flint.queryIndex(testFlintIndex).select("base_score", "mymap"),
-        Seq(
-          Row(3.1415926, Row(null, null, null, null, "mapvalue1")),
-          Row(4.1415926, Row("mapvalue2", null, null, null, null)),
-          Row(5.1415926, Row(null, null, "mapvalue3", null, null)),
-          Row(6.1415926, Row(null, null, null, "mapvalue4", null)),
-          Row(7.1415926, Row(null, "mapvalue5", null, null, null))))
-    }
-  }
-}
+    with FlintSparkIcebergSuite {}

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/iceberg/FlintSparkIcebergMaterializedViewITSuite.scala
@@ -33,11 +33,11 @@ class FlintSparkIcebergMaterializedViewITSuite
   }
 
   override def afterAll(): Unit = {
-    super.afterAll()
     deleteTestIndex(testFlintIndex)
     sql(s"DROP TABLE $testTable")
     conf.unsetConf(FlintSparkConf.CUSTOM_FLINT_SCHEDULER_CLASS.key)
     conf.unsetConf(FlintSparkConf.EXTERNAL_SCHEDULER_ENABLED.key)
+    super.afterAll()
   }
 
   test("create materialized view with decimal and map types") {


### PR DESCRIPTION
### Description
Adds support for serializing Spark's DecimalType in FlintDataType

### Related Issues
_List any issues this PR will resolve, e.g. Resolves [...]._

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
