### PR TITLE
Implement FlintJob to handle all query types in warmpool mode

### DIFF
--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -96,6 +96,11 @@ public final class MetricConstants {
     public static final String RESULT_METADATA_WRITE_METRIC_PREFIX = "result.metadata.write";
 
     /**
+     * Prefix for metrics related to interactive queries
+     */
+     public static final String STATEMENT = "statement";
+
+    /**
      * Metric name for counting the number of statements currently running.
      */
     public static final String STATEMENT_RUNNING_METRIC = "statement.running.count";
@@ -136,9 +141,29 @@ public final class MetricConstants {
     public static final String STREAMING_HEARTBEAT_FAILED_METRIC = "streaming.heartbeat.failed.count";
 
     /**
+     * Metric for tracking the count of jobs failed during query execution
+     */
+    public static final String QUERY_EXECUTION_FAILED_METRIC = "execution.failed.count";
+
+    /**
+     * Metric for tracking the count of jobs failed during query result write
+     */
+    public static final String RESULT_WRITER_FAILED_METRIC = "writer.failed.count";
+
+    /**
      * Metric for tracking the latency of query execution (start to complete query execution) excluding result write.
      */
     public static final String QUERY_EXECUTION_TIME_METRIC = "query.execution.processingTime";
+
+    /**
+     * Metric for tracking the latency of query result write only (excluding query execution)
+     */
+    public static final String QUERY_RESULT_WRITER_TIME_METRIC = "result.writer.processingTime";
+
+    /**
+     * Metric for tracking the latency of query total execution including result write.
+     */
+    public static final String QUERY_TOTAL_TIME_METRIC = "query.total.processingTime";
 
     /**
      * Metric for query count of each query type (DROP/VACUUM/ALTER/REFRESH/CREATE INDEX)

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -171,6 +171,12 @@ object FlintSparkConf {
     .doc("Enable external scheduler for index refresh")
     .createWithDefault("false")
 
+  val WARMPOOL_ENABLED =
+    FlintConfig("spark.flint.job.warmpoolEnabled")
+      .createWithDefault("false")
+
+  val MAX_EXECUTORS_COUNT = FlintConfig("spark.dynamicAllocation.maxExecutors").createOptional()
+
   val EXTERNAL_SCHEDULER_INTERVAL_THRESHOLD =
     FlintConfig("spark.flint.job.externalScheduler.interval")
       .doc("Interval threshold in minutes for external scheduler to trigger index refresh")
@@ -246,6 +252,10 @@ object FlintSparkConf {
     FlintConfig(s"spark.flint.job.requestIndex")
       .doc("Request index")
       .createOptional()
+  val RESULT_INDEX =
+    FlintConfig(s"spark.flint.job.resultIndex")
+      .doc("Result index")
+      .createOptional()
   val EXCLUDE_JOB_IDS =
     FlintConfig(s"spark.flint.deployment.excludeJobs")
       .doc("Exclude job ids")
@@ -271,6 +281,9 @@ object FlintSparkConf {
   val CUSTOM_QUERY_RESULT_WRITER =
     FlintConfig("spark.flint.job.customQueryResultWriter")
       .createOptional()
+  val TERMINATE_JVM = FlintConfig("spark.flint.terminateJVM")
+    .doc("Indicates whether the JVM should be terminated after query execution")
+    .createWithDefault("true")
 }
 
 /**

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -173,6 +173,7 @@ object FlintSparkConf {
 
   val WARMPOOL_ENABLED =
     FlintConfig("spark.flint.job.warmpoolEnabled")
+      .doc("Enable warmPool mode for the EMR Job to reduce startup times")
       .createWithDefault("false")
 
   val MAX_EXECUTORS_COUNT = FlintConfig("spark.dynamicAllocation.maxExecutors").createOptional()

--- a/integ-test/src/integration/scala/org/apache/spark/sql/FlintJobITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/sql/FlintJobITSuite.scala
@@ -16,12 +16,15 @@ import scala.util.{Failure, Success}
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.opensearch.action.get.GetRequest
 import org.opensearch.client.RequestOptions
+import org.opensearch.flint.common.model.FlintStatement
+import org.opensearch.flint.common.scheduler.model.LangType
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.spark.{FlintSparkIndexMonitor, FlintSparkSuite}
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
 import org.scalatest.matchers.must.Matchers.{contain, defined}
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
+import org.apache.spark.sql.FlintREPL.currentTimeProvider
 import org.apache.spark.sql.flint.FlintDataSourceV2.FLINT_DATASOURCE
 import org.apache.spark.sql.flint.config.FlintSparkConf
 import org.apache.spark.sql.flint.config.FlintSparkConf._
@@ -94,12 +97,22 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
     spark.conf.set(JOB_TYPE.key, FlintJobType.STREAMING)
     spark.conf.set(REQUEST_INDEX.key, requestIndex)
 
+    val flintStatement =
+      new FlintStatement(
+        "running",
+        query,
+        "",
+        queryId,
+        LangType.SQL,
+        currentTimeProvider.currentEpochMillis(),
+        Option.empty,
+        Map.empty)
+
     val job = JobOperator(
       appId,
       jobRunId,
       spark,
-      query,
-      queryId,
+      flintStatement,
       dataSourceName,
       resultIndex,
       FlintJobType.STREAMING,

--- a/integ-test/src/integration/scala/org/apache/spark/sql/FlintJobITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/sql/FlintJobITSuite.scala
@@ -39,6 +39,7 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
   val appId = "00feq82b752mbt0p"
   val dataSourceName = "my_glue1"
   val queryId = "testQueryId"
+  val requestIndex = "testRequestIndex"
   var osClient: OSClient = _
   val threadLocalFuture = new ThreadLocal[Future[Unit]]()
 
@@ -83,6 +84,7 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
 
   def createJobOperator(query: String, jobRunId: String): JobOperator = {
     val streamingRunningCount = new AtomicInteger(0)
+    val statementRunningCount = new AtomicInteger(0)
 
     /*
      * Because we cannot test from FlintJob.main() for the reason below, we have to configure
@@ -90,6 +92,7 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
      */
     spark.conf.set(DATA_SOURCE_NAME.key, dataSourceName)
     spark.conf.set(JOB_TYPE.key, FlintJobType.STREAMING)
+    spark.conf.set(REQUEST_INDEX.key, requestIndex)
 
     val job = JobOperator(
       appId,
@@ -100,7 +103,8 @@ class FlintJobITSuite extends FlintSparkSuite with JobTest {
       dataSourceName,
       resultIndex,
       FlintJobType.STREAMING,
-      streamingRunningCount)
+      streamingRunningCount,
+      statementRunningCount)
     job.terminateJVM = false
     job
   }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
@@ -10,6 +10,8 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
+import org.opensearch.flint.common.model.FlintStatement
+import org.opensearch.flint.common.scheduler.model.LangType
 import org.opensearch.flint.core.logging.CustomLogging
 import org.opensearch.flint.core.metrics.MetricConstants
 import org.opensearch.flint.core.metrics.MetricsUtil.registerGauge
@@ -58,30 +60,29 @@ object FlintJob extends Logging with FlintJobExecutor {
       if (resultIndexOption.isEmpty) {
         logAndThrow("resultIndex is not set")
       }
-      // https://github.com/opensearch-project/opensearch-spark/issues/138
-      /*
-       * To execute queries such as `CREATE SKIPPING INDEX ON my_glue1.default.http_logs_plain (`@timestamp` VALUE_SET) WITH (auto_refresh = true)`,
-       * it's necessary to set `spark.sql.defaultCatalog=my_glue1`. This is because AWS Glue uses a single database (default) and table (http_logs_plain),
-       * and we need to configure Spark to recognize `my_glue1` as a reference to AWS Glue's database and table.
-       * By doing this, we effectively map `my_glue1` to AWS Glue, allowing Spark to resolve the database and table names correctly.
-       * Without this setup, Spark would not recognize names in the format `my_glue1.default`.
-       */
-      conf.set("spark.sql.defaultCatalog", dataSource)
-      configDYNMaxExecutors(conf, jobType)
 
-      val jobOperator =
-        JobOperator(
-          applicationId,
-          jobId,
-          sparkSession,
+      configDYNMaxExecutors(conf, jobType)
+      val flintStatement =
+        new FlintStatement(
+          "running",
           query,
+          "",
           queryId,
-          dataSource,
-          resultIndexOption.get,
-          jobType,
-          streamingRunningCount,
-          statementRunningCount,
+          LangType.SQL,
+          currentTimeProvider.currentEpochMillis(),
+          Option.empty,
           Map.empty)
+
+      val jobOperator = createJobOperator(
+        sparkSession,
+        applicationId,
+        jobId,
+        flintStatement,
+        dataSource,
+        resultIndexOption.get,
+        jobType,
+        streamingRunningCount,
+        statementRunningCount)
       registerGauge(MetricConstants.STREAMING_RUNNING_METRIC, streamingRunningCount)
       jobOperator.start()
     } else {

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJob.scala
@@ -8,12 +8,15 @@ package org.apache.spark.sql
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+
 import org.opensearch.flint.core.logging.CustomLogging
 import org.opensearch.flint.core.metrics.MetricConstants
 import org.opensearch.flint.core.metrics.MetricsUtil.registerGauge
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.flint.config.FlintSparkConf
+import org.apache.spark.util.ThreadUtils
 
 /**
  * Spark SQL Application entrypoint
@@ -26,52 +29,71 @@ import org.apache.spark.sql.flint.config.FlintSparkConf
  *   write sql query result to given opensearch index
  */
 object FlintJob extends Logging with FlintJobExecutor {
+  private val streamingRunningCount = new AtomicInteger(0)
+  private val statementRunningCount = new AtomicInteger(0)
+
   def main(args: Array[String]): Unit = {
     val (queryOption, resultIndexOption) = parseArgs(args)
 
     val conf = createSparkConf()
-    val jobType = conf.get("spark.flint.job.type", FlintJobType.BATCH)
-    CustomLogging.logInfo(s"""Job type is: ${jobType}""")
-    conf.set(FlintSparkConf.JOB_TYPE.key, jobType)
-
-    val dataSource = conf.get("spark.flint.datasource.name", "")
-    val query = queryOption.getOrElse(unescapeQuery(conf.get(FlintSparkConf.QUERY.key, "")))
-    if (query.isEmpty) {
-      logAndThrow(s"Query undefined for the ${jobType} job.")
-    }
-    val queryId = conf.get(FlintSparkConf.QUERY_ID.key, "")
-
-    if (resultIndexOption.isEmpty) {
-      logAndThrow("resultIndex is not set")
-    }
-    // https://github.com/opensearch-project/opensearch-spark/issues/138
-    /*
-     * To execute queries such as `CREATE SKIPPING INDEX ON my_glue1.default.http_logs_plain (`@timestamp` VALUE_SET) WITH (auto_refresh = true)`,
-     * it's necessary to set `spark.sql.defaultCatalog=my_glue1`. This is because AWS Glue uses a single database (default) and table (http_logs_plain),
-     * and we need to configure Spark to recognize `my_glue1` as a reference to AWS Glue's database and table.
-     * By doing this, we effectively map `my_glue1` to AWS Glue, allowing Spark to resolve the database and table names correctly.
-     * Without this setup, Spark would not recognize names in the format `my_glue1.default`.
-     */
-    conf.set("spark.sql.defaultCatalog", dataSource)
-    configDYNMaxExecutors(conf, jobType)
-
+    val sparkSession = createSparkSession(conf)
     val applicationId =
       environmentProvider.getEnvVar("SERVERLESS_EMR_VIRTUAL_CLUSTER_ID", "unknown")
     val jobId = environmentProvider.getEnvVar("SERVERLESS_EMR_JOB_ID", "unknown")
+    val isWarmpoolEnabled = conf.get(FlintSparkConf.WARMPOOL_ENABLED.key, "false").toBoolean
+    logInfo(s"isWarmpoolEnabled: ${isWarmpoolEnabled}")
 
-    val streamingRunningCount = new AtomicInteger(0)
-    val jobOperator =
-      JobOperator(
-        applicationId,
-        jobId,
-        createSparkSession(conf),
-        query,
-        queryId,
-        dataSource,
-        resultIndexOption.get,
-        jobType,
-        streamingRunningCount)
-    registerGauge(MetricConstants.STREAMING_RUNNING_METRIC, streamingRunningCount)
-    jobOperator.start()
+    if (!isWarmpoolEnabled) {
+      val jobType = sparkSession.conf.get("spark.flint.job.type", FlintJobType.BATCH)
+      CustomLogging.logInfo(s"""Job type is: ${jobType}""")
+      sparkSession.conf.set(FlintSparkConf.JOB_TYPE.key, jobType)
+
+      val dataSource = conf.get("spark.flint.datasource.name", "")
+      val query = queryOption.getOrElse(unescapeQuery(conf.get(FlintSparkConf.QUERY.key, "")))
+      if (query.isEmpty) {
+        logAndThrow(s"Query undefined for the ${jobType} job.")
+      }
+      val queryId = conf.get(FlintSparkConf.QUERY_ID.key, "")
+
+      if (resultIndexOption.isEmpty) {
+        logAndThrow("resultIndex is not set")
+      }
+      // https://github.com/opensearch-project/opensearch-spark/issues/138
+      /*
+       * To execute queries such as `CREATE SKIPPING INDEX ON my_glue1.default.http_logs_plain (`@timestamp` VALUE_SET) WITH (auto_refresh = true)`,
+       * it's necessary to set `spark.sql.defaultCatalog=my_glue1`. This is because AWS Glue uses a single database (default) and table (http_logs_plain),
+       * and we need to configure Spark to recognize `my_glue1` as a reference to AWS Glue's database and table.
+       * By doing this, we effectively map `my_glue1` to AWS Glue, allowing Spark to resolve the database and table names correctly.
+       * Without this setup, Spark would not recognize names in the format `my_glue1.default`.
+       */
+      conf.set("spark.sql.defaultCatalog", dataSource)
+      configDYNMaxExecutors(conf, jobType)
+
+      val jobOperator =
+        JobOperator(
+          applicationId,
+          jobId,
+          sparkSession,
+          query,
+          queryId,
+          dataSource,
+          resultIndexOption.get,
+          jobType,
+          streamingRunningCount,
+          statementRunningCount,
+          Map.empty)
+      registerGauge(MetricConstants.STREAMING_RUNNING_METRIC, streamingRunningCount)
+      jobOperator.start()
+    } else {
+      // Fetch and execute queries in warm pool mode
+      val warmpoolJob =
+        WarmpoolJob(
+          applicationId,
+          jobId,
+          sparkSession,
+          streamingRunningCount,
+          statementRunningCount)
+      warmpoolJob.start()
+    }
   }
 }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -106,7 +106,8 @@ object FlintREPL extends Logging with FlintJobExecutor {
           dataSource,
           resultIndexOption.get,
           jobType,
-          streamingRunningCount)
+          streamingRunningCount,
+          statementRunningCount)
       registerGauge(MetricConstants.STREAMING_RUNNING_METRIC, streamingRunningCount)
       jobOperator.start()
     } else {
@@ -1019,33 +1020,6 @@ object FlintREPL extends Logging with FlintJobExecutor {
       case _ =>
         logAndThrow(s"${FlintSparkConf.SESSION_ID.key} is not set or is empty")
     }
-  }
-
-  private def instantiateSessionManager(
-      spark: SparkSession,
-      resultIndexOption: Option[String]): SessionManager = {
-    instantiate(
-      new SessionManagerImpl(spark, resultIndexOption),
-      spark.conf.get(FlintSparkConf.CUSTOM_SESSION_MANAGER.key, ""),
-      resultIndexOption.getOrElse(""))
-  }
-
-  private def instantiateStatementExecutionManager(
-      commandContext: CommandContext): StatementExecutionManager = {
-    import commandContext._
-    instantiate(
-      new StatementExecutionManagerImpl(commandContext),
-      spark.conf.get(FlintSparkConf.CUSTOM_STATEMENT_MANAGER.key, ""),
-      spark,
-      sessionId)
-  }
-
-  private def instantiateQueryResultWriter(
-      spark: SparkSession,
-      commandContext: CommandContext): QueryResultWriter = {
-    instantiate(
-      new QueryResultWriterImpl(commandContext),
-      spark.conf.get(FlintSparkConf.CUSTOM_QUERY_RESULT_WRITER.key, ""))
   }
 
   private def recordSessionSuccess(sessionTimerContext: Timer.Context): Unit = {

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -15,6 +15,7 @@ import scala.util.control.NonFatal
 
 import com.codahale.metrics.Timer
 import org.opensearch.flint.common.model.{FlintStatement, InteractiveSession, SessionStates}
+import org.opensearch.flint.common.scheduler.model.LangType
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.logging.CustomLogging
 import org.opensearch.flint.core.metrics.{MetricConstants, MetricsSparkListener, MetricsUtil}
@@ -23,6 +24,7 @@ import org.opensearch.flint.core.metrics.MetricsUtil.{getTimerContext, increment
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
+import org.apache.spark.sql.FlintJob.currentTimeProvider
 import org.apache.spark.sql.FlintREPLConfConstants._
 import org.apache.spark.sql.SessionUpdateMode._
 import org.apache.spark.sql.flint.config.FlintSparkConf
@@ -95,14 +97,24 @@ object FlintREPL extends Logging with FlintJobExecutor {
         logAndThrow("resultIndex is not set")
       }
       configDYNMaxExecutors(conf, jobType)
+
       val streamingRunningCount = new AtomicInteger(0)
+      val flintStatement =
+        new FlintStatement(
+          "running",
+          query,
+          "",
+          queryId,
+          LangType.SQL,
+          currentTimeProvider.currentEpochMillis(),
+          Option.empty,
+          Map.empty)
       val jobOperator =
         JobOperator(
           applicationId,
           jobId,
           createSparkSession(conf),
-          query,
-          queryId,
+          flintStatement,
           dataSource,
           resultIndexOption.get,
           jobType,

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -169,7 +169,7 @@ case class JobOperator(
         case t: Throwable =>
           incrementCounter(MetricConstants.RESULT_WRITER_FAILED_METRIC)
           throwableHandler.recordThrowable(
-            s"Failed to write to result. originalError='${t.getMessage}'",
+            s"Failed to write to result. originalError='${throwableHandler.error}'",
             t)
       } finally {
         emitTimerMetric(MetricConstants.QUERY_RESULT_WRITER_TIME_METRIC, resultWriterStartTime)

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -15,7 +15,6 @@ import scala.util.{Failure, Success, Try}
 import org.opensearch.flint.common.model.FlintStatement
 import org.opensearch.flint.common.scheduler.model.LangType
 import org.opensearch.flint.core.metrics.{MetricConstants, MetricsSparkListener, MetricsUtil}
-import org.opensearch.flint.core.metrics.MetricsUtil.incrementCounter
 import org.opensearch.flint.spark.FlintSpark
 
 import org.apache.spark.internal.Logging
@@ -32,25 +31,39 @@ case class JobOperator(
     dataSource: String,
     resultIndex: String,
     jobType: String,
-    streamingRunningCount: AtomicInteger)
+    streamingRunningCount: AtomicInteger,
+    statementRunningCount: AtomicInteger,
+    statementContext: Map[String, Any] = Map.empty[String, Any])
     extends Logging
     with FlintJobExecutor {
 
   // JVM shutdown hook
   sys.addShutdownHook(stop())
+  val isStreamingOrBatch =
+    jobType.equalsIgnoreCase(FlintJobType.STREAMING) || jobType.equalsIgnoreCase(
+      FlintJobType.BATCH)
+  val isWarmpoolEnabled =
+    sparkSession.conf.get(FlintSparkConf.WARMPOOL_ENABLED.key, "false").toBoolean
+  val segmentName = getSegmentName(sparkSession)
 
   def start(): Unit = {
     val threadPool = ThreadUtils.newDaemonFixedThreadPool(1, "check-create-index")
     implicit val executionContext = ExecutionContext.fromExecutor(threadPool)
-
     var dataToWrite: Option[DataFrame] = None
 
     val startTime = System.currentTimeMillis()
-    streamingRunningCount.incrementAndGet()
+    if (isStreamingOrBatch) {
+      streamingRunningCount.incrementAndGet()
+    } else {
+      statementRunningCount.incrementAndGet()
+    }
 
     // osClient needs spark session to be created first to get FlintOptions initialized.
     // Otherwise, we will have connection exception from EMR-S to OS.
     val osClient = new OSClient(FlintSparkConf().flintOptions())
+
+    // QueryResultWriter depends on sessionManager to fetch the sessionContext
+    val sessionManager = instantiateSessionManager(sparkSession, Some(resultIndex))
 
     // TODO: Update FlintJob to Support All Query Types. Track on https://github.com/opensearch-project/opensearch-spark/issues/633
     val commandContext = CommandContext(
@@ -60,7 +73,7 @@ case class JobOperator(
       dataSource,
       jobType,
       "", // FlintJob doesn't have sessionId
-      null, // FlintJob doesn't have SessionManager
+      sessionManager,
       Duration.Inf, // FlintJob doesn't have queryExecutionTimeout
       -1, // FlintJob doesn't have inactivityLimitMillis
       -1, // FlintJob doesn't have queryWaitTimeMillis
@@ -80,7 +93,9 @@ case class JobOperator(
         "",
         queryId,
         LangType.SQL,
-        currentTimeProvider.currentEpochMillis())
+        currentTimeProvider.currentEpochMillis(),
+        Option.empty,
+        statementContext)
 
     try {
       val futurePrepareQueryExecution = Future {
@@ -119,6 +134,7 @@ case class JobOperator(
             query,
             "",
             startTime))
+        incrementCounter(MetricConstants.QUERY_EXECUTION_FAILED_METRIC)
       case t: Throwable =>
         val error = processQueryException(t)
         dataToWrite = Some(
@@ -133,18 +149,30 @@ case class JobOperator(
             query,
             "",
             startTime))
+        incrementCounter(MetricConstants.QUERY_EXECUTION_FAILED_METRIC)
     } finally {
-      emitQueryExecutionTimeMetric(startTime)
+      emitTimerMetric(MetricConstants.QUERY_EXECUTION_TIME_METRIC, startTime)
       readWriteBytesSparkListener.emitMetrics()
       sparkSession.sparkContext.removeSparkListener(readWriteBytesSparkListener)
 
+      val resultWriterStartTime = System.currentTimeMillis()
       try {
-        dataToWrite.foreach(df => writeDataFrameToOpensearch(df, resultIndex, osClient))
+        dataToWrite.foreach(df => {
+          if (isStreamingOrBatch) {
+            writeDataFrameToOpensearch(df, resultIndex, osClient)
+          } else {
+            val queryResultWriter = instantiateQueryResultWriter(sparkSession, commandContext)
+            queryResultWriter.writeDataFrame(df, statement)
+          }
+        })
       } catch {
         case t: Throwable =>
+          incrementCounter(MetricConstants.RESULT_WRITER_FAILED_METRIC)
           throwableHandler.recordThrowable(
-            s"Failed to write to result index. originalError='${throwableHandler.error}'",
+            s"Failed to write to result. originalError='${t.getMessage}'",
             t)
+      } finally {
+        emitTimerMetric(MetricConstants.QUERY_RESULT_WRITER_TIME_METRIC, resultWriterStartTime)
       }
       if (throwableHandler.hasException) statement.fail() else statement.complete()
       statement.error = Some(throwableHandler.error)
@@ -157,30 +185,29 @@ case class JobOperator(
             s"Failed to update statement. originalError='${throwableHandler.error}'",
             t)
       }
-
+      emitTimerMetric(MetricConstants.QUERY_TOTAL_TIME_METRIC, startTime)
       cleanUpResources(threadPool)
     }
   }
 
   def cleanUpResources(threadPool: ThreadPoolExecutor): Unit = {
-    val isStreaming = jobType.equalsIgnoreCase(FlintJobType.STREAMING)
     try {
-      // Wait for streaming job complete if no error
-      if (!throwableHandler.hasException && isStreaming) {
+      // Wait for job complete if no error
+      if (!throwableHandler.hasException && isStreamingOrBatch) {
         // Clean Spark shuffle data after each microBatch.
         sparkSession.streams.addListener(new ShuffleCleaner(sparkSession))
         // Await index monitor before the main thread terminates
         new FlintSpark(sparkSession).flintIndexMonitor.awaitMonitor()
       } else {
         logInfo(s"""
-           | Skip streaming job await due to conditions not met:
-           |  - exceptionThrown: ${throwableHandler.hasException}
-           |  - streaming: $isStreaming
-           |  - activeStreams: ${sparkSession.streams.active.mkString(",")}
-           |""".stripMargin)
+                   | Skip job await due to conditions not met:
+                   |  - exceptionThrown: ${throwableHandler.hasException}
+                   |  - streaming: $isStreamingOrBatch
+                   |  - activeStreams: ${sparkSession.streams.active.mkString(",")}
+                   |""".stripMargin)
       }
     } catch {
-      case e: Exception => logError("streaming job failed", e)
+      case e: Exception => logError("job failed", e)
     }
 
     try {
@@ -190,7 +217,7 @@ case class JobOperator(
     } catch {
       case e: Exception => logError("Fail to close threadpool", e)
     }
-    recordStreamingCompletionStatus(throwableHandler.hasException)
+    recordCompletionStatus(throwableHandler.hasException)
 
     // Check for non-daemon threads that may prevent the driver from shutting down.
     // Non-daemon threads other than the main thread indicate that the driver is still processing tasks,
@@ -205,11 +232,9 @@ case class JobOperator(
     }
   }
 
-  private def emitQueryExecutionTimeMetric(startTime: Long): Unit = {
+  private def emitTimerMetric(metricName: String, startTime: Long): Unit = {
     MetricsUtil
-      .addHistoricGauge(
-        MetricConstants.QUERY_EXECUTION_TIME_METRIC,
-        System.currentTimeMillis() - startTime)
+      .addHistoricGauge(resolveMetricName(metricName), System.currentTimeMillis() - startTime)
   }
 
   def stop(): Unit = {
@@ -229,22 +254,34 @@ case class JobOperator(
   }
 
   /**
-   * Records the completion of a streaming job by updating the appropriate metrics. This method
-   * decrements the running metric for streaming jobs and increments either the success or failure
-   * metric based on whether an exception was thrown.
+   * Records the completion of a job by updating the appropriate metrics. This method decrements
+   * the running metric for jobs and increments either the success or failure metric based on
+   * whether an exception was thrown.
    *
    * @param exceptionThrown
-   *   Indicates whether an exception was thrown during the streaming job execution.
+   *   Indicates whether an exception was thrown during the job execution.
    */
-  private def recordStreamingCompletionStatus(exceptionThrown: Boolean): Unit = {
-    // Decrement the metric for running streaming jobs as the job is now completing.
+  private def recordCompletionStatus(exceptionThrown: Boolean): Unit = {
+    // Decrement the metric for running jobs as the job is now completing.
     if (streamingRunningCount.get() > 0) {
       streamingRunningCount.decrementAndGet()
+    } else if (statementRunningCount.get() > 0) {
+      statementRunningCount.decrementAndGet()
     }
 
-    exceptionThrown match {
-      case true => incrementCounter(MetricConstants.STREAMING_FAILED_METRIC)
-      case false => incrementCounter(MetricConstants.STREAMING_SUCCESS_METRIC)
+    val metric = {
+      (exceptionThrown, isStreamingOrBatch) match {
+        case (true, true) => MetricConstants.STREAMING_FAILED_METRIC
+        case (true, false) => MetricConstants.STATEMENT_FAILED_METRIC
+        case (false, true) => MetricConstants.STREAMING_SUCCESS_METRIC
+        case (false, false) => MetricConstants.STATEMENT_SUCCESS_METRIC
+      }
+    }
+
+    if (isWarmpoolEnabled) {
+      MetricsUtil.incrementCounter(String.format("%s.%s", segmentName, metric));
+    } else {
+      MetricsUtil.incrementCounter(metric);
     }
   }
 
@@ -258,5 +295,42 @@ case class JobOperator(
       spark.conf.get(FlintSparkConf.CUSTOM_STATEMENT_MANAGER.key, ""),
       spark,
       sessionId)
+  }
+
+  /**
+   * Returns a segment name formatted with the maximum executor count. For example, if the max
+   * executor count is 1, the return value will be "1e".
+   *
+   * @param spark
+   *   The Spark session.
+   * @return
+   *   A string in the format "<maxExecutorsCount>e", e.g., "1e", "2e".
+   */
+  private def getSegmentName(spark: SparkSession): String = {
+    val maxExecutorsCount = spark.conf.get(FlintSparkConf.MAX_EXECUTORS_COUNT.key, "unknown")
+    String.format("%se", maxExecutorsCount)
+  }
+
+  /**
+   * Resolves the full metric name based on the job type and warm pool status. If the warm pool is
+   * enabled, the metric name is prefixed with the segment name and job type (STREAMING or
+   * STATEMENT).
+   *
+   * @param metricName
+   *   The base metric name to resolve.
+   * @return
+   *   The resolved metric name, e.g., "1e.streaming.success.count" if warm pool is enabled.
+   */
+  private def resolveMetricName(metricName: String): String = {
+    if (isWarmpoolEnabled) {
+      val jobType = if (isStreamingOrBatch) FlintJobType.STREAMING else MetricConstants.STATEMENT
+      val newMetricName = String.format("%s.%s.%s", segmentName, jobType, metricName)
+      return newMetricName
+    }
+    metricName
+  }
+
+  private def incrementCounter(metricName: String): Unit = {
+    MetricsUtil.incrementCounter(resolveMetricName(metricName))
   }
 }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/WarmpoolJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/WarmpoolJob.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.spark.sql
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.duration.Duration
+
+import org.opensearch.flint.common.model.FlintStatement
+import org.opensearch.flint.core.metrics.MetricConstants
+import org.opensearch.flint.core.metrics.MetricsUtil.registerGauge
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.flint.config.FlintSparkConf
+
+/**
+ * This class executes Spark jobs in "warm pool" mode, repeatedly calling the client to fetch
+ * query details (job type, data source, configurations). The job is created without any
+ * query-specific configurations, and the client sets the Spark configurations at runtime during
+ * each iteration
+ */
+case class WarmpoolJob(
+    applicationId: String,
+    jobId: String,
+    spark: SparkSession,
+    streamingRunningCount: AtomicInteger,
+    statementRunningCount: AtomicInteger)
+    extends Logging
+    with FlintJobExecutor {
+
+  def start(): Unit = {
+    val commandContext = CommandContext(
+      applicationId,
+      jobId,
+      spark,
+      "", // datasource is not known yet
+      "", // jobType is not known yet
+      "", // WP doesn't have sessionId
+      null, // WP doesn't use SessionManager
+      Duration.Inf, // WP doesn't have queryExecutionTimeout
+      -1, // WP doesn't have inactivityLimitMillis
+      -1, // WP doesn't have queryWaitTimeMillis
+      -1 // WP doesn't have queryLoopExecutionFrequency
+    )
+
+    registerGauge(MetricConstants.STREAMING_RUNNING_METRIC, streamingRunningCount)
+    registerGauge(MetricConstants.STATEMENT_RUNNING_METRIC, statementRunningCount)
+    val statementExecutionManager =
+      instantiateStatementExecutionManager(commandContext)
+
+    queryLoop(statementExecutionManager)
+  }
+
+  /**
+   * Executes statements from the StatementExecutionManager in a loop until no more statements are
+   * available.
+   */
+  def queryLoop(statementExecutionManager: StatementExecutionManager): Unit = {
+    var canProceed = true
+
+    try {
+      while (canProceed) {
+        statementExecutionManager.getNextStatement() match {
+          case Some(flintStatement) =>
+            flintStatement.running()
+            statementExecutionManager.updateStatement(flintStatement)
+
+            val jobType = spark.conf.get(FlintSparkConf.JOB_TYPE.key, FlintJobType.BATCH)
+            val dataSource = spark.conf.get(FlintSparkConf.DATA_SOURCE_NAME.key)
+            val resultIndex = spark.conf.get(FlintSparkConf.RESULT_INDEX.key)
+            val jobOperator = createJobOperator(flintStatement, dataSource, resultIndex, jobType)
+
+            // The client sets this Spark configuration at runtime for each iteration
+            // to control whether the JVM should be terminated after the query execution.
+            jobOperator.terminateJVM =
+              spark.conf.get(FlintSparkConf.TERMINATE_JVM.key, "true").toBoolean
+            jobOperator.start()
+
+          case _ =>
+            canProceed = false
+        }
+      }
+    } catch {
+      case t: Throwable =>
+        // Record and rethrow in query loop
+        throwableHandler.recordThrowable(s"Query loop execution failed.", t)
+        throw t
+    }
+  }
+
+  def createJobOperator(
+      flintStatement: FlintStatement,
+      dataSource: String,
+      resultIndex: String,
+      jobType: String): JobOperator = {
+    // https://github.com/opensearch-project/opensearch-spark/issues/138
+    /*
+     * To execute queries such as `CREATE SKIPPING INDEX ON my_glue1.default.http_logs_plain (`@timestamp` VALUE_SET) WITH (auto_refresh = true)`,
+     * it's necessary to set `spark.sql.defaultCatalog=my_glue1`. This is because AWS Glue uses a single database (default) and table (http_logs_plain),
+     * and we need to configure Spark to recognize `my_glue1` as a reference to AWS Glue's database and table.
+     * By doing this, we effectively map `my_glue1` to AWS Glue, allowing Spark to resolve the database and table names correctly.
+     * Without this setup, Spark would not recognize names in the format `my_glue1.default`.
+     */
+    spark.conf.set("spark.sql.defaultCatalog", dataSource)
+    val jobOperator =
+      JobOperator(
+        applicationId,
+        jobId,
+        spark,
+        flintStatement.query,
+        flintStatement.queryId,
+        dataSource,
+        resultIndex,
+        jobType,
+        streamingRunningCount,
+        statementRunningCount,
+        flintStatement.context)
+    jobOperator
+  }
+}

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/WarmpoolJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/WarmpoolJob.scala
@@ -9,10 +9,12 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.Duration
 
 import org.opensearch.flint.common.model.FlintStatement
+import org.opensearch.flint.common.scheduler.model.LangType
 import org.opensearch.flint.core.metrics.MetricConstants
 import org.opensearch.flint.core.metrics.MetricsUtil.registerGauge
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.FlintJob.currentTimeProvider
 import org.apache.spark.sql.flint.config.FlintSparkConf
 
 /**
@@ -70,7 +72,16 @@ case class WarmpoolJob(
             val jobType = spark.conf.get(FlintSparkConf.JOB_TYPE.key, FlintJobType.BATCH)
             val dataSource = spark.conf.get(FlintSparkConf.DATA_SOURCE_NAME.key)
             val resultIndex = spark.conf.get(FlintSparkConf.RESULT_INDEX.key)
-            val jobOperator = createJobOperator(flintStatement, dataSource, resultIndex, jobType)
+            val jobOperator = createJobOperator(
+              spark,
+              applicationId,
+              jobId,
+              flintStatement,
+              dataSource,
+              resultIndex,
+              jobType,
+              streamingRunningCount,
+              statementRunningCount)
 
             // The client sets this Spark configuration at runtime for each iteration
             // to control whether the JVM should be terminated after the query execution.
@@ -88,35 +99,5 @@ case class WarmpoolJob(
         throwableHandler.recordThrowable(s"Query loop execution failed.", t)
         throw t
     }
-  }
-
-  def createJobOperator(
-      flintStatement: FlintStatement,
-      dataSource: String,
-      resultIndex: String,
-      jobType: String): JobOperator = {
-    // https://github.com/opensearch-project/opensearch-spark/issues/138
-    /*
-     * To execute queries such as `CREATE SKIPPING INDEX ON my_glue1.default.http_logs_plain (`@timestamp` VALUE_SET) WITH (auto_refresh = true)`,
-     * it's necessary to set `spark.sql.defaultCatalog=my_glue1`. This is because AWS Glue uses a single database (default) and table (http_logs_plain),
-     * and we need to configure Spark to recognize `my_glue1` as a reference to AWS Glue's database and table.
-     * By doing this, we effectively map `my_glue1` to AWS Glue, allowing Spark to resolve the database and table names correctly.
-     * Without this setup, Spark would not recognize names in the format `my_glue1.default`.
-     */
-    spark.conf.set("spark.sql.defaultCatalog", dataSource)
-    val jobOperator =
-      JobOperator(
-        applicationId,
-        jobId,
-        spark,
-        flintStatement.query,
-        flintStatement.queryId,
-        dataSource,
-        resultIndex,
-        jobType,
-        streamingRunningCount,
-        statementRunningCount,
-        flintStatement.context)
-    jobOperator
   }
 }

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/util/WarmpoolTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/util/WarmpoolTest.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql
+
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.Mockito.{doAnswer, spy, times, verify, when}
+import org.opensearch.flint.common.model.FlintStatement
+import org.opensearch.flint.common.scheduler.model.LangType
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.flint.config.FlintSparkConf
+
+class WarmpoolTest extends SparkFunSuite with MockitoSugar with JobMatchers {
+  private val jobId = "testJobId"
+  private val applicationId = "testApplicationId"
+  val streamingRunningCount = new AtomicInteger(0)
+  val statementRunningCount = new AtomicInteger(0)
+  var mockStatementExecutionManager: StatementExecutionManager = _
+  val resultIndex = "testResultIndex"
+  val dataSourceName = "my_glue1"
+  val requestIndex = "testRequestIndex"
+
+  test("verify job operator starts twice when there are two Flint statements") {
+    val mockSparkSession = mock[SparkSession]
+    val mockConf = mock[RuntimeConfig]
+    val mockStatementExecutionManager = mock[StatementExecutionManager]
+    val mockJobOperator = mock[JobOperator]
+
+    val firstFlintStatement = new FlintStatement(
+      "waiting",
+      "select 1",
+      "30",
+      "10",
+      LangType.SQL,
+      Instant.now().toEpochMilli(),
+      None)
+
+    val secondFlintStatement = new FlintStatement(
+      "waiting",
+      "select * from DB",
+      "30",
+      "10",
+      LangType.SQL,
+      Instant.now().toEpochMilli(),
+      None)
+
+    when(mockSparkSession.conf).thenReturn(mockConf)
+    when(mockStatementExecutionManager.getNextStatement())
+      .thenReturn(Some(firstFlintStatement))
+      .thenReturn(Some(secondFlintStatement))
+      .thenReturn(None)
+
+    when(mockSparkSession.conf.get(FlintSparkConf.JOB_TYPE.key, FlintJobType.BATCH))
+      .thenReturn(FlintJobType.BATCH)
+    when(mockSparkSession.conf.get(FlintSparkConf.DATA_SOURCE_NAME.key))
+      .thenReturn(dataSourceName)
+    when(mockSparkSession.conf.get(FlintSparkConf.RESULT_INDEX.key)).thenReturn(resultIndex)
+    when(mockSparkSession.conf.get(FlintSparkConf.TERMINATE_JVM.key, "true")).thenReturn("true")
+    when(mockSparkSession.conf.get(FlintSparkConf.WARMPOOL_ENABLED.key, "false"))
+      .thenReturn("true")
+    when(mockSparkSession.conf.get(FlintSparkConf.REQUEST_INDEX.key, ""))
+      .thenReturn(requestIndex)
+
+    val job = spy(
+      WarmpoolJob(
+        applicationId,
+        jobId,
+        mockSparkSession,
+        statementRunningCount,
+        statementRunningCount))
+
+    doAnswer(_ => mockJobOperator)
+      .when(job)
+      .createJobOperator(any(), anyString(), anyString(), anyString())
+
+    job.queryLoop(mockStatementExecutionManager)
+    verify(mockJobOperator, times(2)).start()
+  }
+
+  test("Query loop execution failure") {
+    val mockSparkSession = mock[SparkSession]
+    val mockConf = mock[RuntimeConfig]
+    val mockStatementExecutionManager = mock[StatementExecutionManager]
+
+    when(mockSparkSession.conf).thenReturn(mockConf)
+    when(mockStatementExecutionManager.getNextStatement())
+      .thenThrow(new RuntimeException("something went wrong"))
+
+    val job =
+      WarmpoolJob(
+        applicationId,
+        jobId,
+        mockSparkSession,
+        statementRunningCount,
+        statementRunningCount)
+
+    assertThrows[Throwable] {
+      job.queryLoop(mockStatementExecutionManager)
+    }
+  }
+}

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/util/WarmpoolTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/util/WarmpoolTest.scala
@@ -78,7 +78,16 @@ class WarmpoolTest extends SparkFunSuite with MockitoSugar with JobMatchers {
 
     doAnswer(_ => mockJobOperator)
       .when(job)
-      .createJobOperator(any(), anyString(), anyString(), anyString())
+      .createJobOperator(
+        any(),
+        anyString(),
+        anyString(),
+        any(),
+        anyString(),
+        anyString(),
+        anyString(),
+        any(),
+        any())
 
     job.queryLoop(mockStatementExecutionManager)
     verify(mockJobOperator, times(2)).start()


### PR DESCRIPTION
### Description

This PR introduces support for FlintJob to handle all types of queries — interactive, streaming, and batch — with all data sources in warmpool mode. Additionally, FlintJob will also support non-warmpool mode for streaming and batch queries, configurable via a Spark configuration setting.

FlintJob invokes `Warmpool.scala`, which in turn calls the client to continuously fetch queries for execution. The client sets various Spark configurations, such as the datasource, resultIndex, and other parameters. It also controls when to terminate the loop and stop the job. When a valid query is received, the JobOperator flow is triggered to execute the query and write the results accordingly.


**Changes:**

- Introduces a new file, Warmpool.scala, which repeatedly calls `getNextStatement()` in a loop.
- Adds support in `JobOperator` to write the query results either to QueryResultWriter or an OpenSearch Index, depending on the job type.
- Implements the emission of success, failure, and latency metrics within `JobOperator`.

### Related Issues


### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
