### PR TITLE
Unshade auth-crt due to known issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,8 +68,7 @@ val packagesToShade = Seq(
   "org.glassfish.json.**",
   "org.joda.time.**",
   "org.reactivestreams.**",
-  "org.yaml.**",
-  "software.amazon.**"
+  "org.yaml.**"
 )
 
 ThisBuild / assemblyShadeRules := Seq(


### PR DESCRIPTION
### Description
* Unshaded auth-crt library to address the `UnsatisfiedLinkError`. This change is necessary due to a known issue where a temporary library copy is created for loading, and the `CRT_LIB_NAME` constant cannot be altered.


### Related Issues
https://github.com/awslabs/aws-crt-java/issues/166

```
java.lang.NoClassDefFoundError: Could not initialize class shaded.flint.software.amazon.awssdk.crt.auth.signing.AwsSigningConfig
	at shaded.flint.software.amazon.awssdk.authcrt.signer.internal.SigningConfigProvider.createStringToSignConfig(SigningConfigProvider.java:111) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at shaded.flint.software.amazon.awssdk.authcrt.signer.internal.SigningConfigProvider.createDefaultRequestConfig(SigningConfigProvider.java:91) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at shaded.flint.software.amazon.awssdk.authcrt.signer.internal.SigningConfigProvider.createCrtSigningConfig(SigningConfigProvider.java:41) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at shaded.flint.software.amazon.awssdk.authcrt.signer.internal.DefaultAwsCrtV4aSigner.sign(DefaultAwsCrtV4aSigner.java:58) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at org.opensearch.flint.core.auth.AWSRequestSigV4ASigningApacheInterceptor.signRequest(AWSRequestSigV4ASigningApacheInterceptor.java:171) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at org.opensearch.flint.core.auth.AWSRequestSigV4ASigningApacheInterceptor.process(AWSRequestSigV4ASigningApacheInterceptor.java:85) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at org.opensearch.flint.core.auth.ResourceBasedAWSRequestSigningApacheInterceptor.process(ResourceBasedAWSRequestSigningApacheInterceptor.java:91) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at shaded.flint.org.apache.http.protocol.ImmutableHttpProcessor.process(ImmutableHttpProcessor.java:133) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
...
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError: 'void shaded.flint.software.amazon.awssdk.crt.CRT.awsCrtInit(int, boolean, boolean)' [in thread "main"]
	at shaded.flint.software.amazon.awssdk.crt.CRT.awsCrtInit(Native Method) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at shaded.flint.software.amazon.awssdk.crt.CRT.<clinit>(CRT.java:62) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at shaded.flint.software.amazon.awssdk.crt.CrtResource.<clinit>(CrtResource.java:104) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at shaded.flint.software.amazon.awssdk.authcrt.signer.internal.SigningConfigProvider.createStringToSignConfig(SigningConfigProvider.java:111) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at shaded.flint.software.amazon.awssdk.authcrt.signer.internal.SigningConfigProvider.createDefaultRequestConfig(SigningConfigProvider.java:91) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at shaded.flint.software.amazon.awssdk.authcrt.signer.internal.SigningConfigProvider.createCrtSigningConfig(SigningConfigProvider.java:41) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]
	at shaded.flint.software.amazon.awssdk.authcrt.signer.internal.DefaultAwsCrtV4aSigner.sign(DefaultAwsCrtV4aSigner.java:58) ~[opensearch-spark-standalone_2.12-latest.jar:0.6.0-SNAPSHOT]

```

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
