### PR TITLE
Refactor the `Alias` node to avoid ambiguity

### DIFF
--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Alias.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ast/expression/Alias.java
@@ -13,26 +13,22 @@ import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 /**
- * Alias abstraction that associate an unnamed expression with a name and an optional alias. The
- * name and alias information preserved is useful for semantic analysis and response formatting
+ * Alias abstraction that associate an unnamed expression with a name.
+ * The name information preserved is useful for semantic analysis and response formatting
  * eventually. This can avoid restoring the info in toString() method which is inaccurate because
  * original info is already lost.
  */
-@AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 @Getter
 @RequiredArgsConstructor
 @ToString
 public class Alias extends UnresolvedExpression {
 
-  /** Original field name. */
+  /** The name to be associated with the result of computing delegated expression. */
   private final String name;
 
   /** Expression aliased. */
   private final UnresolvedExpression delegated;
-
-  /** Optional field alias. */
-  private String alias;
 
   @Override
   public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystExpressionVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystExpressionVisitor.java
@@ -257,7 +257,7 @@ public class CatalystExpressionVisitor extends AbstractNodeVisitor<Expression, C
         Expression arg = context.popNamedParseExpressions().get();
         return context.getNamedParseExpressions().push(
                 org.apache.spark.sql.catalyst.expressions.Alias$.MODULE$.apply(arg,
-                        node.getAlias() != null ? node.getAlias() : node.getName(),
+                        node.getName(),
                         NamedExpression.newExprId(),
                         seq(new java.util.ArrayList<String>()),
                         Option.empty(),

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -383,8 +383,7 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     public UnresolvedExpression visitBySpanClause(OpenSearchPPLParser.BySpanClauseContext ctx) {
         String name = ctx.spanClause().getText();
         return ctx.alias != null
-                ? new Alias(
-                name, visit(ctx.spanClause()), StringUtils.unquoteIdentifier(ctx.alias.getText()))
+                ? new Alias(StringUtils.unquoteIdentifier(ctx.alias.getText()), visit(ctx.spanClause()))
                 : new Alias(name, visit(ctx.spanClause()));
     }
 


### PR DESCRIPTION
### Description
Refactor the Alias node to avoid ambiguity. See https://github.com/opensearch-project/opensearch-spark/issues/974 for details.

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-spark/issues/974

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
