### PR TITLE
[BUG] Fix the PPL Lookup command behavior when inputField is missing and REPLACE with existing fields

### DIFF
--- a/docs/ppl-lang/ppl-lookup-command.md
+++ b/docs/ppl-lang/ppl-lookup-command.md
@@ -34,12 +34,12 @@ LOOKUP <lookupIndex> (<lookupMappingField> [AS <sourceMappingField>])...
 **outputField**
 - Optional
 - Default: \<inputField\>
-- Description:  A field of output. You can specify zero or multiple \<outputField\>. The specified \<outputField\> must be an existing field name in source query output.
+- Description:  A field of output. You can specify zero or multiple \<outputField\>. If you specify \<outputField\> with an existing field name in source query, its values will be replaced or appended by matched values from \<inputField\>. If the field specified in \<outputField\> is a new field, in REPLACE strategy, an extended new field will be applied to the results, but fail in APPEND strategy.
 
 **REPLACE | APPEND**
 - Optional
 - Default: REPLACE
-- Description: If you specify REPLACE, matched values in \<lookupIndex\> field overwrite the values in result. If you specify APPEND, matched values in \<lookupIndex\> field only append to the missing values in result.
+- Description: The output strategies. If you specify REPLACE, matched values in \<lookupIndex\> field overwrite the values in result. If you specify APPEND, matched values in \<lookupIndex\> field only append to the missing values in result.
 
 ### Usage
 - `LOOKUP <lookupIndex> id AS cid REPLACE mail AS email`

--- a/docs/ppl-lang/ppl-lookup-command.md
+++ b/docs/ppl-lang/ppl-lookup-command.md
@@ -34,7 +34,7 @@ LOOKUP <lookupIndex> (<lookupMappingField> [AS <sourceMappingField>])...
 **outputField**
 - Optional
 - Default: \<inputField\>
-- Description:  A field of output. You can specify multiple \<outputField\>. If you specify \<outputField\> with an existing field name in source query, its values will be replaced or appended by matched values from \<inputField\>. If the field specified in \<outputField\> is a new field, an extended new field will be applied to the results.
+- Description:  A field of output. You can specify zero or multiple \<outputField\>. The specified \<outputField\> must be an existing field name in source query output.
 
 **REPLACE | APPEND**
 - Optional

--- a/docs/ppl-lang/ppl-lookup-command.md
+++ b/docs/ppl-lang/ppl-lookup-command.md
@@ -29,7 +29,7 @@ LOOKUP <lookupIndex> (<lookupMappingField> [AS <sourceMappingField>])...
 **inputField**
 - Optional
 - Default: All fields of \<lookupIndex\> where matched values are applied to result output if no field is specified.
-- Description: A field in \<lookupIndex\> where matched values are applied to result output. You can specify multiple \<inputField\> with comma-delimited. If you don't specify any \<inputField\>, all fields of \<lookupIndex\> where matched values are applied to result output.
+- Description: A field in \<lookupIndex\> where matched values are applied to result output. You can specify multiple \<inputField\> with comma-delimited. If you don't specify any \<inputField\>, all fields expect \<lookupMappingField\> from \<lookupIndex\> where matched values are applied to result output.
 
 **outputField**
 - Optional

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
@@ -64,15 +64,12 @@ class FlintSparkPPLLookupITSuite
       Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
     val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
