### PR TITLE
Support OpenSearch alias field type

### DIFF
--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -59,8 +59,8 @@ The following table defines the data type mapping between OpenSearch index field
 | byte                     | ByteType                          |
 | double                   | DoubleType                        |
 | float                    | FloatType                         |
-| date(Timestamp)          | DateType                          |
-| date(Date)               | TimestampType                     |
+| date(Timestamp)          | TimestampType                     |
+| date(Date)               | DateType                          |
 | keyword                  | StringType, VarcharType, CharType |
 | text                     | StringType(meta(osType)=text)     |
 | object                   | StructType                        |

--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -47,6 +47,37 @@ Using a wildcard index name:
 val df = spark.sql("SELECT * FROM dev.default.`my_index*`")
 df.show()
 ```
+## Data Types
+The following table defines the data type mapping between OpenSearch index field type and Spark data type.
+
+| **OpenSearch FieldType** | **SparkDataType**                 |
+|--------------------------|-----------------------------------|
+| boolean                  | BooleanType                       |
+| long                     | LongType                          |
+| integer                  | IntegerType                       |
+| short                    | ShortType                         |
+| byte                     | ByteType                          |
+| double                   | DoubleType                        |
+| float                    | FloatType                         |
+| date(Timestamp)          | DateType                          |
+| date(Date)               | TimestampType                     |
+| keyword                  | StringType, VarcharType, CharType |
+| text                     | StringType(meta(osType)=text)     |
+| object                   | StructType                        |
+| alias                    | Inherits referenced field type    |
+
+* OpenSearch data type date is mapped to Spark data type based on the format:
+    * Map to DateType if format = strict_date, (we also support format = date, may change in future)
+    * Map to TimestampType if format = strict_date_optional_time_nanos, (we also support format =
+      strict_date_optional_time | epoch_millis, may change in future)
+* Spark data types VarcharType(length) and CharType(length) are both currently mapped to Flint data
+  type *keyword*, dropping their length property. On the other hand, Flint data type *keyword* only
+  maps to StringType.
+* Spark data type MapType is mapped to an empty OpenSearch object. The inner fields then rely on
+  dynamic mapping. On the other hand, Flint data type *object* only maps to StructType.
+* Spark data type DecimalType is mapped to an OpenSearch double. On the other hand, Flint data type
+  *double* only maps to DoubleType.
+* OpenSearch alias fields allow alternative names for existing fields in the schema without duplicating data. They inherit the data type and nullability of the referenced field and resolve dynamically to the primary field in queries.
 
 ## Limitation
 ### catalog operation

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
@@ -297,12 +297,15 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
         |  }
         |}""".stripMargin
 
-    val expectedStructType = StructType(Seq(
-      StructField("distance", LongType, true),
-      StructField("transit_mode", StringType, true),
-      StructField("route_length_miles", LongType, true,
-        new MetadataBuilder().putString("aliasPath", "distance").build())
-    ))
+    val expectedStructType = StructType(
+      Seq(
+        StructField("distance", LongType, true),
+        StructField("transit_mode", StringType, true),
+        StructField(
+          "route_length_miles",
+          LongType,
+          true,
+          new MetadataBuilder().putString("aliasPath", "distance").build())))
 
     val deserialized = FlintDataType.deserialize(flintDataType)
 

--- a/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableITSuite.scala
@@ -5,8 +5,6 @@
 
 package org.apache.spark.opensearch.table
 
-import org.apache.spark.sql.Row
-
 class OpenSearchTableITSuite extends OpenSearchCatalogSuite {
 
   def multipleShardsIndex(indexName: String): Unit = {
@@ -61,24 +59,6 @@ class OpenSearchTableITSuite extends OpenSearchCatalogSuite {
 
         assert(df.rdd.getNumPartitions == 2)
       }
-    }
-  }
-
-  test("Query index with alias data type") {
-    val index1 = "t0001"
-    withIndexName(index1) {
-      indexWithAlias(index1)
-      // select original field and alias field
-      var df = spark.sql(s"""SELECT id, alias FROM ${catalogName}.default.$index1""")
-      checkAnswer(df, Seq(Row(1, 1), Row(2, 2)))
-
-      // filter on alias field
-      df = spark.sql(s"""SELECT id, alias FROM ${catalogName}.default.$index1 WHERE alias=1""")
-      checkAnswer(df, Row(1, 1))
-
-      // filter on original field
-      df = spark.sql(s"""SELECT id, alias FROM ${catalogName}.default.$index1 WHERE id=1""")
-      checkAnswer(df, Row(1, 1))
     }
   }
 }

--- a/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableITSuite.scala
@@ -5,6 +5,8 @@
 
 package org.apache.spark.opensearch.table
 
+import org.apache.spark.sql.Row
+
 class OpenSearchTableITSuite extends OpenSearchCatalogSuite {
 
   def multipleShardsIndex(indexName: String): Unit = {
@@ -59,6 +61,24 @@ class OpenSearchTableITSuite extends OpenSearchCatalogSuite {
 
         assert(df.rdd.getNumPartitions == 2)
       }
+    }
+  }
+
+  test("Query index with alias data type") {
+    val index1 = "t0001"
+    withIndexName(index1) {
+      indexWithAlias(index1)
+      // select original field and alias field
+      var df = spark.sql(s"""SELECT id, alias FROM ${catalogName}.default.$index1""")
+      checkAnswer(df, Seq(Row(1, 1), Row(2, 2)))
+
+      // filter on alias field
+      df = spark.sql(s"""SELECT id, alias FROM ${catalogName}.default.$index1 WHERE alias=1""")
+      checkAnswer(df, Row(1, 1))
+
+      // filter on original field
+      df = spark.sql(s"""SELECT id, alias FROM ${catalogName}.default.$index1 WHERE id=1""")
+      checkAnswer(df, Row(1, 1))
     }
   }
 }

--- a/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
@@ -47,4 +47,22 @@ class OpenSearchTableQueryITSuite extends OpenSearchCatalogSuite with FlintPPLSu
       }
     }
   }
+
+  test("Query index with alias data type") {
+    val index1 = "t0001"
+    withIndexName(index1) {
+      indexWithAlias(index1)
+      // select original field and alias field
+      var df = spark.sql(s"""SELECT id, alias FROM ${catalogName}.default.$index1""")
+      checkAnswer(df, Seq(Row(1, 1), Row(2, 2)))
+
+      // filter on alias field
+      df = spark.sql(s"""SELECT id, alias FROM ${catalogName}.default.$index1 WHERE alias=1""")
+      checkAnswer(df, Row(1, 1))
+
+      // filter on original field
+      df = spark.sql(s"""SELECT id, alias FROM ${catalogName}.default.$index1 WHERE id=1""")
+      checkAnswer(df, Row(1, 1))
+    }
+  }
 }

--- a/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
@@ -123,6 +123,22 @@ trait OpenSearchSuite extends BeforeAndAfterAll {
     index(indexName, oneNodeSetting, mappings, docs)
   }
 
+  def indexWithAlias(indexName: String): Unit = {
+    val mappings = """{
+                     |  "properties": {
+                     |    "id": {
+                     |      "type": "integer"
+                     |    },
+                     |    "alias": {
+                     |      "type": "alias",
+                     |      "path": "id"
+                     |    }
+                     |  }
+                     |}""".stripMargin
+    val docs = Seq("""{"id": 1}""", """{"id": 2}""")
+    index(indexName, oneNodeSetting, mappings, docs)
+  }
+
   def index(index: String, settings: String, mappings: String, docs: Seq[String]): Unit = {
     openSearchClient.indices.create(
       new CreateIndexRequest(index)


### PR DESCRIPTION
### Description

#### Summary
This PR introduces support for alias fields in `FlintDataType`, allowing fields to be referenced by alternative names. The change enables schema parsing and JSON processing to recognize alias fields and map them to their corresponding primary fields.

#### Changes
1. **FlintDataType.scala**
   - Updated `deserializeJValue` to identify and process alias fields.
   - Modified `deserializeField` to support alias metadata assignment.

2. **FlintJacksonParser.scala**
   - Implemented `fieldMapping` to associate JSON keys with schema field indices, allowing alias fields to be correctly resolved during parsing.
   - Updated JSON parsing logic to handle multiple schema fields mapped to a single JSON key.

3. **Add OpenSearch Table datatype in docs**
   - https://github.com/penghuo/penghuo-opensearch-spark/blob/dataTypeAlias/docs/opensearch-table.md#data-types

#### Testing
- Added test cases for alias field deserialization to validate schema correctness.
- Integration tests confirm alias field support in OpenSearch queries.

### Related Issues
https://github.com/opensearch-project/opensearch-spark/issues/1033

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
