### PR TITLE
[followup] Add setup-sbt in publish workflow

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -27,6 +27,9 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
+      - name: Set up SBT
+        uses: sbt/setup-sbt@v1
+
       - name: Publish to Local Maven
         run: |
           sbt standaloneCosmetic/publishM2


### PR DESCRIPTION
### Description
A follow-up of #976 . Failure occurs in publishing snapshot to maven.

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-spark/issues/977

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