-    val coalesceForSafeExpr =
-      Coalesce(
-        Seq(
-          UnresolvedAttribute("__auto_generated_subquery_name_l.department"),
-          UnresolvedAttribute("department")))
     val projectAfterJoin = Project(
       Seq(
         UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
-        Alias(coalesceForSafeExpr, "department")()),
+        Alias(
+          UnresolvedAttribute("__auto_generated_subquery_name_l.department"),
+          "department")()),
       joinPlan)
     val dropColumns = DataFrameDropColumns(
       Seq(
@@ -105,11 +102,10 @@ class FlintSparkPPLLookupITSuite
         Seq(
           UnresolvedAttribute("department"),
           UnresolvedAttribute("__auto_generated_subquery_name_l.department")))
-    val coalesceForSafeExpr = Coalesce(Seq(coalesceExpr, UnresolvedAttribute("department")))
     val projectAfterJoin = Project(
       Seq(
         UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
-        Alias(coalesceForSafeExpr, "department")()),
+        Alias(coalesceExpr, "department")()),
       joinPlan)
     val dropColumns = DataFrameDropColumns(
       Seq(
@@ -127,10 +123,10 @@ class FlintSparkPPLLookupITSuite
       sql(s"source = $sourceTable| LOOKUP $lookupTable uid AS id REPLACE department AS country")
     val expectedResults: Array[Row] = Array(
       Row(1000, "Jake", "Engineer", 100000, "IT"),
-      Row(1001, "Hello", "Artist", 70000, "USA"),
+      Row(1001, "Hello", "Artist", 70000, null),
       Row(1002, "John", "Doctor", 120000, "DATA"),
       Row(1003, "David", "Doctor", 120000, "HR"),
-      Row(1004, "David", null, 0, "Canada"),
+      Row(1004, "David", null, 0, null),
       Row(1005, "Jane", "Scientist", 90000, "DATA"))
     assertSameRows(expectedResults, frame)
 
@@ -138,15 +134,10 @@ class FlintSparkPPLLookupITSuite
       Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
     val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
-    val coalesceForSafeExpr =
-      Coalesce(
-        Seq(
-          UnresolvedAttribute("__auto_generated_subquery_name_l.department"),
-          UnresolvedAttribute("__auto_generated_subquery_name_s.country")))
     val projectAfterJoin = Project(
       Seq(
         UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
-        Alias(coalesceForSafeExpr, "country")()),
+        Alias(UnresolvedAttribute("__auto_generated_subquery_name_l.department"), "country")()),
       joinPlan)
     val dropColumns = DataFrameDropColumns(
       Seq(
@@ -180,12 +171,10 @@ class FlintSparkPPLLookupITSuite
         Seq(
           UnresolvedAttribute("__auto_generated_subquery_name_s.country"),
           UnresolvedAttribute("__auto_generated_subquery_name_l.department")))
-    val coalesceForSafeExpr =
-      Coalesce(Seq(coalesceExpr, UnresolvedAttribute("__auto_generated_subquery_name_s.country")))
     val projectAfterJoin = Project(
       Seq(
         UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
-        Alias(coalesceForSafeExpr, "country")()),
+        Alias(coalesceExpr, "country")()),
       joinPlan)
     val dropColumns = DataFrameDropColumns(
       Seq(
@@ -224,15 +213,12 @@ class FlintSparkPPLLookupITSuite
           UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
           UnresolvedAttribute("__auto_generated_subquery_name_s.name")))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
-    val coalesceForSafeExpr =
-      Coalesce(
-        Seq(
-          UnresolvedAttribute("__auto_generated_subquery_name_l.department"),
-          UnresolvedAttribute("department")))
     val projectAfterJoin = Project(
       Seq(
         UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
-        Alias(coalesceForSafeExpr, "department")()),
+        Alias(
+          UnresolvedAttribute("__auto_generated_subquery_name_l.department"),
+          "department")()),
       joinPlan)
     val dropColumns = DataFrameDropColumns(
       Seq(
@@ -277,11 +263,10 @@ class FlintSparkPPLLookupITSuite
         Seq(
           UnresolvedAttribute("department"),
           UnresolvedAttribute("__auto_generated_subquery_name_l.department")))
-    val coalesceForSafeExpr = Coalesce(Seq(coalesceExpr, UnresolvedAttribute("department")))
     val projectAfterJoin = Project(
       Seq(
         UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
-        Alias(coalesceForSafeExpr, "department")()),
+        Alias(coalesceExpr, "department")()),
       joinPlan)
     val dropColumns = DataFrameDropColumns(
       Seq(
@@ -314,7 +299,7 @@ class FlintSparkPPLLookupITSuite
         s"source = $sourceTable | eval major = occupation | fields id, name, major, country, salary | LOOKUP $lookupTable name REPLACE occupation AS major")
     val expectedResults: Array[Row] = Array(
       Row(1000, "Jake", "England", 100000, "Engineer"),
-      Row(1001, "Hello", "USA", 70000, "Artist"),
+      Row(1001, "Hello", "USA", 70000, null),
       Row(1002, "John", "Canada", 120000, "Scientist"),
       Row(1003, "David", null, 120000, "Doctor"),
       Row(1004, "David", "Canada", 0, "Doctor"),
@@ -340,15 +325,10 @@ class FlintSparkPPLLookupITSuite
       UnresolvedAttribute("__auto_generated_subquery_name_s.name"),
       UnresolvedAttribute("__auto_generated_subquery_name_l.name"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
-    val coalesceForSafeExpr =
-      Coalesce(
-        Seq(
-          UnresolvedAttribute("__auto_generated_subquery_name_l.occupation"),
-          UnresolvedAttribute("major")))
     val projectAfterJoin = Project(
       Seq(
         UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
-        Alias(coalesceForSafeExpr, "major")()),
+        Alias(UnresolvedAttribute("__auto_generated_subquery_name_l.occupation"), "major")()),
       joinPlan)
     val dropColumns = DataFrameDropColumns(
       Seq(
@@ -398,12 +378,10 @@ class FlintSparkPPLLookupITSuite
         Seq(
           UnresolvedAttribute("major"),
           UnresolvedAttribute("__auto_generated_subquery_name_l.occupation")))
-    val coalesceForSafeExpr =
-      Coalesce(Seq(coalesceExpr, UnresolvedAttribute("major")))
     val projectAfterJoin = Project(
       Seq(
         UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
-        Alias(coalesceForSafeExpr, "major")()),
+        Alias(coalesceExpr, "major")()),
       joinPlan)
     val dropColumns = DataFrameDropColumns(
       Seq(
@@ -445,8 +423,7 @@ class FlintSparkPPLLookupITSuite
     assertSameRows(expectedResults, frame)
   }
 
-  test(
-    "test the unmatched rows in LOOKUP without inputField doesn't apply explicit replacement") {
+  test("correctness combination test") {
     sql(s"""
            | CREATE TABLE s
            | (
@@ -459,7 +436,8 @@ class FlintSparkPPLLookupITSuite
     sql(s"""
            | INSERT INTO s
            | VALUES (1, 'a', 'b'),
-           |        (2, 'aa', 'bb')
+           |        (2, 'aa', 'bb'),
+           |        (3, null, 'ccc')
            | """.stripMargin)
 
     sql(s"""
@@ -476,9 +454,35 @@ class FlintSparkPPLLookupITSuite
            | VALUES (1, 'x', 'y'),
            |        (3, 'xx', 'yy')
            | """.stripMargin)
-    val frame = sql(s"source = s | LOOKUP l id | fields id, col1, col2, col3")
-    val expectedResults: Array[Row] = Array(Row(1, "x", "b", "y"), Row(2, null, "bb", null))
+    var frame = sql(s"source = s | LOOKUP l id | fields id, col1, col2, col3")
+    var expectedResults =
+      Array(Row(1, "x", "b", "y"), Row(2, null, "bb", null), Row(3, "xx", "ccc", "yy"))
     assertSameRows(expectedResults, frame)
+    frame = sql(s"source = s | LOOKUP l id REPLACE id, col1, col3 | fields id, col1, col2, col3")
+    expectedResults =
+      Array(Row(1, "x", "b", "y"), Row(null, null, "bb", null), Row(3, "xx", "ccc", "yy"))
+    assertSameRows(expectedResults, frame)
+    frame = sql(s"source = s | LOOKUP l id APPEND id, col1, col3 | fields id, col1, col2, col3")
+    expectedResults =
+      Array(Row(1, "a", "b", "y"), Row(2, "aa", "bb", null), Row(3, "xx", "ccc", "yy"))
+    assertSameRows(expectedResults, frame)
+    frame = sql(s"source = s | LOOKUP l id REPLACE col1 | fields id, col1, col2")
+    expectedResults = Array(Row(1, "x", "b"), Row(2, null, "bb"), Row(3, "xx", "ccc"))
+    assertSameRows(expectedResults, frame)
+    frame = sql(s"source = s | LOOKUP l id APPEND col1 | fields id, col1, col2")
+    expectedResults = Array(Row(1, "a", "b"), Row(2, "aa", "bb"), Row(3, "xx", "ccc"))
+    assertSameRows(expectedResults, frame)
+    frame = sql(s"source = s | LOOKUP l id REPLACE col1 as col2 | fields id, col1, col2")
+    expectedResults = Array(Row(1, "a", "x"), Row(2, "aa", null), Row(3, null, "xx"))
+    assertSameRows(expectedResults, frame)
+    frame = sql(s"source = s | LOOKUP l id APPEND col1 as col2 | fields id, col1, col2")
+    expectedResults = Array(Row(1, "a", "b"), Row(2, "aa", "bb"), Row(3, null, "ccc"))
+    assertSameRows(expectedResults, frame)
+    frame = sql(s"source = s | LOOKUP l id REPLACE col1 as colA | fields id, col1, col2, colA")
+    expectedResults =
+      Array(Row(1, "a", "b", "x"), Row(2, "aa", "bb", null), Row(3, null, "ccc", "xx"))
+    assertSameRows(expectedResults, frame)
+    // source = s | LOOKUP l id APPEND col1 as colA | fields id, col1, col2, colA throw exception
   }
 
   test("test LOOKUP lookupTable name REPLACE occupation - 2") {
@@ -486,7 +490,7 @@ class FlintSparkPPLLookupITSuite
       sql(s"source = $sourceTable | LOOKUP $lookupTable name REPLACE occupation")
     val expectedResults: Array[Row] = Array(
       Row(1000, "Jake", "England", 100000, "Engineer"),
-      Row(1001, "Hello", "USA", 70000, "Artist"),
+      Row(1001, "Hello", "USA", 70000, null),
       Row(1002, "John", "Canada", 120000, "Scientist"),
       Row(1003, "David", null, 120000, "Doctor"),
       Row(1004, "David", "Canada", 0, "Doctor"),
@@ -494,9 +498,22 @@ class FlintSparkPPLLookupITSuite
     assertSameRows(expectedResults, frame)
   }
 
-  test("test LOOKUP lookupTable name REPLACE occupation - 3") {
+  test("test LOOKUP lookupTable name REPLACE occupation as new_col") {
+    val frame =
+      sql(s"source = $sourceTable | LOOKUP $lookupTable name REPLACE occupation as new_col")
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "Engineer", "England", 100000, "Engineer"),
+      Row(1001, "Hello", "Artist", "USA", 70000, null),
+      Row(1002, "John", "Doctor", "Canada", 120000, "Scientist"),
+      Row(1003, "David", "Doctor", null, 120000, "Doctor"),
+      Row(1004, "David", null, "Canada", 0, "Doctor"),
+      Row(1005, "Jane", "Scientist", "Canada", 90000, "Engineer"))
+    assertSameRows(expectedResults, frame)
+  }
+
+  test("test LOOKUP lookupTable name APPEND occupation as new_col throw exception") {
     val ex = intercept[AnalysisException](sql(s"""
-             | source = $sourceTable | LOOKUP $lookupTable name REPLACE occupation as new_col
+             | source = $sourceTable | LOOKUP $lookupTable name APPEND occupation as new_col
              | """.stripMargin))
     assert(
       ex.getMessage.contains(

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
@@ -298,12 +298,12 @@ class FlintSparkPPLLookupITSuite
   test("test LOOKUP lookupTable uid AS id, name") {
     val frame = sql(s"source = $sourceTable| LOOKUP $lookupTable uID AS id, name")
     val expectedResults: Array[Row] = Array(
-      Row(1000, "Jake", "Engineer", "England", 100000, "IT", "Engineer"),
-      Row(1001, "Hello", "Artist", "USA", 70000, null, null),
-      Row(1002, "John", "Doctor", "Canada", 120000, "DATA", "Scientist"),
-      Row(1003, "David", "Doctor", null, 120000, "HR", "Doctor"),
-      Row(1004, "David", null, "Canada", 0, null, null),
-      Row(1005, "Jane", "Scientist", "Canada", 90000, "DATA", "Engineer"))
+      Row(1000, "Jake", "England", 100000, "IT", "Engineer"),
+      Row(1001, "Hello", "USA", 70000, null, null),
+      Row(1002, "John", "Canada", 120000, "DATA", "Scientist"),
+      Row(1003, "David", null, 120000, "HR", "Doctor"),
+      Row(1004, "David", "Canada", 0, null, null),
+      Row(1005, "Jane", "Canada", 90000, "DATA", "Engineer"))
 
     assertSameRows(expectedResults, frame)
   }
@@ -420,12 +420,12 @@ class FlintSparkPPLLookupITSuite
     val frame =
       sql(s"source = $sourceTable | LOOKUP $lookupTable name")
     val expectedResults: Array[Row] = Array(
-      Row(1000, "Jake", "Engineer", "England", 100000, 1000, "IT", "Engineer"),
-      Row(1001, "Hello", "Artist", "USA", 70000, null, null, null),
-      Row(1002, "John", "Doctor", "Canada", 120000, 1002, "DATA", "Scientist"),
-      Row(1003, "David", "Doctor", null, 120000, 1003, "HR", "Doctor"),
-      Row(1004, "David", null, "Canada", 0, 1003, "HR", "Doctor"),
-      Row(1005, "Jane", "Scientist", "Canada", 90000, 1005, "DATA", "Engineer"))
+      Row(1000, "Jake", "England", 100000, 1000, "IT", "Engineer"),
+      Row(1001, "Hello", "USA", 70000, null, null, null),
+      Row(1002, "John", "Canada", 120000, 1002, "DATA", "Scientist"),
+      Row(1003, "David", null, 120000, 1003, "HR", "Doctor"),
+      Row(1004, "David", "Canada", 0, 1003, "HR", "Doctor"),
+      Row(1005, "Jane", "Canada", 90000, 1005, "DATA", "Engineer"))
     assertSameRows(expectedResults, frame)
   }
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystExpressionVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystExpressionVisitor.java
@@ -368,6 +368,7 @@ public class CatalystExpressionVisitor extends AbstractNodeVisitor<Expression, C
     @Override
     public Expression visitInSubquery(InSubquery node, CatalystPlanContext outerContext) {
         CatalystPlanContext innerContext = new CatalystPlanContext();
+        innerContext.withSparkSession(outerContext.getSparkSession());
         visitExpressionList(node.getChild(), innerContext);
         Seq<Expression> values = innerContext.retainAllNamedParseExpressions(p -> p);
         UnresolvedPlan outerPlan = node.getQuery();
@@ -387,6 +388,7 @@ public class CatalystExpressionVisitor extends AbstractNodeVisitor<Expression, C
     @Override
     public Expression visitScalarSubquery(ScalarSubquery node, CatalystPlanContext context) {
         CatalystPlanContext innerContext = new CatalystPlanContext();
+        innerContext.withSparkSession(context.getSparkSession());
         UnresolvedPlan outerPlan = node.getQuery();
         LogicalPlan subSearch = outerPlan.accept(planVisitor, innerContext);
         Expression scalarSubQuery = ScalarSubquery$.MODULE$.apply(
@@ -402,6 +404,7 @@ public class CatalystExpressionVisitor extends AbstractNodeVisitor<Expression, C
     @Override
     public Expression visitExistsSubquery(ExistsSubquery node, CatalystPlanContext context) {
         CatalystPlanContext innerContext = new CatalystPlanContext();
+        innerContext.withSparkSession(context.getSparkSession());
         UnresolvedPlan outerPlan = node.getQuery();
         LogicalPlan subSearch = outerPlan.accept(planVisitor, innerContext);
         Expression existsSubQuery = Exists$.MODULE$.apply(

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystPlanContext.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystPlanContext.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.ppl;
 
 import lombok.Getter;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.Expression;
@@ -38,6 +39,8 @@ import static scala.collection.JavaConverters.asScalaBuffer;
  * The context used for Catalyst logical plan.
  */
 public class CatalystPlanContext {
+
+    @Getter private SparkSession sparkSession;
     /**
      * Catalyst relations list
      **/
@@ -282,5 +285,9 @@ public class CatalystPlanContext {
         Expression result = transformFunction.apply(expr, this);
         isResolvingJoinCondition = false;
         return result;
+    }
+
+    public void withSparkSession(SparkSession sparkSession) {
+        this.sparkSession = sparkSession;
     }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
@@ -106,16 +106,13 @@ public interface LookupTransformer {
             } else {
                 child = inputCol;
             }
-            // The result output project list we build here is used to replace the source output,
-            // for the unmatched rows of left outer join, the outputs are null, so fall back to source output.
-            Expression nullSafeOutput = Coalesce$.MODULE$.apply(seq(child, outputCol));
-            NamedExpression nullSafeOutputCol = Alias$.MODULE$.apply(nullSafeOutput,
+            NamedExpression output = Alias$.MODULE$.apply(child,
                 inputFieldWithAlias.getName(),
                 NamedExpression.newExprId(),
                 seq(new java.util.ArrayList<String>()),
                 Option.empty(),
                 seq(new java.util.ArrayList<String>()));
-            outputProjectList.add(nullSafeOutputCol);
+            outputProjectList.add(output);
         }
         context.retainAllNamedParseExpressions(p -> p);
         return outputProjectList;

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
@@ -95,7 +95,7 @@ public interface LookupTransformer {
             // If not, resolve the outputCol expression without alias: <fieldName> to avoid failure of unable to resolved attribute.
             Expression inputCol = expressionAnalyzer.visitField(buildFieldWithLookupSubqueryAlias(node, inputField), context);
             Expression outputCol;
-            if (RelationUtils.columnExistsInCatalogTable(context.getSparkSession(), outputField, searchSide)) {
+            if (RelationUtils.columnExistsInCatalogTable(context.getSparkSession(), searchSide, outputField)) {
                 outputCol = expressionAnalyzer.visitField(buildFieldWithSourceSubqueryAlias(node, outputField), context);
             } else {
                 outputCol = expressionAnalyzer.visitField(outputField, context);

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
@@ -11,13 +11,13 @@ import org.apache.spark.sql.catalyst.expressions.Coalesce$;
 import org.apache.spark.sql.catalyst.expressions.EqualTo$;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.ast.tree.Lookup;
 import org.opensearch.sql.ppl.CatalystExpressionVisitor;
 import org.opensearch.sql.ppl.CatalystPlanContext;
-import org.opensearch.sql.ppl.CatalystQueryPlanVisitor;
 import scala.Option;
 
 import java.util.ArrayList;
@@ -83,15 +83,23 @@ public interface LookupTransformer {
         Lookup node,
         Lookup.OutputStrategy strategy,
         CatalystExpressionVisitor expressionAnalyzer,
-        CatalystPlanContext context) {
+        CatalystPlanContext context,
+        LogicalPlan searchSide) {
         List<NamedExpression> outputProjectList = new ArrayList<>();
         for (Map.Entry<Alias, Field> entry : node.getOutputCandidateMap().entrySet()) {
             Alias inputFieldWithAlias = entry.getKey();
             Field inputField = (Field) inputFieldWithAlias.getDelegated();
             Field outputField = entry.getValue();
-            Expression inputCol = expressionAnalyzer.visitField(inputField, context);
-            Expression outputCol = expressionAnalyzer.visitField(outputField, context);
-
+            // Always resolve the inputCol expression with alias: __auto_generated_subquery_name_l.<fieldName>
+            // If the outputField existed in source table, resolve the outputCol expression with alias: __auto_generated_subquery_name_s.<fieldName>
+            // If not, resolve the outputCol expression without alias: <fieldName> to avoid failure of unable to resolved attribute.
+            Expression inputCol = expressionAnalyzer.visitField(buildFieldWithLookupSubqueryAlias(node, inputField), context);
+            Expression outputCol;
+            if (RelationUtils.columnExistsInCatalogTable(context.getSparkSession(), outputField, searchSide)) {
+                outputCol = expressionAnalyzer.visitField(buildFieldWithSourceSubqueryAlias(node, outputField), context);
+            } else {
+                outputCol = expressionAnalyzer.visitField(outputField, context);
+            }
             Expression child;
             if (strategy == Lookup.OutputStrategy.APPEND) {
                 child = Coalesce$.MODULE$.apply(seq(outputCol, inputCol));

--- a/ppl-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintPPLSparkExtensions.scala
+++ b/ppl-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintPPLSparkExtensions.scala
@@ -16,7 +16,7 @@ class FlintPPLSparkExtensions extends (SparkSessionExtensions => Unit) {
 
   override def apply(extensions: SparkSessionExtensions): Unit = {
     extensions.injectParser { (spark, parser) =>
-      new FlintSparkPPLParser(parser)
+      new FlintSparkPPLParser(parser, spark)
     }
   }
 }

--- a/ppl-spark-integration/src/main/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLParser.scala
+++ b/ppl-spark-integration/src/main/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLParser.scala
@@ -31,6 +31,7 @@ import org.opensearch.flint.spark.ppl.PlaneUtils.plan
 import org.opensearch.sql.common.antlr.SyntaxCheckException
 import org.opensearch.sql.ppl.{CatalystPlanContext, CatalystQueryPlanVisitor}
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.parser._
@@ -44,7 +45,8 @@ import org.apache.spark.sql.types.{DataType, StructType}
  * @param sparkParser
  *   Spark SQL parser
  */
-class FlintSparkPPLParser(sparkParser: ParserInterface) extends ParserInterface {
+class FlintSparkPPLParser(sparkParser: ParserInterface, val spark: SparkSession)
+    extends ParserInterface {
 
   /** OpenSearch (PPL) AST builder. */
   private val planTransformer = new CatalystQueryPlanVisitor()
@@ -55,6 +57,7 @@ class FlintSparkPPLParser(sparkParser: ParserInterface) extends ParserInterface 
     try {
       // if successful build ppl logical plan and translate to catalyst logical plan
       val context = new CatalystPlanContext
+      context.withSparkSession(spark)
       planTransformer.visit(plan(pplParser, sqlText), context)
       context.getPlan
     } catch {

--- a/ppl-spark-integration/src/main/scala/org/opensearch/flint/spark/ppl/PPLSparkUtils.scala
+++ b/ppl-spark-integration/src/main/scala/org/opensearch/flint/spark/ppl/PPLSparkUtils.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.ppl
+
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+object PPLSparkUtils {
+
+  def findLogicalRelations(plan: LogicalPlan): Seq[UnresolvedRelation] = {
+    plan
+      .transformDown { case relation: UnresolvedRelation =>
+        relation
+      }
+      .collect { case relation: UnresolvedRelation =>
+        relation
+      }
+  }
+}

--- a/ppl-spark-integration/src/main/scala/org/opensearch/flint/spark/ppl/PPLSparkUtils.scala
+++ b/ppl-spark-integration/src/main/scala/org/opensearch/flint/spark/ppl/PPLSparkUtils.scala
@@ -5,8 +5,8 @@
 
 package org.opensearch.flint.spark.ppl
 
-import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Project}
 
 object PPLSparkUtils {
 


### PR DESCRIPTION
### Description
**issue-1:**

The current behaviour of [inputField](https://github.com/opensearch-project/opensearch-spark/blob/main/docs/ppl-lang/ppl-lookup-command.md) is "If you don't specify any `<inputField>`, **all fields of `<lookupIndex>`** where matched values are applied to result output." 

The correct behaviour should be "If you don't specify any `<inputField>`, **all fields of `<lookupIndex>` that are not the mapping fields** where matched values are applied to result output." 

**issue-2:**

A known bug. The existing IT "test LOOKUP lookupTable name REPLACE occupation" provided a workaround. The PR fixed the issue and provide a new IT "test LOOKUP lookupTable name REPLACE occupation - 2"

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-spark/issues/1026

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
