### PR TITLE
Wait after create index complete

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -546,7 +546,7 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.flint.index.checkpointLocation.rootDir`: default is None. Flint will create a default checkpoint location in format of '<rootDir>/<indexName>/<UUID>' to isolate checkpoint data.
 - `spark.flint.index.checkpoint.mandatory`: default is true.
 - `spark.datasource.flint.socket_timeout_millis`: default value is 60000.
-- `spark.datasource.flint.request.completionDelayMillis`: Time to wait in milliseconds after request is complete. Applied after index creation. Default value is 0.
+- `spark.datasource.flint.request.completionDelayMillis`: Time to wait in milliseconds after request is complete. Applied after index creation. Default value is 2000 if using aoss service, otherwise 0.
 - `spark.flint.monitor.initialDelaySeconds`: Initial delay in seconds before starting the monitoring task. Default value is 15.
 - `spark.flint.monitor.intervalSeconds`: Interval in seconds for scheduling the monitoring task. Default value is 60.
 - `spark.flint.monitor.maxErrorCount`: Maximum number of consecutive errors allowed before stopping the monitoring task. Default value is 5.

--- a/docs/index.md
+++ b/docs/index.md
@@ -546,6 +546,7 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.flint.index.checkpointLocation.rootDir`: default is None. Flint will create a default checkpoint location in format of '<rootDir>/<indexName>/<UUID>' to isolate checkpoint data.
 - `spark.flint.index.checkpoint.mandatory`: default is true.
 - `spark.datasource.flint.socket_timeout_millis`: default value is 60000.
