### PR TITLE
Fix ppl-fillnull-command.md

### DIFF
--- a/docs/ppl-lang/ppl-fillnull-command.md
+++ b/docs/ppl-lang/ppl-fillnull-command.md
@@ -17,7 +17,7 @@ The example show fillnull one field.
 
 PPL query:
 
-    os> source=logs | fields status_code | eval input=status_code | fillnull value = 0 status_code;
+    os> source=logs | fields status_code | eval input=status_code | fillnull with 0 in status_code;
 | input | status_code |
 |-------|-------------|
 | 403   | 403         |
@@ -43,7 +43,7 @@ The example show fillnull applied to multiple fields.
 
 PPL query:
 
-    os> source=logs | fields request_path, timestamp | eval input_request_path=request_path, input_timestamp = timestamp | fillnull value = '???' request_path, timestamp;
+    os> source=logs | fields request_path, timestamp | eval input_request_path=request_path, input_timestamp = timestamp | fillnull with '???' in request_path, timestamp;
 | input_request_path | input_timestamp       | request_path | timestamp              |
 |--------------------|-----------------------|--------------|------------------------|
 | /contact           | NULL                  | /contact     | ???                    |


### PR DESCRIPTION
### Description
The example in ppl-fillnull-command.md is outdated and mismatch with our current syntax.  Update the examples with correct syntax. 

### Related Issues

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
