### PR TITLE
Alias could be wrapped with backticks in RENAME and other commands

### DIFF
--- a/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/ppl-spark-integration/src/main/antlr4/OpenSearchPPLParser.g4
@@ -349,7 +349,7 @@ joinType
    ;
 
 sideAlias
-   : (LEFT EQUAL leftAlias = ident)? COMMA? (RIGHT EQUAL rightAlias = ident)?
+   : (LEFT EQUAL leftAlias = qualifiedName)? COMMA? (RIGHT EQUAL rightAlias = qualifiedName)?
    ;
 
 joinCriteria

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -162,13 +162,13 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
       joinType = Join.JoinType.CROSS;
     }
     Join.JoinHint joinHint = getJoinHint(ctx.joinHintList());
-    Optional<String> leftAlias = ctx.sideAlias().leftAlias != null ? Optional.of(ctx.sideAlias().leftAlias.getText()) : Optional.empty();
+    Optional<String> leftAlias = ctx.sideAlias().leftAlias != null ? Optional.of(internalVisitExpression(ctx.sideAlias().leftAlias).toString()) : Optional.empty();
     Optional<String> rightAlias = Optional.empty();
     if (ctx.tableOrSubqueryClause().alias != null) {
-      rightAlias = Optional.of(ctx.tableOrSubqueryClause().alias.getText());
+      rightAlias = Optional.of(internalVisitExpression(ctx.tableOrSubqueryClause().alias).toString());
     }
     if (ctx.sideAlias().rightAlias != null) {
-      rightAlias = Optional.of(ctx.sideAlias().rightAlias.getText());
+      rightAlias = Optional.of(internalVisitExpression(ctx.sideAlias().rightAlias).toString());
     }
 
     UnresolvedPlan rightRelation = visit(ctx.tableOrSubqueryClause());
@@ -248,7 +248,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
             .map(
                 ct ->
                     new Alias(
-                        ct.renamedField.getText(),
+                        ((Field) internalVisitExpression(ct.renamedField)).getField().toString(),
                         internalVisitExpression(ct.orignalField)))
             .collect(Collectors.toList()));
   }
@@ -262,7 +262,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
       String name =
           aggCtx.alias == null
               ? getTextInQuery(aggCtx)
-              : aggCtx.alias.getText();
+              : ((Field) internalVisitExpression(aggCtx.alias)).getField().toString();
       Alias alias = new Alias(name, aggExpression);
       aggListBuilder.add(alias);
     }
@@ -442,7 +442,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
       throw new SyntaxCheckException("Number of trendline data-points must be greater than or equal to 1");
     }
     Field dataField = (Field) expressionBuilder.visitFieldExpression(ctx.field);
-    String alias = ctx.alias == null?dataField.getField().toString()+"_trendline":ctx.alias.getText();
+    String alias = ctx.alias == null? dataField.getField().toString() + "_trendline" : internalVisitExpression(ctx.alias).toString();
     String computationType = ctx.trendlineType().getText();
     return new Trendline.TrendlineComputation(numberOfDataPoints, dataField, alias, Trendline.TrendlineType.valueOf(computationType.toUpperCase()));
   }
