### PR TITLE
Add Join and Lookup IT on OpenSearch Table

### DIFF
--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -48,6 +48,12 @@ val df = spark.sql("SELECT * FROM dev.default.`my_index*`")
 df.show()
 ```
 
+Join two indices
+```scala
+val df = spark.sql("SELECT * FROM dev.default.my_index as t1 JOIN dev.default.my_index as t2 ON t1.id == t2.id")
+df.show()
+```
+
 ## Limitation
 ### catalog operation
 - List Tables: Not supported.

--- a/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.opensearch.table
+
+import org.opensearch.flint.spark.ppl.FlintPPLSuite
+
+import org.apache.spark.sql.Row
+
+/**
+ * Test queries on OpenSearch Table
+ */
+class OpenSearchTableQueryITSuite extends OpenSearchCatalogSuite with FlintPPLSuite {
+  test("SQL Join two indices") {
+    val indexName1 = "t0001"
+    val indexName2 = "t0002"
+    withIndexName(indexName1) {
+      withIndexName(indexName2) {
+        simpleIndex(indexName1)
+        simpleIndex(indexName2)
+        val df = spark.sql(s"""
+        SELECT t1.accountId, t2.eventName, t2.eventSource
+        FROM ${catalogName}.default.$indexName1 as t1 JOIN ${catalogName}.default.$indexName2 as t2 ON
+        t1.accountId == t2.accountId""")
+
+        checkAnswer(df, Row("123", "event", "source"))
+      }
+    }
+  }
+
+  test("PPL Lookup") {
+    val indexName1 = "t0001"
+    val indexName2 = "t0002"
+    val factTbl = s"${catalogName}.default.$indexName1"
+    val lookupTbl = s"${catalogName}.default.$indexName2"
+    withIndexName(indexName1) {
+      withIndexName(indexName2) {
+        simpleIndex(indexName1)
+        simpleIndex(indexName2)
+
+        val df = spark.sql(
+          s"source = $factTbl | stats count() by accountId " +
+            s"| LOOKUP $lookupTbl accountId REPLACE eventSource")
+        checkAnswer(df, Row(1, "123", "source"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
1. Add Join and Lookup IT on OpenSearch Table.
2. Add Join example in OpenSearch Table doc 

### Related Issues
n/a

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
