### PR TITLE
Fix CI failed related to query_177

### DIFF
--- a/e2e-test/src/test/resources/spark/queries/ppl/query_177.results
+++ b/e2e-test/src/test/resources/spark/queries/ppl/query_177.results
@@ -1,6 +1,5 @@
 @timestamp,name,country,salary,id,occupation,stddev_samp(salary),stddev_pop(salary),"percentile_approx(salary, 60)"
 2024-06-15T13:40:23.000Z,Jake,England,100000,1000,Engineer,,0.0,100000
-2024-06-15T13:40:33.000Z,Hello,USA,70000,1001,Artist,,0.0,70000
 2024-06-15T13:40:43.000Z,John,Canada,120000,1002,Doctor,,0.0,120000
 2024-06-15T13:41:03.000Z,David,Canada,0,1004,,,0.0,0
 2024-06-15T13:41:13.000Z,Jane,Canada,90000,1005,Scientist,,0.0,90000

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/storage/FlintQueryCompilerSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/storage/FlintQueryCompilerSuite.scala
@@ -196,6 +196,20 @@ class FlintQueryCompilerSuite extends FlintSuite {
     assertResult("")(query)
   }
 
+  test(
+    "Bug fix, https://github.com/opensearch-project/opensearch-spark/actions/runs/13338348402/job/37258321066?pr=1052 ") {
+    val schema = StructType(
+      Seq(
+        StructField(
+          "aText",
+          StringType,
+          nullable = true,
+          new MetadataBuilder().withTextField.build())))
+
+    val query = FlintQueryCompiler(schema).compile(Not(EqualTo("aText", "text")).toV2)
+    assertResult("")(query)
+  }
+
   protected def schema(): StructType = {
     StructType(
       Seq(

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/storage/FlintQueryCompilerSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/storage/FlintQueryCompilerSuite.scala
@@ -196,8 +196,7 @@ class FlintQueryCompilerSuite extends FlintSuite {
     assertResult("")(query)
   }
 
-  test(
-    "Bug fix, https://github.com/opensearch-project/opensearch-spark/actions/runs/13338348402/job/37258321066?pr=1052 ") {
+  test("Bug fix, https://github.com/opensearch-project/opensearch-spark/issues/1056") {
     val schema = StructType(
       Seq(
         StructField(


### PR DESCRIPTION
### Description
1. Fix bug in QueryCompiler to correct handle `NOT "textField" = "literalString"`. It should not be push down to DSL.
2. Remove unexpected result from Query_177.results.

### Related Issues
[Fix Query_177 failure.](https://github.com/opensearch-project/opensearch-spark/issues/1056)

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