@@ -537,7 +537,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   public UnresolvedPlan visitTableOrSubqueryClause(OpenSearchPPLParser.TableOrSubqueryClauseContext ctx) {
       if (ctx.subSearch() != null) {
           return ctx.alias != null
-              ? new SubqueryAlias(ctx.alias.getText(), visitSubSearch(ctx.subSearch()))
+              ? new SubqueryAlias(internalVisitExpression(ctx.alias).toString(), visitSubSearch(ctx.subSearch()))
               : visitSubSearch(ctx.subSearch());
       } else {
           return visitTableSourceClause(ctx.tableSourceClause());
@@ -547,7 +547,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   @Override
   public UnresolvedPlan visitTableSourceClause(OpenSearchPPLParser.TableSourceClauseContext ctx) {
     Relation relation = new Relation(ctx.tableSource().stream().map(this::internalVisitExpression).collect(Collectors.toList()));
-    return ctx.alias != null ? new SubqueryAlias(ctx.alias.getText(), relation) : relation;
+    return ctx.alias != null ? new SubqueryAlias(internalVisitExpression(ctx.alias).toString(), relation) : relation;
   }
 
   @Override

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanAggregationQueriesTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanAggregationQueriesTranslatorTestSuite.scala
@@ -1106,38 +1106,13 @@ class PPLLogicalPlanAggregationQueriesTranslatorTestSuite
     comparePlans(expectedPlan, logPlan, checkAnalysis = false)
   }
 
-  test("test average backticks price") {
-    val context = new CatalystPlanContext
-    val logPlan =
-      planTransformer.visit(plan(pplParser, "source = table | stats avg(`price`)"), context)
-    val star = Seq(UnresolvedStar(None))
-
-    val priceField = UnresolvedAttribute("price")
-    val tableRelation = UnresolvedRelation(Seq("table"))
-    val aggregateExpressions = Seq(
-      Alias(
-        UnresolvedFunction(Seq("AVG"), Seq(priceField), isDistinct = false),
-        "avg(`price`)")())
-    val aggregatePlan = Aggregate(Seq(), aggregateExpressions, tableRelation)
-    val expectedPlan = Project(star, aggregatePlan)
-
-    comparePlans(expectedPlan, logPlan, false)
-  }
-
   test("test average price with backticks alias") {
-    val context = new CatalystPlanContext
+    val expectedPlan = planTransformer.visit(
+      plan(pplParser, "source = table | stats avg(price) as avg_price"),
+      new CatalystPlanContext)
     val logPlan = planTransformer.visit(
-      plan(pplParser, "source = table | stats avg(price) as `avg_price`"),
-      context)
-    val star = Seq(UnresolvedStar(None))
-
-    val priceField = UnresolvedAttribute("price")
-    val tableRelation = UnresolvedRelation(Seq("table"))
-    val aggregateExpressions = Seq(
-      Alias(UnresolvedFunction(Seq("AVG"), Seq(priceField), isDistinct = false), "avg_price")())
-    val aggregatePlan = Aggregate(Seq(), aggregateExpressions, tableRelation)
-    val expectedPlan = Project(star, aggregatePlan)
-
+      plan(pplParser, "source = table | stats avg(`price`) as `avg_price`"),
+      new CatalystPlanContext)
     comparePlans(expectedPlan, logPlan, false)
   }
 }

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanAggregationQueriesTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanAggregationQueriesTranslatorTestSuite.scala
@@ -1105,4 +1105,39 @@ class PPLLogicalPlanAggregationQueriesTranslatorTestSuite
     val expectedPlan = Project(Seq(UnresolvedStar(None)), aggregate)
     comparePlans(expectedPlan, logPlan, checkAnalysis = false)
   }
