### PR TITLE
Clean expression stack before resolving project list

### DIFF
--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystExpressionVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystExpressionVisitor.java
@@ -349,7 +349,7 @@ public class CatalystExpressionVisitor extends AbstractNodeVisitor<Expression, C
                         )
                 );
             }
-            context.retainAllNamedParseExpressions(e -> e);
+            context.resetNamedParseExpressions();
         }
         context.setNamedParseExpressions(initialNameExpressions);
         return context.getNamedParseExpressions().push(new CaseWhen(seq(whens), Option.apply(elseValue)));
@@ -421,7 +421,7 @@ public class CatalystExpressionVisitor extends AbstractNodeVisitor<Expression, C
         Expression value = analyze(node.getValue(), context);
         Expression lower = analyze(node.getLowerBound(), context);
         Expression upper = analyze(node.getUpperBound(), context);
-        context.retainAllNamedParseExpressions(p -> p);
+        context.resetNamedParseExpressions();
         return context.getNamedParseExpressions().push(new org.apache.spark.sql.catalyst.expressions.And(new GreaterThanOrEqual(value, lower), new LessThanOrEqual(value, upper)));
     }
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystPlanContext.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystPlanContext.java
@@ -8,15 +8,11 @@ package org.opensearch.sql.ppl;
 import lombok.Getter;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation;
-import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.Expression;
-import org.apache.spark.sql.catalyst.expressions.NamedExpression;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
 import org.apache.spark.sql.catalyst.plans.logical.Union;
-import org.apache.spark.sql.types.Metadata;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
-import org.opensearch.sql.data.type.ExprType;
 import scala.collection.Iterator;
 import scala.collection.Seq;
 
@@ -27,7 +23,6 @@ import java.util.Optional;
 import java.util.Stack;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
@@ -219,6 +214,14 @@ public class CatalystPlanContext {
     }
 
     /**
+     * Reset all expressions in stack,
+     * generally use it after calling visitFirstChild() in visit methods.
+     */
+    public void resetNamedParseExpressions() {
+        getNamedParseExpressions().retainAll(emptyList());
+    }
+
+    /**
      * retain all expressions and clear expression stack
      *
      * @return
@@ -226,7 +229,7 @@ public class CatalystPlanContext {
     public <T> Seq<T> retainAllNamedParseExpressions(Function<Expression, T> transformFunction) {
         Seq<T> aggregateExpressions = seq(getNamedParseExpressions().stream()
                 .map(transformFunction).collect(Collectors.toList()));
-        getNamedParseExpressions().retainAll(emptyList());
+        resetNamedParseExpressions();
         return aggregateExpressions;
     }
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/GeoIpCatalystLogicalPlanTranslator.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/GeoIpCatalystLogicalPlanTranslator.java
@@ -116,7 +116,7 @@ public interface GeoIpCatalystLogicalPlanTranslator {
                             UnresolvedAttribute$.MODULE$.apply(seq(GEOIP_TABLE_ALIAS,GEOIP_IPV4_COLUMN_NAME))
                     )
             ));
-            context.retainAllNamedParseExpressions(p -> p);
+            context.resetNamedParseExpressions();
             context.retainAllPlans(p -> p);
             return join(leftAlias,
                     rightAlias,

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
@@ -75,7 +75,7 @@ public interface LookupTransformer {
             Expression equalTo = EqualTo$.MODULE$.apply(lookupNamedExpression, sourceNamedExpression);
             equiConditions.add(equalTo);
         }
-        context.retainAllNamedParseExpressions(e -> e);
+        context.resetNamedParseExpressions();
         return equiConditions.stream().reduce(org.apache.spark.sql.catalyst.expressions.And::new).orElse(null);
     }
 
@@ -114,7 +114,7 @@ public interface LookupTransformer {
                 seq(new java.util.ArrayList<String>()));
             outputProjectList.add(output);
         }
-        context.retainAllNamedParseExpressions(p -> p);
+        context.resetNamedParseExpressions();
         return outputProjectList;
     }
 


### PR DESCRIPTION
### Description
Issue described in https://github.com/opensearch-project/opensearch-spark/issues/1058.
Root cause is missing reset expression stack before resolving project list.

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-spark/issues/1058

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