+- `spark.datasource.flint.request.completionDelayMillis`: Time to wait in milliseconds after request is complete. Applied after index creation. Default value is 0.
 - `spark.flint.monitor.initialDelaySeconds`: Initial delay in seconds before starting the monitoring task. Default value is 15.
 - `spark.flint.monitor.intervalSeconds`: Interval in seconds for scheduling the monitoring task. Default value is 60.
 - `spark.flint.monitor.maxErrorCount`: Maximum number of consecutive errors allowed before stopping the monitoring task. Default value is 5.

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -91,6 +91,7 @@ public class FlintOptions implements Serializable {
 
   public static final String REQUEST_COMPLETION_DELAY_MILLIS = "request.completionDelayMillis";
   public static final int DEFAULT_REQUEST_COMPLETION_DELAY_MILLIS = 0;
+  public static final int DEFAULT_AOSS_REQUEST_COMPLETION_DELAY_MILLIS = 2000;
 
   public static final String DATA_SOURCE_NAME = "spark.flint.datasource.name";
 
@@ -182,7 +183,10 @@ public class FlintOptions implements Serializable {
   }
 
   public int getRequestCompletionDelayMillis() {
-    return Integer.parseInt(options.getOrDefault(REQUEST_COMPLETION_DELAY_MILLIS, String.valueOf(DEFAULT_REQUEST_COMPLETION_DELAY_MILLIS)));
+    int defaultValue = SERVICE_NAME_AOSS.equals(getServiceName())
+        ? DEFAULT_AOSS_REQUEST_COMPLETION_DELAY_MILLIS
+        : DEFAULT_REQUEST_COMPLETION_DELAY_MILLIS;
+    return Integer.parseInt(options.getOrDefault(REQUEST_COMPLETION_DELAY_MILLIS, String.valueOf(defaultValue)));
   }
 
   public String getDataSourceName() {

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -88,7 +88,10 @@ public class FlintOptions implements Serializable {
   public static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 60000;
 
   public static final int DEFAULT_INACTIVITY_LIMIT_MILLIS = 3 * 60 * 1000;
-  
+
+  public static final String REQUEST_COMPLETION_DELAY_MILLIS = "request.completionDelayMillis";
+  public static final int DEFAULT_REQUEST_COMPLETION_DELAY_MILLIS = 0;
+
   public static final String DATA_SOURCE_NAME = "spark.flint.datasource.name";
 
   public static final String BATCH_BYTES = "write.batch_bytes";
@@ -176,6 +179,10 @@ public class FlintOptions implements Serializable {
 
   public int getSocketTimeoutMillis() {
     return Integer.parseInt(options.getOrDefault(SOCKET_TIMEOUT_MILLIS, String.valueOf(DEFAULT_SOCKET_TIMEOUT_MILLIS)));
+  }
+
+  public int getRequestCompletionDelayMillis() {
+    return Integer.parseInt(options.getOrDefault(REQUEST_COMPLETION_DELAY_MILLIS, String.valueOf(DEFAULT_REQUEST_COMPLETION_DELAY_MILLIS)));
   }
 
   public String getDataSourceName() {

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
@@ -44,6 +44,7 @@ public class FlintOpenSearchClient implements FlintClient {
     LOG.info("Creating Flint index " + indexName + " with metadata " + metadata);
     try {
       createIndex(indexName, FlintOpenSearchIndexMetadataService.serialize(metadata, false), metadata.indexSettings());
+      waitRequestComplete(); // Delay to ensure create is complete before making other requests for the index
       emitIndexCreationSuccessMetric(metadata.kind());
     } catch (IllegalStateException ex) {
       emitIndexCreationFailureMetric(metadata.kind());
@@ -129,6 +130,14 @@ public class FlintOpenSearchClient implements FlintClient {
 
   private String sanitizeIndexName(String indexName) {
     return OpenSearchClientUtils.sanitizeIndexName(indexName);
+  }
+
+  private void waitRequestComplete() {
+    try {
+      Thread.sleep(options.getRequestCompletionDelayMillis());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   private void emitIndexCreationSuccessMetric(String indexKind) {

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -205,7 +205,7 @@ object FlintSparkConf {
     FlintConfig(s"spark.datasource.flint.${FlintOptions.REQUEST_COMPLETION_DELAY_MILLIS}")
       .datasourceOption()
       .doc("delay in milliseconds after index creation is completed")
-      .createWithDefault(String.valueOf(FlintOptions.DEFAULT_REQUEST_COMPLETION_DELAY_MILLIS))
+      .createOptional()
   val DATA_SOURCE_NAME =
     FlintConfig(s"spark.flint.datasource.name")
       .doc("data source name")
@@ -347,8 +347,7 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
       SOCKET_TIMEOUT_MILLIS,
       JOB_TYPE,
       REPL_INACTIVITY_TIMEOUT_MILLIS,
-      BATCH_BYTES,
-      REQUEST_COMPLETION_DELAY_MILLIS)
+      BATCH_BYTES)
       .map(conf => (conf.optionKey, conf.readFrom(reader)))
       .toMap
 
@@ -362,7 +361,8 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
       REQUEST_INDEX,
       METADATA_ACCESS_AWS_CREDENTIALS_PROVIDER,
       EXCLUDE_JOB_IDS,
-      SCROLL_SIZE)
+      SCROLL_SIZE,
+      REQUEST_COMPLETION_DELAY_MILLIS)
       .map(conf => (conf.optionKey, conf.readFrom(reader)))
       .flatMap {
         case (_, None) => None

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -201,6 +201,11 @@ object FlintSparkConf {
       .datasourceOption()
       .doc("socket duration in milliseconds")
       .createWithDefault(String.valueOf(FlintOptions.DEFAULT_SOCKET_TIMEOUT_MILLIS))
+  val REQUEST_COMPLETION_DELAY_MILLIS =
+    FlintConfig(s"spark.datasource.flint.${FlintOptions.REQUEST_COMPLETION_DELAY_MILLIS}")
+      .datasourceOption()
+      .doc("delay in milliseconds after index creation is completed")
+      .createWithDefault(String.valueOf(FlintOptions.DEFAULT_REQUEST_COMPLETION_DELAY_MILLIS))
   val DATA_SOURCE_NAME =
     FlintConfig(s"spark.flint.datasource.name")
       .doc("data source name")
@@ -342,7 +347,8 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
       SOCKET_TIMEOUT_MILLIS,
       JOB_TYPE,
       REPL_INACTIVITY_TIMEOUT_MILLIS,
-      BATCH_BYTES)
+      BATCH_BYTES,
+      REQUEST_COMPLETION_DELAY_MILLIS)
       .map(conf => (conf.optionKey, conf.readFrom(reader)))
       .toMap
 

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -118,6 +118,11 @@ class FlintSparkConfSuite extends FlintSuite {
     FlintSparkConf().flintOptions().getRequestCompletionDelayMillis shouldBe 0
   }
 
+  test("test request completionDelayMillis default value for aoss") {
+    val options = FlintSparkConf(Map("auth.servicename" -> "aoss").asJava).flintOptions()
+    options.getRequestCompletionDelayMillis shouldBe 2000
+  }
+
   test("test specified request completionDelayMillis") {
     val options =
       FlintSparkConf(Map("request.completionDelayMillis" -> "1000").asJava).flintOptions()

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -114,6 +114,16 @@ class FlintSparkConfSuite extends FlintSuite {
     }
   }
 
+  test("test request completionDelayMillis default value") {
+    FlintSparkConf().flintOptions().getRequestCompletionDelayMillis shouldBe 0
+  }
+
+  test("test specified request completionDelayMillis") {
+    val options =
+      FlintSparkConf(Map("request.completionDelayMillis" -> "1000").asJava).flintOptions()
+    options.getRequestCompletionDelayMillis shouldBe 1000
+  }
+
   test("externalSchedulerIntervalThreshold should return default value when empty") {
     val options = FlintSparkConf(Map("spark.flint.job.externalScheduler.interval" -> "").asJava)
     assert(options

--- a/integ-test/src/integration/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
@@ -65,6 +65,27 @@ class FlintOpenSearchClientSuite extends AnyFlatSpec with OpenSearchSuite with M
     (settings \ "index.number_of_replicas").extract[String] shouldBe "2"
   }
 
+  it should "create index with request completion delay config" in {
+    val metadata = FlintOpenSearchIndexMetadataService.deserialize("{}")
+    // Create a dummy index to avoid timing the initial overhead
+    flintClient.createIndex("dummy", metadata)
+
+    val indexName = "flint_test_without_request_completion_delay"
+    val elapsedTimeWithoutDelay = timer {
+      flintClient.createIndex(indexName, metadata)
+    }
+
+    val delayIndexName = "flint_test_with_request_completion_delay"
+    val delayOptions =
+      openSearchOptions + (FlintOptions.REQUEST_COMPLETION_DELAY_MILLIS -> "2000")
+    val delayFlintOptions = new FlintOptions(delayOptions.asJava)
+    val delayFlintClient = new FlintOpenSearchClient(delayFlintOptions)
+    val elapsedTimeWithDelay = timer {
+      delayFlintClient.createIndex(delayIndexName, metadata)
+    }
+    elapsedTimeWithDelay - elapsedTimeWithoutDelay should be >= 1800L // allowing 200ms of wiggle room
+  }
+
   it should "get all index names with the given index name pattern" in {
     val metadata = FlintOpenSearchIndexMetadataService.deserialize(
       """{"properties": {"test": { "type": "integer" } } }""")
@@ -219,5 +240,12 @@ class FlintOpenSearchClientSuite extends AnyFlatSpec with OpenSearchSuite with M
 
   def createTable(indexName: String, options: FlintOptions): Table = {
     OpenSearchCluster.apply(indexName, options).asScala.head
+  }
+
+  def timer(block: => Unit): Long = {
+    val start = System.currentTimeMillis()
+    block
+    val end = System.currentTimeMillis()
+    end - start
   }
 }


### PR DESCRIPTION
### Description
Add a new spark config `spark.datasource.flint.request.completionDelayMillis` to set a wait time after OpenSearch index creation is complete.
It's set to 2000 if using aoss service by default, otherwise it's 0.

### Related Issues

* #950 

### Testing
Create index with default config
<pre>
<b>24/11/26 23:49:04</b> INFO FlintOpenSearchClient: Creating Flint index flint_myglue_test_default_no_wait_time with metadata FlintMetadata(...)
24/11/26 23:49:04 INFO FlintOpenSearchClient: Creating Flint index flint_myglue_test_default_no_wait_time
24/11/26 23:49:04 INFO RetryableHttpAsyncClient: Building retryable http async client with options: FlintRetryOptions{maxRetries=3, retryableStatusCodes=429,502, retryableExceptionClassNames=Optional.empty}
24/11/26 23:49:04 INFO HttpStatusCodeResultPredicate: Checking if status code is retryable: 200
24/11/26 23:49:04 INFO HttpStatusCodeResultPredicate: Status code 200 check result: false
<b>24/11/26 23:49:04</b> INFO FlintOpenSearchIndexMetadataService: Updating Flint index flint_myglue_test_default_no_wait_time with metadata FlintMetadata(...)
24/11/26 23:49:04 INFO RetryableHttpAsyncClient: Building retryable http async client with options: FlintRetryOptions{maxRetries=3, retryableStatusCodes=429,502, retryableExceptionClassNames=Optional.empty}
24/11/26 23:49:04 INFO HttpStatusCodeResultPredicate: Checking if status code is retryable: 200
24/11/26 23:49:04 INFO HttpStatusCodeResultPredicate: Status code 200 check result: false
</pre>

Create index with config `--conf spark.datasource.flint.request.completionDelayMillis=2000`
<pre>
<b>24/11/26 23:50:20</b> INFO FlintOpenSearchClient: Creating Flint index flint_myglue_test_default_with_wait_time with metadata FlintMetadata(...)
24/11/26 23:50:20 INFO FlintOpenSearchClient: Creating Flint index flint_myglue_test_default_with_wait_time
24/11/26 23:50:20 INFO RetryableHttpAsyncClient: Building retryable http async client with options: FlintRetryOptions{maxRetries=3, retryableStatusCodes=429,502, retryableExceptionClassNames=Optional.empty}
24/11/26 23:50:20 INFO HttpStatusCodeResultPredicate: Checking if status code is retryable: 200
24/11/26 23:50:20 INFO HttpStatusCodeResultPredicate: Status code 200 check result: false
<b>24/11/26 23:50:22</b> INFO FlintOpenSearchIndexMetadataService: Updating Flint index flint_myglue_test_default_with_wait_time with metadata FlintMetadata(...)
24/11/26 23:50:22 INFO RetryableHttpAsyncClient: Building retryable http async client with options: FlintRetryOptions{maxRetries=3, retryableStatusCodes=429,502, retryableExceptionClassNames=Optional.empty}
24/11/26 23:50:22 INFO HttpStatusCodeResultPredicate: Checking if status code is retryable: 200
24/11/26 23:50:22 INFO HttpStatusCodeResultPredicate: Status code 200 check result: false
</pre>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
