### PR TITLE
Add setup-sbt in build workflow

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -22,6 +22,9 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
+      - name: Set up SBT
+        uses: sbt/setup-sbt@v1
+
       - name: Style check
         run: sbt scalafmtCheckAll
 


### PR DESCRIPTION
### Description
sbt is missing in the latest ubuntu runner release. CI failed with message:
```
Run sbt scalafmtCheckAll
/home/runner/work/_temp/1f7874ac-2254-462e-8dda-84ebc8c5e9ba.sh: line 1: sbt: command not found
Error: Process completed with exit code 127.
```

Add setup-sbt action in workflow.

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-spark/issues/977

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