+
+  test("test average backticks price") {
+    val context = new CatalystPlanContext
+    val logPlan =
+      planTransformer.visit(plan(pplParser, "source = table | stats avg(`price`)"), context)
+    val star = Seq(UnresolvedStar(None))
+
+    val priceField = UnresolvedAttribute("price")
+    val tableRelation = UnresolvedRelation(Seq("table"))
+    val aggregateExpressions = Seq(
+      Alias(
+        UnresolvedFunction(Seq("AVG"), Seq(priceField), isDistinct = false),
+        "avg(`price`)")())
+    val aggregatePlan = Aggregate(Seq(), aggregateExpressions, tableRelation)
+    val expectedPlan = Project(star, aggregatePlan)
+
+    comparePlans(expectedPlan, logPlan, false)
+  }
+
+  test("test average price with backticks alias") {
+    val context = new CatalystPlanContext
+    val logPlan = planTransformer.visit(
+      plan(pplParser, "source = table | stats avg(price) as `avg_price`"),
+      context)
+    val star = Seq(UnresolvedStar(None))
+
+    val priceField = UnresolvedAttribute("price")
+    val tableRelation = UnresolvedRelation(Seq("table"))
+    val aggregateExpressions = Seq(
+      Alias(UnresolvedFunction(Seq("AVG"), Seq(priceField), isDistinct = false), "avg_price")())
+    val aggregatePlan = Aggregate(Seq(), aggregateExpressions, tableRelation)
+    val expectedPlan = Project(star, aggregatePlan)
+
+    comparePlans(expectedPlan, logPlan, false)
+  }
 }

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanBasicQueriesTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanBasicQueriesTranslatorTestSuite.scala
@@ -395,39 +395,24 @@ class PPLLogicalPlanBasicQueriesTranslatorTestSuite
   }
 
   test("Search multiple tables - with backticks table alias") {
-    val context = new CatalystPlanContext
+    val expectedPlan =
+      planTransformer.visit(
+        plan(
+          pplParser,
+          """
+            | source=table1, table2, table3 as t
+            | | where t.name = 'Molly'
+            |""".stripMargin),
+        new CatalystPlanContext)
     val logPlan =
       planTransformer.visit(
         plan(
           pplParser,
           """
             | source=table1, table2, table3 as `t`
-            | | where t.name = 'Molly'
+            | | where `t`.`name` = 'Molly'
             |""".stripMargin),
-        context)
-
-    val table1 = UnresolvedRelation(Seq("table1"))
-    val table2 = UnresolvedRelation(Seq("table2"))
-    val table3 = UnresolvedRelation(Seq("table3"))
-    val star = UnresolvedStar(None)
-    val plan1 = Project(
-      Seq(star),
-      Filter(
-        EqualTo(UnresolvedAttribute("t.name"), Literal("Molly")),
-        SubqueryAlias("t", table1)))
-    val plan2 = Project(
-      Seq(star),
-      Filter(
-        EqualTo(UnresolvedAttribute("t.name"), Literal("Molly")),
-        SubqueryAlias("t", table2)))
-    val plan3 = Project(
-      Seq(star),
-      Filter(
-        EqualTo(UnresolvedAttribute("t.name"), Literal("Molly")),
-        SubqueryAlias("t", table3)))
-
-    val expectedPlan =
-      Union(Seq(plan1, plan2, plan3), byName = true, allowMissingCol = true)
+        new CatalystPlanContext)
 
     comparePlans(expectedPlan, logPlan, false)
   }

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanJoinTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanJoinTranslatorTestSuite.scala
@@ -847,71 +847,62 @@ class PPLLogicalPlanJoinTranslatorTestSuite
   }
 
   test("test multiple joins with table and subquery backticks alias") {
-    val context = new CatalystPlanContext
-    val logPlan = plan(
+    val originPlan = plan(
       pplParser,
       s"""
          | source = table1 as t1
-         | | JOIN left = `l` right = `r` ON t1.id = t2.id
+         | | JOIN left = l right = r ON t1.id = t2.id
+         |   [
+         |     source = table2 as t2
+         |   ]
+         | | JOIN left = l right = r ON t2.id = t3.id
+         |   [
+         |     source = table3 as t3
+         |   ]
+         | | JOIN left = l right = r ON t3.id = t4.id
+         |   [
+         |     source = table4 as t4
+         |   ]
+         | """.stripMargin)
+    val expectedPlan = planTransformer.visit(originPlan, new CatalystPlanContext)
+    val logPlan = plan(
+      pplParser,
+      s"""
+         | source = table1 as `t1`
+         | | JOIN left = `l` right = `r` ON `t1`.`id` = `t2`.`id`
          |   [
          |     source = table2 as `t2`
          |   ]
-         | | JOIN left = `l` right = `r` ON t2.id = t3.id
+         | | JOIN left = `l` right = `r` ON `t2`.`id` = `t3`.`id`
          |   [
          |     source = table3 as `t3`
          |   ]
-         | | JOIN left = `l` right = `r` ON t3.id = t4.id
+         | | JOIN left = `l` right = `r` ON `t3`.`id` = `t4`.`id`
          |   [
          |     source = table4 as `t4`
          |   ]
          | """.stripMargin)
-    val logicalPlan = planTransformer.visit(logPlan, context)
-    val table1 = UnresolvedRelation(Seq("table1"))
-    val table2 = UnresolvedRelation(Seq("table2"))
-    val table3 = UnresolvedRelation(Seq("table3"))
-    val table4 = UnresolvedRelation(Seq("table4"))
-    val joinPlan1 = Join(
-      SubqueryAlias("l", SubqueryAlias("t1", table1)),
-      SubqueryAlias("r", SubqueryAlias("t2", table2)),
-      Inner,
-      Some(EqualTo(UnresolvedAttribute("t1.id"), UnresolvedAttribute("t2.id"))),
-      JoinHint.NONE)
-    val joinPlan2 = Join(
-      SubqueryAlias("l", joinPlan1),
-      SubqueryAlias("r", SubqueryAlias("t3", table3)),
-      Inner,
-      Some(EqualTo(UnresolvedAttribute("t2.id"), UnresolvedAttribute("t3.id"))),
-      JoinHint.NONE)
-    val joinPlan3 = Join(
-      SubqueryAlias("l", joinPlan2),
-      SubqueryAlias("r", SubqueryAlias("t4", table4)),
-      Inner,
-      Some(EqualTo(UnresolvedAttribute("t3.id"), UnresolvedAttribute("t4.id"))),
-      JoinHint.NONE)
-    val expectedPlan = Project(Seq(UnresolvedStar(None)), joinPlan3)
+    val logicalPlan = planTransformer.visit(logPlan, new CatalystPlanContext)
     comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
   }
 
   test("test complex backticks subquery alias") {
-    val context = new CatalystPlanContext
+    val originPlan = plan(
+      pplParser,
+      s"""
+         | source = $testTable1
+         | | JOIN left = t1 right = t2 ON t1.name = t2.name [ source = $testTable2 as ttt ] as tt
+         | | fields t1.name, t2.name
+         | """.stripMargin)
+    val expectedPlan = planTransformer.visit(originPlan, new CatalystPlanContext)
     val logPlan = plan(
       pplParser,
       s"""
          | source = $testTable1
-         | | JOIN left = `t1` right = `t2` ON t1.name = t2.name [ source = $testTable2 as `ttt` ] as `tt`
-         | | fields t1.name, t2.name
+         | | JOIN left = `t1` right = `t2` ON `t1`.`name` = `t2`.`name` [ source = $testTable2 as `ttt` ] as `tt`
+         | | fields `t1`.`name`, `t2`.`name`
          | """.stripMargin)
-    val logicalPlan = planTransformer.visit(logPlan, context)
-    val table1 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test1"))
-    val table2 = UnresolvedRelation(Seq("spark_catalog", "default", "flint_ppl_test2"))
-    val joinPlan1 = Join(
-      SubqueryAlias("t1", table1),
-      SubqueryAlias("t2", SubqueryAlias("tt", SubqueryAlias("ttt", table2))),
-      Inner,
-      Some(EqualTo(UnresolvedAttribute("t1.name"), UnresolvedAttribute("t2.name"))),
-      JoinHint.NONE)
-    val expectedPlan =
-      Project(Seq(UnresolvedAttribute("t1.name"), UnresolvedAttribute("t2.name")), joinPlan1)
+    val logicalPlan = planTransformer.visit(logPlan, new CatalystPlanContext)
     comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
   }
 }

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanRenameTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanRenameTranslatorTestSuite.scala
@@ -126,20 +126,14 @@ class PPLLogicalPlanRenameTranslatorTestSuite
   }
 
   test("test rename with backticks alias") {
-    val context = new CatalystPlanContext
+    val expectedPlan =
+      planTransformer.visit(
+        plan(pplParser, "source=t | rename a as r_a, b as r_b | fields c"),
+        new CatalystPlanContext)
     val logPlan =
       planTransformer.visit(
         plan(pplParser, "source=t | rename `a` as `r_a`, `b` as `r_b` | fields `c`"),
-        context)
-    val renameProjectList: Seq[NamedExpression] =
-      Seq(
-        UnresolvedStar(None),
-        Alias(UnresolvedAttribute("a"), "r_a")(),
-        Alias(UnresolvedAttribute("b"), "r_b")())
-    val innerProject = Project(renameProjectList, UnresolvedRelation(Seq("t")))
-    val planDropColumn =
-      DataFrameDropColumns(Seq(UnresolvedAttribute("a"), UnresolvedAttribute("b")), innerProject)
-    val expectedPlan = Project(seq(UnresolvedAttribute("c")), planDropColumn)
+        new CatalystPlanContext)
     comparePlans(expectedPlan, logPlan, checkAnalysis = false)
   }
 }

