### PR TITLE
[Backport 0.6] [followup] Add setup-sbt in snapshot-publish workflow

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -27,6 +27,9 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
+      - name: Set up SBT
+        uses: sbt/setup-sbt@v1
+
       - name: Publish to Local Maven
         run: |
           sbt standaloneCosmetic/publishM2


### PR DESCRIPTION
Backport https://github.com/opensearch-project/opensearch-spark/commit/9902a3f8b788a010057dbb30f8c372ce2c92fbde from https://github.com/opensearch-project/opensearch-spark/pull/978.