### PR TITLE
Stabilize adaptive rate limit by considering current rate

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -543,6 +543,8 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
 - `spark.datasource.flint.read.scroll_size`: default value is 100.
 - `spark.datasource.flint.read.scroll_duration`: default value is 5 minutes. scroll context keep alive duration.
 - `spark.datasource.flint.retry.max_retries`: max retries on failed HTTP request. default value is 3. Use 0 to disable retry.
+- `spark.datasource.flint.retry.bulk.max_retries`: max retries on failed bulk request. default value is 10. Use 0 to disable retry.
+- `spark.datasource.flint.retry.bulk.initial_backoff`: initial backoff in seconds for bulk request retry, default is 4.
 - `spark.datasource.flint.retry.http_status_codes`: retryable HTTP response status code list. default value is "429,502" (429 Too Many Request and 502 Bad Gateway).
 - `spark.datasource.flint.retry.exception_class_names`: retryable exception class name list. by default no retry on any exception thrown.
 - `spark.datasource.flint.read.support_shard`: default is true. set to false if index does not support shard (AWS OpenSearch Serverless collection). Do not use in production, this setting will be removed in later version. 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/FlintRetryOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/FlintRetryOptions.java
@@ -41,6 +41,10 @@ public class FlintRetryOptions implements Serializable {
    */
   public static final int DEFAULT_MAX_RETRIES = 3;
   public static final String MAX_RETRIES = "retry.max_retries";
+  public static final int DEFAULT_BULK_MAX_RETRIES = 10;
+  public static final String BULK_MAX_RETRIES = "retry.bulk.max_retries";
+  public static final int DEFAULT_BULK_INITIAL_BACKOFF = 4;
+  public static final String BULK_INITIAL_BACKOFF = "retry.bulk.initial_backoff";
 
   public static final String DEFAULT_RETRYABLE_HTTP_STATUS_CODES = "429,502";
   public static final String RETRYABLE_HTTP_STATUS_CODES = "retry.http_status_codes";
@@ -90,9 +94,9 @@ public class FlintRetryOptions implements Serializable {
   public RetryPolicy<BulkResponse> getBulkRetryPolicy(CheckedPredicate<BulkResponse> resultPredicate) {
     return RetryPolicy.<BulkResponse>builder()
         // Using higher initial backoff to mitigate throttling quickly
-        .withBackoff(4, 30, SECONDS)
+        .withBackoff(getBulkInitialBackoff(), 30, SECONDS)
         .withJitter(Duration.ofMillis(100))
-        .withMaxRetries(getMaxRetries())
+        .withMaxRetries(getBulkMaxRetries())
         // Do not retry on exception (will be handled by the other retry policy
         .handleIf((ex) -> false)
         .handleResultIf(resultPredicate)
@@ -119,6 +123,22 @@ public class FlintRetryOptions implements Serializable {
   public int getMaxRetries() {
     return Integer.parseInt(
         options.getOrDefault(MAX_RETRIES, String.valueOf(DEFAULT_MAX_RETRIES)));
+  }
+
+  /**
+   * @return bulk maximum retry option value
+   */
+  public int getBulkMaxRetries() {
+    return Integer.parseInt(
+        options.getOrDefault(BULK_MAX_RETRIES, String.valueOf(DEFAULT_BULK_MAX_RETRIES)));
+  }
+
+  /**
+   * @return maximum retry option value
+   */
+  public int getBulkInitialBackoff() {
+    return Integer.parseInt(
+        options.getOrDefault(BULK_INITIAL_BACKOFF, String.valueOf(DEFAULT_BULK_INITIAL_BACKOFF)));
   }
 
   /**

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/FlintRetryOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/FlintRetryOptions.java
@@ -49,7 +49,7 @@ public class FlintRetryOptions implements Serializable {
   public static final int DEFAULT_BULK_INITIAL_BACKOFF = 4;
   public static final String BULK_INITIAL_BACKOFF = "retry.bulk.initial_backoff";
 
-  public static final String DEFAULT_RETRYABLE_HTTP_STATUS_CODES = "429,502";
+  public static final String DEFAULT_RETRYABLE_HTTP_STATUS_CODES = "429,500,502";
   public static final String RETRYABLE_HTTP_STATUS_CODES = "retry.http_status_codes";
 
   /**

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/FlintRetryOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/FlintRetryOptions.java
@@ -15,9 +15,12 @@ import dev.failsafe.RetryPolicyBuilder;
 import dev.failsafe.event.ExecutionAttemptedEvent;
 import dev.failsafe.function.CheckedPredicate;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.flint.core.http.handler.ExceptionClassNameFailurePredicate;
 import org.opensearch.flint.core.http.handler.HttpAOSSResultPredicate;
@@ -141,11 +144,12 @@ public class FlintRetryOptions implements Serializable {
         options.getOrDefault(BULK_INITIAL_BACKOFF, String.valueOf(DEFAULT_BULK_INITIAL_BACKOFF)));
   }
 
-  /**
-   * @return retryable HTTP status code list
-   */
-  public String getRetryableHttpStatusCodes() {
-    return options.getOrDefault(RETRYABLE_HTTP_STATUS_CODES, DEFAULT_RETRYABLE_HTTP_STATUS_CODES);
+  public Set<Integer> getRetryableHttpStatusCodes() {
+    String statusCodes = options.getOrDefault(RETRYABLE_HTTP_STATUS_CODES, DEFAULT_RETRYABLE_HTTP_STATUS_CODES);
+    return Arrays.stream(statusCodes.split(","))
+        .map(String::trim)
+        .map(Integer::valueOf)
+        .collect(Collectors.toSet());
   }
 
   /**

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/HttpStatusCodeResultPredicate.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/HttpStatusCodeResultPredicate.java
@@ -26,12 +26,8 @@ public class HttpStatusCodeResultPredicate<T> implements CheckedPredicate<T> {
    */
   private final Set<Integer> retryableStatusCodes;
 
-  public HttpStatusCodeResultPredicate(String httpStatusCodes) {
-    this.retryableStatusCodes =
-        Arrays.stream(httpStatusCodes.split(","))
-            .map(String::trim)
-            .map(Integer::valueOf)
-            .collect(Collectors.toSet());
+  public HttpStatusCodeResultPredicate(Set<Integer> httpStatusCodes) {
+    this.retryableStatusCodes = httpStatusCodes;
   }
 
   @Override

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchBulkWrapper.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchBulkWrapper.java
@@ -11,6 +11,7 @@ import dev.failsafe.RetryPolicy;
 import dev.failsafe.function.CheckedPredicate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
@@ -34,10 +35,12 @@ public class OpenSearchBulkWrapper {
 
   private final RetryPolicy<BulkResponse> retryPolicy;
   private final BulkRequestRateLimiter rateLimiter;
+  private final Set<Integer> retryableStatusCodes;
 
   public OpenSearchBulkWrapper(FlintRetryOptions retryOptions, BulkRequestRateLimiter rateLimiter) {
     this.retryPolicy = retryOptions.getBulkRetryPolicy(bulkItemRetryableResultPredicate);
     this.rateLimiter = rateLimiter;
+    this.retryableStatusCodes = retryOptions.getRetryableHttpStatusCodes();
   }
 
   /**
@@ -119,10 +122,10 @@ public class OpenSearchBulkWrapper {
   /**
    * A predicate to decide if a BulkResponse is retryable or not.
    */
-  private static final CheckedPredicate<BulkResponse> bulkItemRetryableResultPredicate = bulkResponse ->
+  private final CheckedPredicate<BulkResponse> bulkItemRetryableResultPredicate = bulkResponse ->
       bulkResponse.hasFailures() && isRetryable(bulkResponse);
 
-  private static boolean isRetryable(BulkResponse bulkResponse) {
+  private boolean isRetryable(BulkResponse bulkResponse) {
     if (Arrays.stream(bulkResponse.getItems())
         .anyMatch(itemResp -> isItemRetryable(itemResp))) {
       LOG.info("Found retryable failure in the bulk response");
@@ -131,12 +134,17 @@ public class OpenSearchBulkWrapper {
     return false;
   }
 
-  private static boolean isItemRetryable(BulkItemResponse itemResponse) {
-    return itemResponse.isFailed() && !isCreateConflict(itemResponse);
+  private boolean isItemRetryable(BulkItemResponse itemResponse) {
+    return itemResponse.isFailed() && !isCreateConflict(itemResponse)
+        && isFailureStatusRetryable(itemResponse);
   }
 
   private static boolean isCreateConflict(BulkItemResponse itemResp) {
     return itemResp.getOpType() == DocWriteRequest.OpType.CREATE &&
         itemResp.getFailure().getStatus() == RestStatus.CONFLICT;
+  }
+
+  private boolean isFailureStatusRetryable(BulkItemResponse itemResp) {
+    return retryableStatusCodes.contains(itemResp.getFailure().getStatus().getStatus());
   }
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchBulkWrapper.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchBulkWrapper.java
@@ -145,6 +145,12 @@ public class OpenSearchBulkWrapper {
   }
 
   private boolean isFailureStatusRetryable(BulkItemResponse itemResp) {
-    return retryableStatusCodes.contains(itemResp.getFailure().getStatus().getStatus());
+    if (retryableStatusCodes.contains(itemResp.getFailure().getStatus().getStatus())) {
+      return true;
+    } else {
+      LOG.info("Found non-retryable failure in bulk response: " + itemResp.getFailure().getStatus()
+          + ", " + itemResp.getFailure().toString());
+      return false;
+    }
   }
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/RequestRateMeter.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/RequestRateMeter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core.storage;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Track the current request rate based on the past requests within ESTIMATE_RANGE_DURATION_MSEC
+ * milliseconds period.
+ */
+public class RequestRateMeter {
+  private static final long ESTIMATE_RANGE_DURATION_MSEC = 3000;
+
+  private static class DataPoint {
+    long timestamp;
+    long requestCount;
+    public DataPoint(long timestamp, long requestCount) {
+      this.timestamp = timestamp;
+      this.requestCount = requestCount;
+    }
+  }
+
+  private List<DataPoint> dataPoints = new LinkedList<>();
+  private long currentSum = 0;
+
+  synchronized void addDataPoint(long timestamp, long requestCount) {
+    dataPoints.add(new DataPoint(timestamp, requestCount));
+    currentSum += requestCount;
+  }
+
+  synchronized void removeOldDataPoints() {
+    long curr = System.currentTimeMillis();
+    while (!dataPoints.isEmpty() && dataPoints.get(0).timestamp < curr - ESTIMATE_RANGE_DURATION_MSEC) {
+      currentSum -= dataPoints.get(0).requestCount;
+      dataPoints.remove(0);
+    }
+  }
+
+  synchronized long getCurrentEstimatedRate() {
+    removeOldDataPoints();
+    return currentSum * 1000 / ESTIMATE_RANGE_DURATION_MSEC;
+  }
+}

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/RequestRateMeter.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/RequestRateMeter.java
@@ -7,6 +7,7 @@ package org.opensearch.flint.core.storage;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 /**
  * Track the current request rate based on the past requests within ESTIMATE_RANGE_DURATION_MSEC
@@ -24,7 +25,7 @@ public class RequestRateMeter {
     }
   }
 
-  private List<DataPoint> dataPoints = new LinkedList<>();
+  private Queue<DataPoint> dataPoints = new LinkedList<>();
   private long currentSum = 0;
 
   synchronized void addDataPoint(long timestamp, long requestCount) {
@@ -34,9 +35,8 @@ public class RequestRateMeter {
 
   synchronized void removeOldDataPoints() {
     long curr = System.currentTimeMillis();
-    while (!dataPoints.isEmpty() && dataPoints.get(0).timestamp < curr - ESTIMATE_RANGE_DURATION_MSEC) {
-      currentSum -= dataPoints.get(0).requestCount;
-      dataPoints.remove(0);
+    while (!dataPoints.isEmpty() && dataPoints.peek().timestamp < curr - ESTIMATE_RANGE_DURATION_MSEC) {
+      currentSum -= dataPoints.remove().requestCount;
     }
   }
 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/RequestRateMeter.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/RequestRateMeter.java
@@ -28,20 +28,21 @@ public class RequestRateMeter {
   private Queue<DataPoint> dataPoints = new LinkedList<>();
   private long currentSum = 0;
 
-  synchronized void addDataPoint(long timestamp, long requestCount) {
+  public synchronized void addDataPoint(long timestamp, long requestCount) {
     dataPoints.add(new DataPoint(timestamp, requestCount));
     currentSum += requestCount;
+    removeOldDataPoints();
   }
 
-  synchronized void removeOldDataPoints() {
+  public synchronized long getCurrentEstimatedRate() {
+    removeOldDataPoints();
+    return currentSum * 1000 / ESTIMATE_RANGE_DURATION_MSEC;
+  }
+
+  private synchronized void removeOldDataPoints() {
     long curr = System.currentTimeMillis();
     while (!dataPoints.isEmpty() && dataPoints.peek().timestamp < curr - ESTIMATE_RANGE_DURATION_MSEC) {
       currentSum -= dataPoints.remove().requestCount;
     }
-  }
-
-  synchronized long getCurrentEstimatedRate() {
-    removeOldDataPoints();
-    return currentSum * 1000 / ESTIMATE_RANGE_DURATION_MSEC;
   }
 }

--- a/flint-core/src/test/java/org/opensearch/flint/core/storage/RequestRateMeterTest.java
+++ b/flint-core/src/test/java/org/opensearch/flint/core/storage/RequestRateMeterTest.java
@@ -26,6 +26,14 @@ class RequestRateMeterTest {
   }
 
   @Test
+  void testAddDataPointRemoveOldDataPoint() {
+    long timestamp = System.currentTimeMillis();
+    requestRateMeter.addDataPoint(timestamp - 4000, 30);
+    requestRateMeter.addDataPoint(timestamp, 90);
+    assertEquals(90 / 3, requestRateMeter.getCurrentEstimatedRate());
+  }
+
+  @Test
   void testRemoveOldDataPoints() {
     long currentTime = System.currentTimeMillis();
     requestRateMeter.addDataPoint(currentTime - 4000, 30);

--- a/flint-core/src/test/java/org/opensearch/flint/core/storage/RequestRateMeterTest.java
+++ b/flint-core/src/test/java/org/opensearch/flint/core/storage/RequestRateMeterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core.storage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RequestRateMeterTest {
+
+  private RequestRateMeter requestRateMeter;
+
+  @BeforeEach
+  void setUp() {
+    requestRateMeter = new RequestRateMeter();
+  }
+
+  @Test
+  void testAddDataPoint() {
+    long timestamp = System.currentTimeMillis();
+    requestRateMeter.addDataPoint(timestamp, 30);
+    assertEquals(10, requestRateMeter.getCurrentEstimatedRate());
+  }
+
+  @Test
+  void testRemoveOldDataPoints() {
+    long currentTime = System.currentTimeMillis();
+    requestRateMeter.addDataPoint(currentTime - 4000, 30);
+    requestRateMeter.addDataPoint(currentTime - 2000, 60);
+    requestRateMeter.addDataPoint(currentTime, 90);
+
+    assertEquals((60 + 90)/3, requestRateMeter.getCurrentEstimatedRate());
+  }
+
+  @Test
+  void testGetCurrentEstimatedRate() {
+    long currentTime = System.currentTimeMillis();
+    requestRateMeter.addDataPoint(currentTime - 2500, 30);
+    requestRateMeter.addDataPoint(currentTime - 1500, 60);
+    requestRateMeter.addDataPoint(currentTime - 500, 90);
+
+    assertEquals((30 + 60 + 90)/3, requestRateMeter.getCurrentEstimatedRate());
+  }
+
+  @Test
+  void testEmptyRateMeter() {
+    assertEquals(0, requestRateMeter.getCurrentEstimatedRate());
+  }
+
+  @Test
+  void testSingleDataPoint() {
+    requestRateMeter.addDataPoint(System.currentTimeMillis(), 30);
+    assertEquals(30 / 3, requestRateMeter.getCurrentEstimatedRate());
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -136,6 +136,18 @@ object FlintSparkConf {
     .doc("max retries on failed HTTP request, 0 means retry is disabled, default is 3")
     .createWithDefault(String.valueOf(FlintRetryOptions.DEFAULT_MAX_RETRIES))
 
+  val BULK_MAX_RETRIES =
+    FlintConfig(s"spark.datasource.flint.${FlintRetryOptions.BULK_MAX_RETRIES}")
+      .datasourceOption()
+      .doc("max retries on failed HTTP request, 0 means retry is disabled, default is 10")
+      .createWithDefault(String.valueOf(FlintRetryOptions.DEFAULT_BULK_MAX_RETRIES))
+
+  val BULK_INITIAL_BACKOFF =
+    FlintConfig(s"spark.datasource.flint.${FlintRetryOptions.BULK_INITIAL_BACKOFF}")
+      .datasourceOption()
+      .doc("initial backoff for bulk request retry, default is 4")
+      .createWithDefault(String.valueOf(FlintRetryOptions.DEFAULT_BULK_INITIAL_BACKOFF))
+
   val BULK_REQUEST_RATE_LIMIT_PER_NODE_ENABLED =
     FlintConfig(
       s"spark.datasource.flint.${FlintOptions.BULK_REQUEST_RATE_LIMIT_PER_NODE_ENABLED}")
@@ -368,6 +380,8 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
       SCHEME,
       AUTH,
       MAX_RETRIES,
+      BULK_MAX_RETRIES,
+      BULK_INITIAL_BACKOFF,
       RETRYABLE_HTTP_STATUS_CODES,
       BULK_REQUEST_RATE_LIMIT_PER_NODE_ENABLED,
       BULK_REQUEST_MIN_RATE_LIMIT_PER_NODE,

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -145,7 +145,7 @@ object FlintSparkConf {
   val BULK_INITIAL_BACKOFF =
     FlintConfig(s"spark.datasource.flint.${FlintRetryOptions.BULK_INITIAL_BACKOFF}")
       .datasourceOption()
-      .doc("initial backoff for bulk request retry, default is 4")
+      .doc("initial backoff in seconds for bulk request retry, default is 4s")
       .createWithDefault(String.valueOf(FlintRetryOptions.DEFAULT_BULK_INITIAL_BACKOFF))
 
   val BULK_REQUEST_RATE_LIMIT_PER_NODE_ENABLED =

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -46,7 +46,7 @@ class FlintSparkConfSuite extends FlintSuite {
   test("test retry options default values") {
     val retryOptions = FlintSparkConf().flintOptions().getRetryOptions
     retryOptions.getMaxRetries shouldBe DEFAULT_MAX_RETRIES
-    retryOptions.getRetryableHttpStatusCodes shouldBe DEFAULT_RETRYABLE_HTTP_STATUS_CODES
+    retryOptions.getRetryableHttpStatusCodes shouldBe Set(429, 502)
     retryOptions.getRetryableExceptionClassNames shouldBe Optional.empty
   }
 
@@ -60,7 +60,7 @@ class FlintSparkConfSuite extends FlintSuite {
       .getRetryOptions
 
     retryOptions.getMaxRetries shouldBe 5
-    retryOptions.getRetryableHttpStatusCodes shouldBe "429,502,503,504"
+    retryOptions.getRetryableHttpStatusCodes shouldBe Set(429, 502, 503, 504)
     retryOptions.getRetryableExceptionClassNames.get() shouldBe "java.net.ConnectException"
   }
 

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -6,13 +6,16 @@
 package org.apache.spark.sql.flint.config
 
 import java.util.Optional
+
 import scala.collection.JavaConverters._
+
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.http.FlintRetryOptions._
+import org.scalatest.matchers.must.Matchers.contain
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
 import org.apache.spark.FlintSuite
 import org.apache.spark.sql.flint.config.FlintSparkConf.{MONITOR_INITIAL_DELAY_SECONDS, MONITOR_INTERVAL_SECONDS, MONITOR_MAX_ERROR_COUNT}
-import org.scalatest.matchers.must.Matchers.contain
 
 class FlintSparkConfSuite extends FlintSuite {
   test("test spark conf") {
@@ -58,7 +61,11 @@ class FlintSparkConfSuite extends FlintSuite {
       .getRetryOptions
 
     retryOptions.getMaxRetries shouldBe 5
-    retryOptions.getRetryableHttpStatusCodes should contain theSameElementsAs Set(429, 502, 503, 504)
+    retryOptions.getRetryableHttpStatusCodes should contain theSameElementsAs Set(
+      429,
+      502,
+      503,
+      504)
     retryOptions.getRetryableExceptionClassNames.get() shouldBe "java.net.ConnectException"
   }
 

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -47,7 +47,7 @@ class FlintSparkConfSuite extends FlintSuite {
   test("test retry options default values") {
     val retryOptions = FlintSparkConf().flintOptions().getRetryOptions
     retryOptions.getMaxRetries shouldBe DEFAULT_MAX_RETRIES
-    retryOptions.getRetryableHttpStatusCodes should contain theSameElementsAs Set(429, 502)
+    retryOptions.getRetryableHttpStatusCodes should contain theSameElementsAs Set(429, 500, 502)
     retryOptions.getRetryableExceptionClassNames shouldBe Optional.empty
   }
 

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -6,15 +6,13 @@
 package org.apache.spark.sql.flint.config
 
 import java.util.Optional
-
 import scala.collection.JavaConverters._
-
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.http.FlintRetryOptions._
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-
 import org.apache.spark.FlintSuite
 import org.apache.spark.sql.flint.config.FlintSparkConf.{MONITOR_INITIAL_DELAY_SECONDS, MONITOR_INTERVAL_SECONDS, MONITOR_MAX_ERROR_COUNT}
+import org.scalatest.matchers.must.Matchers.contain
 
 class FlintSparkConfSuite extends FlintSuite {
   test("test spark conf") {
@@ -46,7 +44,7 @@ class FlintSparkConfSuite extends FlintSuite {
   test("test retry options default values") {
     val retryOptions = FlintSparkConf().flintOptions().getRetryOptions
     retryOptions.getMaxRetries shouldBe DEFAULT_MAX_RETRIES
-    retryOptions.getRetryableHttpStatusCodes shouldBe Set(429, 502)
+    retryOptions.getRetryableHttpStatusCodes should contain theSameElementsAs Set(429, 502)
     retryOptions.getRetryableExceptionClassNames shouldBe Optional.empty
   }
 
@@ -60,7 +58,7 @@ class FlintSparkConfSuite extends FlintSuite {
       .getRetryOptions
 
     retryOptions.getMaxRetries shouldBe 5
-    retryOptions.getRetryableHttpStatusCodes shouldBe Set(429, 502, 503, 504)
+    retryOptions.getRetryableHttpStatusCodes should contain theSameElementsAs Set(429, 502, 503, 504)
     retryOptions.getRetryableExceptionClassNames.get() shouldBe "java.net.ConnectException"
   }
 


### PR DESCRIPTION
### Description
- Based on testing adaptive rate limit implementation with data, I identified following issues:
 - Rate limit was increase even when the current limit is not fully utilized, and this lead to too high rate limit and limit decrease took long time to become effective.
 - As the rate limit is adjusted when a request finished, adjustment frequency depends on the current request rate. (means rate limit is increased slowly when rate limit is low, and quickly when rate limit is high)
- This PR address the first issue. (Second issue is not critical as far as we don't set minimum rate to lower value. current value is 5000)
- BulkRequestRateMeter collect data points for current rate using recent 3 seconds window, and calculate the estimated current rate. If the current rate is lower than 80% of rate limit, it won't increase the rate.

### Related Issues
- https://github.com/opensearch-project/opensearch-spark/issues/640
- Previous PR: https://github.com/opensearch-project/opensearch-spark/pull/1011

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
