### PR TITLE
Update to upload-artifact@v4

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload test report
         if: always() # Ensures the artifact is saved even if tests fail
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: target/test-reports # Adjust this path if necessary


### PR DESCRIPTION
### Description
CI is failing for
> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

