### PR TITLE
Support OpenSearch ip field type

### DIFF
--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -69,6 +69,7 @@ The following table defines the data type mapping between OpenSearch index field
 | date(Date)               | DateType                          |
 | keyword                  | StringType, VarcharType, CharType |
 | text                     | StringType(meta(osType)=text)     |
+| ip                       | StringType(meta(osType)=ip)       |
 | object                   | StructType                        |
 | alias                    | Inherits referenced field type    |
 

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -115,6 +115,11 @@ object FlintDataType {
       // binary types
       case JString("binary") => BinaryType
 
+      // ip type
+      case JString("ip") =>
+        metadataBuilder.putString("osType", "ip")
+        StringType
+
       // not supported
       case unknown => throw new IllegalStateException(s"unsupported data type: $unknown")
     }

--- a/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
@@ -181,6 +181,33 @@ trait OpenSearchSuite extends BeforeAndAfterAll {
     index(indexName, oneNodeSetting, mappings, docs)
   }
 
+  def indexWithIp(indexName: String): Unit = {
+    val mappings = """{
+                     |  "properties": {
+                     |    "client": {
+                     |      "type": "ip"
+                     |    },
+                     |    "server": {
+                     |      "type": "ip"
+                     |    }
+                     |  }
+                     |}""".stripMargin
+    val docs = Seq(
+      """{
+                     |  "client": "192.168.0.10",
+                     |  "server": "100.10.12.123"
+                     |}""".stripMargin,
+      """{
+                    |  "client": "192.168.0.11",
+                    |  "server": "100.10.12.123"
+                    |}""".stripMargin,
+      """{
+                    |  "client": "2001:db8:3333:4444:5555:6666:7777:8888",
+                    |  "server": "2001:db8::1234:5678"
+                    |}""".stripMargin)
+    index(indexName, oneNodeSetting, mappings, docs)
+  }
+
   def index(index: String, settings: String, mappings: String, docs: Seq[String]): Unit = {
     openSearchClient.indices.create(
       new CreateIndexRequest(index)


### PR DESCRIPTION
### Description
- Support OpenSearch `ip` field type
- This PR implements `ip` field to be stored as StringType.
- Following section summarize the possible approach and their pros/cons. Considering the filtering can be pushed down to OpenSearch, We don't have much benefit to use UDT or Binary type.

### Comparison of the possible approaches
1. **String Type (`StringType`)**
   - ✅ Simple and fully compatible with Spark
   - ❌ Storage inefficient and slower for filtering

2. **User Defined Type (UDT)**
   - ✅ Enables custom IP-specific operations  (e.g., subnet calculations)
   - ❌ Requires additional maintenance and potential compatibility issues
   - ❌ Serialization / Deserialization overhead

3. **Binary Type (`BinaryType`)**
   - ✅ More storage-efficient and performant
   - ❌ Less readable and requires explicit type conversion

### Related Issues
https://github.com/opensearch-project/opensearch-spark/issues/1034

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
