### PR TITLE
[Enhancement] Unify all PPL functions in BuiltinFunctionName

### DIFF
--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLGeoipITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLGeoipITSuite.scala
@@ -7,6 +7,8 @@ package org.opensearch.flint.spark.ppl
 
 import java.util
 
+import org.opensearch.sql.expression.function.BuiltinFunctionName.IP_TO_INT
+import org.opensearch.sql.expression.function.BuiltinFunctionName.IS_IPV4
 import org.opensearch.sql.expression.function.SerializableUdf.visit
 import org.opensearch.sql.ppl.utils.DataTypeTransformer.seq
 
@@ -57,8 +59,8 @@ class FlintSparkPPLGeoipITSuite
       ipAddress: UnresolvedAttribute,
       left: LogicalPlan,
       right: LogicalPlan): LogicalPlan = {
-    val is_ipv4 = visit("is_ipv4", util.List.of[Expression](ipAddress))
-    val ip_to_int = visit("ip_to_int", util.List.of[Expression](ipAddress))
+    val is_ipv4 = visit(IS_IPV4, util.List.of[Expression](ipAddress))
+    val ip_to_int = visit(IP_TO_INT, util.List.of[Expression](ipAddress))
 
     val t1 = SubqueryAlias("t1", left)
     val t2 = SubqueryAlias("t2", right)

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLJsonFunctionITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLJsonFunctionITSuite.scala
@@ -7,6 +7,10 @@ package org.opensearch.flint.spark.ppl
 
 import java.util
 
+import org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_APPEND
+import org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_DELETE
+import org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_EXTEND
+import org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_SET
 import org.opensearch.sql.expression.function.SerializableUdf.visit
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
@@ -408,7 +412,7 @@ class FlintSparkPPLJsonFunctionITSuite
     val jsonObjExp =
       Literal("{\"account_number\":1,\"balance\":39225,\"age\":32,\"gender\":\"M\"}")
     val jsonFunc =
-      Alias(visit("json_delete", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_DELETE, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -429,7 +433,7 @@ class FlintSparkPPLJsonFunctionITSuite
     val jsonObjExp =
       Literal("{\"account_number\":1,\"balance\":39225,\"age\":32,\"gender\":\"M\"}")
     val jsonFunc =
-      Alias(visit("json_delete", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_DELETE, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -450,7 +454,7 @@ class FlintSparkPPLJsonFunctionITSuite
     val jsonObjExp =
       Literal("{\"f1\":\"abc\",\"f2\":{\"f3\":\"a\",\"f4\":\"b\"}}")
     val jsonFunc =
-      Alias(visit("json_delete", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_DELETE, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -475,7 +479,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":\"Alice\",\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_delete", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_DELETE, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -500,7 +504,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":\"Alice\",\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_delete", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_DELETE, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -525,7 +529,7 @@ class FlintSparkPPLJsonFunctionITSuite
     val jsonObjExp =
       Literal("{\"account_number\":1,\"balance\":39225,\"age\":32,\"gender\":\"M\"}")
     val jsonFunc =
-      Alias(visit("json_set", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_SET, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -552,7 +556,7 @@ class FlintSparkPPLJsonFunctionITSuite
     val jsonObjExp =
       Literal("{\"account_number\":1,\"balance\":39225,\"age\":32,\"gender\":\"M\"}")
     val jsonFunc =
-      Alias(visit("json_set", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_SET, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -573,7 +577,7 @@ class FlintSparkPPLJsonFunctionITSuite
     val jsonObjExp =
       Literal("{\"f1\":\"abc\",\"f2\":{\"f3\":\"a\",\"f4\":\"b\"}}")
     val jsonFunc =
-      Alias(visit("json_set", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_SET, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -598,7 +602,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":\"Alice\",\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_set", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_SET, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -625,7 +629,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_append", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_APPEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -653,7 +657,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_append", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_APPEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -681,7 +685,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_append", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_APPEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -709,7 +713,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_append", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_APPEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -737,7 +741,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_append", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_APPEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -765,7 +769,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_append", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_APPEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -797,7 +801,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"school\":{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}}")
     val jsonFunc =
-      Alias(visit("json_append", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_APPEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -824,7 +828,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_extend", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_EXTEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -849,7 +853,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_extend", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_EXTEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -877,7 +881,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_extend", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_EXTEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -905,7 +909,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_extend", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_EXTEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -933,7 +937,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_extend", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_EXTEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -961,7 +965,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}")
     val jsonFunc =
-      Alias(visit("json_extend", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_EXTEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)
@@ -993,7 +997,7 @@ class FlintSparkPPLJsonFunctionITSuite
       Literal(
         "{\"school\":{\"teacher\":[\"Alice\"],\"student\":[{\"name\":\"Bob\",\"rank\":1},{\"name\":\"Charlie\",\"rank\":2}]}}")
     val jsonFunc =
-      Alias(visit("json_extend", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_EXTEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val limit = GlobalLimit(Literal(1), LocalLimit(Literal(1), eval))
     val expectedPlan = Project(Seq(UnresolvedAttribute("result")), limit)

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -223,6 +223,10 @@ public enum BuiltinFunctionName {
   JSON_EXTRACT(FunctionName.of("json_extract")),
   JSON_KEYS(FunctionName.of("json_keys")),
   JSON_VALID(FunctionName.of("json_valid")),
+  JSON_DELETE(FunctionName.of("json_delete")),
+  JSON_SET(FunctionName.of("json_set")),
+  JSON_APPEND(FunctionName.of("json_append")),
+  JSON_EXTEND(FunctionName.of("json_extend")),
 //  JSON_ARRAY_ALL_MATCH(FunctionName.of("json_array_all_match")),
 //  JSON_ARRAY_ANY_MATCH(FunctionName.of("json_array_any_match")),
 //  JSON_ARRAY_FILTER(FunctionName.of("json_array_filter")),
@@ -293,7 +297,13 @@ public enum BuiltinFunctionName {
   MULTIMATCHQUERY(FunctionName.of("multimatchquery")),
   WILDCARDQUERY(FunctionName.of("wildcardquery")),
   WILDCARD_QUERY(FunctionName.of("wildcard_query")),
-  COALESCE(FunctionName.of("coalesce"));
+  COALESCE(FunctionName.of("coalesce")),
+
+  /** IP Relevance Function. */
+  CIDR(FunctionName.of("cidr")),
+  IS_IPV4(FunctionName.of("is_ipv4")),
+  IP_TO_INT(FunctionName.of("ip_to_int")),
+  ;
 
   private FunctionName name;
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/expression/function/SerializableUdf.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/expression/function/SerializableUdf.java
@@ -23,11 +23,9 @@ import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.ScalaUDF;
 import org.apache.spark.sql.types.DataTypes;
-import org.jetbrains.annotations.TestOnly;
 import scala.Function1;
 import scala.Function2;
 import scala.Function3;
@@ -317,18 +315,5 @@ public interface SerializableUdf {
             default:
                 return null;
         }
-    }
-
-    /**
-     * Get the function reference according to its name
-     *
-     * @param funcName string representing function to retrieve.
-     * @return relevant ScalaUDF for given function name.
-     */
-    @TestOnly
-    static ScalaUDF visit(String funcName, List<Expression> expressions) {
-        Optional<BuiltinFunctionName> funcNameEnum = BuiltinFunctionName.of(funcName);
-        assert funcNameEnum.isPresent();
-        return visit(funcNameEnum.get(), expressions);
     }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystExpressionVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystExpressionVisitor.java
@@ -79,6 +79,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.List.of;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.CIDR;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.EQUAL;
 import static org.opensearch.sql.ppl.CatalystPlanContext.findRelation;
 import static org.opensearch.sql.ppl.utils.BuiltinFunctionTransformer.createIntervalArgs;
@@ -431,7 +432,7 @@ public class CatalystExpressionVisitor extends AbstractNodeVisitor<Expression, C
         Expression ipAddressExpression = context.getNamedParseExpressions().pop();
         analyze(node.getCidrBlock(), context);
         Expression cidrBlockExpression = context.getNamedParseExpressions().pop();
-        return context.getNamedParseExpressions().push(SerializableUdf.visit("cidr", of(ipAddressExpression,cidrBlockExpression)));
+        return context.getNamedParseExpressions().push(SerializableUdf.visit(CIDR, of(ipAddressExpression,cidrBlockExpression)));
     }
 
     @Override

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/BuiltinFunctionTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/BuiltinFunctionTransformer.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.ppl.utils;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction$;
 import org.apache.spark.sql.catalyst.expressions.CurrentTimeZone$;
@@ -15,7 +16,6 @@ import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.GreaterThanOrEqual$;
 import org.apache.spark.sql.catalyst.expressions.LessThanOrEqual$;
 import org.apache.spark.sql.catalyst.expressions.Literal$;
-import org.apache.spark.sql.catalyst.expressions.ScalaUDF;
 import org.apache.spark.sql.catalyst.expressions.TimestampAdd$;
 import org.apache.spark.sql.catalyst.expressions.TimestampDiff$;
 import org.apache.spark.sql.catalyst.expressions.ToUTCTimestamp$;
@@ -34,18 +34,25 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.ADD;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.ADDDATE;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.APPROX_COUNT_DISTINCT;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.ARRAY_LENGTH;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.CIDR;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DATEDIFF;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DATE_ADD;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DATE_SUB;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DAY_OF_MONTH;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.COALESCE;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.EARLIEST;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.IP_TO_INT;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_IPV4;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_APPEND;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_ARRAY;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_ARRAY_LENGTH;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_DELETE;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_EXTEND;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_EXTRACT;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_KEYS;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_OBJECT;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_SET;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_VALID;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.LATEST;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.SUBTRACT;
@@ -75,6 +82,14 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.WEEK_OF
 import static org.opensearch.sql.ppl.utils.DataTypeTransformer.seq;
 import static scala.Option.empty;
 
+/**
+ * Transformer for built-in functions. It will transform PPL built-in functions to Spark functions.
+ * There are four ways of transformation:
+ * 1. Transform to spark built-int function directly without name mapping
+ * 2. Transform to spark built-int function with direct name mapping in `SPARK_BUILTIN_FUNCTION_NAME_MAPPING`
+ * 3. Transform to spark built-int function with alternative implementation mapping in `PPL_TO_SPARK_FUNC_MAPPING`
+ * 4. Transform to spark scala function implemented in {@link SerializableUdf}
+ */
 public interface BuiltinFunctionTransformer {
 
     /**
@@ -178,48 +193,86 @@ public interface BuiltinFunctionTransformer {
             args -> {
                 return ToUTCTimestamp$.MODULE$.apply(CurrentTimestamp$.MODULE$.apply(), CurrentTimeZone$.MODULE$.apply());
             })
-
-        // Relative time functions
-        .put(
-                RELATIVE_TIMESTAMP,
-                args -> buildRelativeTimestamp(args.get(0)))
-        .put(
-                EARLIEST,
-                args -> {
-                    Expression relativeTimestamp = buildRelativeTimestamp(args.get(0));
-                    Expression timestamp = args.get(1);
-                    return LessThanOrEqual$.MODULE$.apply(relativeTimestamp, timestamp);
-                })
-        .put(
-                LATEST,
-                args -> {
-                    Expression relativeTimestamp = buildRelativeTimestamp(args.get(0));
-                    Expression timestamp = args.get(1);
-                    return GreaterThanOrEqual$.MODULE$.apply(relativeTimestamp, timestamp);
-                })
         .build();
 
+  /**
+   * The mapping between PPL builtin functions to Spark UDF implemented in this project.
+   */
+  Map<BuiltinFunctionName, Function<List<Expression>, Expression>> PPL_TO_SPARK_UDF_MAPPING
+      = ImmutableMap.<BuiltinFunctionName, Function<List<Expression>, Expression>>builder()
+      // JSON UDF
+      .put(
+          JSON_DELETE,
+          args -> SerializableUdf.visit(JSON_DELETE, args))
+      .put(
+          JSON_SET,
+          args -> SerializableUdf.visit(JSON_SET, args))
+      .put(
+          JSON_APPEND,
+          args -> SerializableUdf.visit(JSON_APPEND, args))
+      .put(
+          JSON_EXTEND,
+          args -> SerializableUdf.visit(JSON_EXTEND, args))
+      // IP Relevance UDF
+      .put(
+          CIDR,
+          args -> SerializableUdf.visit(CIDR, args))
+      .put(
+          IS_IPV4,
+          args -> SerializableUdf.visit(IS_IPV4, args))
+      .put(
+          IP_TO_INT,
+          args -> SerializableUdf.visit(IP_TO_INT, args))
+      // Relative Time UDF
+      .put(
+          RELATIVE_TIMESTAMP,
+          args -> buildRelativeTimestamp(args.get(0)))
+      .put(
+          EARLIEST,
+          args -> {
+            Expression relativeTimestamp = buildRelativeTimestamp(args.get(0));
+            Expression timestamp = args.get(1);
+            return LessThanOrEqual$.MODULE$.apply(relativeTimestamp, timestamp);
+          })
+      .put(
+          LATEST,
+          args -> {
+            Expression relativeTimestamp = buildRelativeTimestamp(args.get(0));
+            Expression timestamp = args.get(1);
+            return GreaterThanOrEqual$.MODULE$.apply(relativeTimestamp, timestamp);
+          })
+      .build();
+
     static Expression builtinFunction(org.opensearch.sql.ast.expression.Function function, List<Expression> args) {
-        if (BuiltinFunctionName.of(function.getFuncName()).isEmpty()) {
-            ScalaUDF udf = SerializableUdf.visit(function.getFuncName(), args);
-            if(udf == null) {
-                throw new UnsupportedOperationException(function.getFuncName() + " is not a builtin function of PPL");
-            }
-            return udf;
-        } else {
-            BuiltinFunctionName builtin = BuiltinFunctionName.of(function.getFuncName()).get();
-            String name = SPARK_BUILTIN_FUNCTION_NAME_MAPPING.get(builtin);
-            if (name != null) {
-                // there is a Spark builtin function mapping with the PPL builtin function
-                return new UnresolvedFunction(seq(name), seq(args), false, empty(),false);
-            }
-            Function<List<Expression>, Expression> alternative = PPL_TO_SPARK_FUNC_MAPPING.get(builtin);
-            if (alternative != null) {
-                return alternative.apply(args);
-            }
-            name = builtin.getName().getFunctionName();
-            return new UnresolvedFunction(seq(name), seq(args), false, empty(),false);
-        }
+      Optional<BuiltinFunctionName> builtinOpt = BuiltinFunctionName.of(function.getFuncName());
+      if (builtinOpt.isEmpty()) {
+          throw new UnsupportedOperationException(function.getFuncName() + " is not a builtin function of PPL");
+      }
+      BuiltinFunctionName builtin = builtinOpt.get();
+
+      // 1. Transform to spark built-int function if there is a direct mapping
+      String name = SPARK_BUILTIN_FUNCTION_NAME_MAPPING.get(builtin);
+      if (name != null) {
+          // there is a Spark builtin function mapping with the PPL builtin function
+          return new UnresolvedFunction(seq(name), seq(args), false, empty(),false);
+      }
+
+      // 2. Transform to spark built-int function if there is an alternative mapping
+      Function<List<Expression>, Expression> alternative = PPL_TO_SPARK_FUNC_MAPPING.get(builtin);
+      if (alternative != null) {
+          return alternative.apply(args);
+      }
+
+      // 3. Transform to spark UDF
+      // if we already have a self-defined implementation in this project
+      Function<List<Expression>, Expression> udf = PPL_TO_SPARK_UDF_MAPPING.get(builtin);
+      if(udf != null) {
+          return udf.apply(args);
+      }
+
+      // 4. Transform to spark built-int function directly without mapping
+      name = builtin.getName().getFunctionName();
+      return new UnresolvedFunction(seq(name), seq(args), false, empty(),false);
     }
 
     static Expression[] createIntervalArgs(IntervalUnit unit, Expression value) {
@@ -241,7 +294,7 @@ public interface BuiltinFunctionTransformer {
 
     private static Expression buildRelativeTimestamp(Expression relativeStringExpression) {
         return SerializableUdf.visit(
-                RELATIVE_TIMESTAMP.getName().getFunctionName(),
+                RELATIVE_TIMESTAMP,
                 List.of(relativeStringExpression, CurrentTimestamp$.MODULE$.apply(), CurrentTimeZone$.MODULE$.apply()));
     }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/BuiltinFunctionTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/BuiltinFunctionTransformer.java
@@ -88,7 +88,7 @@ import static scala.Option.empty;
  * 1. Transform to spark built-int function directly without name mapping
  * 2. Transform to spark built-int function with direct name mapping in `SPARK_BUILTIN_FUNCTION_NAME_MAPPING`
  * 3. Transform to spark built-int function with alternative implementation mapping in `PPL_TO_SPARK_FUNC_MAPPING`
- * 4. Transform to spark scala function implemented in {@link SerializableUdf}
+ * 4. Transform to spark scala function implemented in {@link SerializableUdf} by mapping in `PPL_TO_SPARK_UDF_MAPPING`
  */
 public interface BuiltinFunctionTransformer {
 

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/GeoIpCatalystLogicalPlanTranslator.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/GeoIpCatalystLogicalPlanTranslator.java
@@ -38,6 +38,8 @@ import java.util.stream.Collectors;
 
 import static java.util.List.of;
 
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.IP_TO_INT;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_IPV4;
 import static org.opensearch.sql.ppl.utils.DataTypeTransformer.seq;
 import static org.opensearch.sql.ppl.utils.JoinSpecTransformer.join;
 
@@ -103,16 +105,16 @@ public interface GeoIpCatalystLogicalPlanTranslator {
             Optional<Expression> joinCondition = Optional.of(new And(
                     new And(
                             new GreaterThanOrEqual(
-                                    SerializableUdf.visit("ip_to_int", of(ipAddress)),
+                                    SerializableUdf.visit(IP_TO_INT, of(ipAddress)),
                                     UnresolvedAttribute$.MODULE$.apply(seq(GEOIP_TABLE_ALIAS,GEOIP_IP_RANGE_START_COLUMN_NAME))
                             ),
                             new LessThan(
-                                    SerializableUdf.visit("ip_to_int", of(ipAddress)),
+                                    SerializableUdf.visit(IP_TO_INT, of(ipAddress)),
                                     UnresolvedAttribute$.MODULE$.apply(seq(GEOIP_TABLE_ALIAS,GEOIP_IP_RANGE_END_COLUMN_NAME))
                             )
                     ),
                     new EqualTo(
-                            SerializableUdf.visit("is_ipv4", of(ipAddress)),
+                            SerializableUdf.visit(IS_IPV4, of(ipAddress)),
                             UnresolvedAttribute$.MODULE$.apply(seq(GEOIP_TABLE_ALIAS,GEOIP_IPV4_COLUMN_NAME))
                     )
             ));

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanGeoipFunctionTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanGeoipFunctionTranslatorTestSuite.scala
@@ -8,6 +8,7 @@ package org.opensearch.flint.spark.ppl
 import java.util
 
 import org.opensearch.flint.spark.ppl.PlaneUtils.plan
+import org.opensearch.sql.expression.function.BuiltinFunctionName.{IP_TO_INT, IS_IPV4}
 import org.opensearch.sql.expression.function.SerializableUdf.visit
 import org.opensearch.sql.ppl.{CatalystPlanContext, CatalystQueryPlanVisitor}
 import org.opensearch.sql.ppl.utils.DataTypeTransformer.seq
@@ -15,10 +16,9 @@ import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedFunction, UnresolvedRelation, UnresolvedStar}
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, CreateNamedStruct, Descending, EqualTo, Expression, ExprId, GreaterThanOrEqual, In, LessThan, Literal, NamedExpression, ScalaUDF, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, CreateNamedStruct, EqualTo, Expression, GreaterThanOrEqual, LessThan, Literal, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.{LeftOuter, PlanTest}
-import org.apache.spark.sql.catalyst.plans.logical.{DataFrameDropColumns, Join, JoinHint, LogicalPlan, Project, Sort, SubqueryAlias}
-import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.catalyst.plans.logical.{DataFrameDropColumns, Join, JoinHint, LogicalPlan, Project, SubqueryAlias}
 
 class PPLLogicalPlanGeoipFunctionTranslatorTestSuite
     extends SparkFunSuite
@@ -42,8 +42,8 @@ class PPLLogicalPlanGeoipFunctionTranslatorTestSuite
       ipAddress: UnresolvedAttribute,
       left: LogicalPlan,
       right: LogicalPlan): LogicalPlan = {
-    val is_ipv4 = visit("is_ipv4", util.List.of[Expression](ipAddress))
-    val ip_to_int = visit("ip_to_int", util.List.of[Expression](ipAddress))
+    val is_ipv4 = visit(IS_IPV4, util.List.of[Expression](ipAddress))
+    val ip_to_int = visit(IP_TO_INT, util.List.of[Expression](ipAddress))
 
     val t1 = SubqueryAlias("t1", left)
     val t2 = SubqueryAlias("t2", right)

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanJsonFunctionsTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanJsonFunctionsTranslatorTestSuite.scala
@@ -8,10 +8,12 @@ package org.opensearch.flint.spark.ppl
 import java.util
 
 import org.opensearch.flint.spark.ppl.PlaneUtils.plan
-import org.opensearch.sql.expression.function.SerializableUdf
+import org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_APPEND
+import org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_DELETE
+import org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_EXTEND
+import org.opensearch.sql.expression.function.BuiltinFunctionName.JSON_SET
 import org.opensearch.sql.expression.function.SerializableUdf.visit
 import org.opensearch.sql.ppl.{CatalystPlanContext, CatalystQueryPlanVisitor}
-import org.opensearch.sql.ppl.utils.DataTypeTransformer.seq
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.SparkFunSuite
@@ -19,7 +21,6 @@ import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedFu
 import org.apache.spark.sql.catalyst.expressions.{Alias, EqualTo, Literal}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project}
-import org.apache.spark.sql.types.DataTypes
 
 class PPLLogicalPlanJsonFunctionsTranslatorTestSuite
     extends SparkFunSuite
@@ -209,7 +210,7 @@ class PPLLogicalPlanJsonFunctionsTranslatorTestSuite
     val jsonObjExp =
       Literal("""{"a":[{"b":1},{"c":2}]}""")
     val jsonFunc =
-      Alias(visit("json_set", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_SET, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val expectedPlan = Project(Seq(UnresolvedStar(None)), eval)
     comparePlans(expectedPlan, logPlan, false)
@@ -230,7 +231,7 @@ class PPLLogicalPlanJsonFunctionsTranslatorTestSuite
     val jsonObjExp =
       Literal("""{"a":[{"b":1},{"c":2}]}""")
     val jsonFunc =
-      Alias(visit("json_delete", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_DELETE, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val expectedPlan = Project(Seq(UnresolvedStar(None)), eval)
     comparePlans(expectedPlan, logPlan, false)
@@ -254,7 +255,7 @@ class PPLLogicalPlanJsonFunctionsTranslatorTestSuite
     val jsonObjExp =
       Literal("""{"a":[{"b":1},{"c":2}]}""")
     val jsonFunc =
-      Alias(visit("json_append", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_APPEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val expectedPlan = Project(Seq(UnresolvedStar(None)), eval)
     comparePlans(expectedPlan, logPlan, false)
@@ -282,7 +283,7 @@ class PPLLogicalPlanJsonFunctionsTranslatorTestSuite
     val jsonObjExp =
       Literal("""{"a":[{"b":1},{"c":2}]}""")
     val jsonFunc =
-      Alias(visit("json_extend", util.List.of(jsonObjExp, keysExpression)), "result")()
+      Alias(visit(JSON_EXTEND, util.List.of(jsonObjExp, keysExpression)), "result")()
     val eval = Project(Seq(UnresolvedStar(None), jsonFunc), table)
     val expectedPlan = Project(Seq(UnresolvedStar(None)), eval)
     comparePlans(expectedPlan, logPlan, false)

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanParseCidrmatchTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanParseCidrmatchTestSuite.scala
@@ -6,18 +6,16 @@
 package org.opensearch.flint.spark.ppl
 
 import org.opensearch.flint.spark.ppl.PlaneUtils.plan
-import org.opensearch.sql.expression.function.SerializableUdf
+import org.opensearch.sql.expression.function.BuiltinFunctionName.CIDR
 import org.opensearch.sql.expression.function.SerializableUdf.visit
 import org.opensearch.sql.ppl.{CatalystPlanContext, CatalystQueryPlanVisitor}
-import org.opensearch.sql.ppl.utils.DataTypeTransformer.seq
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedFunction, UnresolvedRelation, UnresolvedStar}
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, Ascending, CaseWhen, Descending, EqualTo, GreaterThan, Literal, NullsFirst, NullsLast, RegExpExtract, SortOrder}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation, UnresolvedStar}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, CaseWhen, EqualTo, Literal}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.types.DataTypes
 
 class PPLLogicalPlanParseCidrmatchTestSuite
     extends SparkFunSuite
@@ -42,7 +40,7 @@ class PPLLogicalPlanParseCidrmatchTestSuite
 
     val filterIpv6 = EqualTo(UnresolvedAttribute("isV6"), Literal(false))
     val filterIsValid = EqualTo(UnresolvedAttribute("isValid"), Literal(true))
-    val cidr = visit("cidr", java.util.List.of(ipAddress, cidrExpression))
+    val cidr = visit(CIDR, java.util.List.of(ipAddress, cidrExpression))
 
     val expectedPlan = Project(
       Seq(UnresolvedStar(None)),
@@ -64,7 +62,7 @@ class PPLLogicalPlanParseCidrmatchTestSuite
 
     val filterIpv6 = EqualTo(UnresolvedAttribute("isV6"), Literal(true))
     val filterIsValid = EqualTo(UnresolvedAttribute("isValid"), Literal(false))
-    val cidr = visit("cidr", java.util.List.of(ipAddress, cidrExpression))
+    val cidr = visit(CIDR, java.util.List.of(ipAddress, cidrExpression))
 
     val expectedPlan = Project(
       Seq(UnresolvedStar(None)),
@@ -85,7 +83,7 @@ class PPLLogicalPlanParseCidrmatchTestSuite
     val cidrExpression = Literal("2003:db8::/32")
 
     val filterIpv6 = EqualTo(UnresolvedAttribute("isV6"), Literal(true))
-    val cidr = visit("cidr", java.util.List.of(ipAddress, cidrExpression))
+    val cidr = visit(CIDR, java.util.List.of(ipAddress, cidrExpression))
 
     val expectedPlan = Project(
       Seq(UnresolvedAttribute("ip")),
@@ -107,7 +105,7 @@ class PPLLogicalPlanParseCidrmatchTestSuite
 
     val filterIpv6 = EqualTo(UnresolvedAttribute("isV6"), Literal(true))
     val filterClause = Filter(filterIpv6, UnresolvedRelation(Seq("t")))
-    val cidr = visit("cidr", java.util.List.of(ipAddress, cidrExpression))
+    val cidr = visit(CIDR, java.util.List.of(ipAddress, cidrExpression))
 
     val equalTo = EqualTo(Literal(true), cidr)
     val caseFunction = CaseWhen(Seq((equalTo, Literal("in"))), Literal("out"))


### PR DESCRIPTION
### Description
Unify all PPL functions in BuiltinFunctionName. This PR includes change:
- Add all PPL functions we have currently in `BuiltinFunctionName`, that place should be the single of truth to maintain all PPL built-in functions.
- For code robust improvement, `SerializableUdf::visit` change to use function enumerator as its switch key instead of string.
- Add `PPL_TO_SPARK_UDF_MAPPING` in `BuiltinFunctionTransformer` to do transformation of PPL built-in function to Spark UDF we implemented in this project.


### Related Issues
Resolves: https://github.com/opensearch-project/opensearch-spark/issues/1051


### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