--- a/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanTrendlineCommandTranslatorTestSuite.scala
+++ b/ppl-spark-integration/src/test/scala/org/opensearch/flint/spark/ppl/PPLLogicalPlanTrendlineCommandTranslatorTestSuite.scala
@@ -94,25 +94,14 @@ class PPLLogicalPlanTrendlineCommandTranslatorTestSuite
   }
 
   test("test trendline with sort and backticks alias") {
-    val context = new CatalystPlanContext
+    val expectedPlan =
+      planTransformer.visit(
+        plan(pplParser, "source=relation | trendline sort - age sma(3, age) as age_sma"),
+        new CatalystPlanContext)
     val logPlan =
       planTransformer.visit(
-        plan(pplParser, "source=relation | trendline sort - age sma(3, age) as `age_sma`"),
-        context)
-
-    val table = UnresolvedRelation(Seq("relation"))
-    val ageField = UnresolvedAttribute("age")
-    val sort = Sort(Seq(SortOrder(ageField, Descending)), global = true, table)
-    val countWindow = new WindowExpression(
-      UnresolvedFunction("COUNT", Seq(Literal(1)), isDistinct = false),
-      WindowSpecDefinition(Seq(), Seq(), SpecifiedWindowFrame(RowFrame, Literal(-2), CurrentRow)))
-    val smaWindow = WindowExpression(
-      UnresolvedFunction("AVG", Seq(ageField), isDistinct = false),
-      WindowSpecDefinition(Seq(), Seq(), SpecifiedWindowFrame(RowFrame, Literal(-2), CurrentRow)))
-    val caseWhen = CaseWhen(Seq((LessThan(countWindow, Literal(3)), Literal(null))), smaWindow)
-    val trendlineProjectList = Seq(UnresolvedStar(None), Alias(caseWhen, "age_sma")())
-    val expectedPlan =
-      Project(Seq(UnresolvedStar(None)), Project(trendlineProjectList, sort))
+        plan(pplParser, "source=relation | trendline sort - `age` sma(3, `age`) as `age_sma`"),
+        new CatalystPlanContext)
     comparePlans(logPlan, expectedPlan, checkAnalysis = false)
   }
 


### PR DESCRIPTION
### Description
Fix customer ticket V1653686949, details in #1063 

### Related Issues
Resolves #1063 

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
