### PR TITLE
Support half_float data type in OpenSearch

### DIFF
--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -65,6 +65,7 @@ The following table defines the data type mapping between OpenSearch index field
 | byte                     | ByteType                          |
 | double                   | DoubleType                        |
 | float                    | FloatType                         |
+| half_float               | FloatType                         |
 | date(Timestamp)          | TimestampType                     |
 | date(Date)               | DateType                          |
 | keyword                  | StringType, VarcharType, CharType |

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -91,7 +91,7 @@ object FlintDataType {
       case JString("double") => DoubleType
       case JString("float") => FloatType
       case JString("half_float") =>
-        metadataBuilder.putString(OS_TYPE_KEY, "half_float")
+        metadataBuilder.withHalfFloat()
         FloatType
 
       // Date

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -12,7 +12,7 @@ import org.json4s.jackson.JsonMethods
 import org.json4s.native.Serialization
 
 import org.apache.spark.sql.catalyst.util.DateFormatter
-import org.apache.spark.sql.flint.datatype.FlintMetadataExtensions.{MetadataBuilderExtension, MetadataExtension}
+import org.apache.spark.sql.flint.datatype.FlintMetadataExtensions.{MetadataBuilderExtension, MetadataExtension, OS_TYPE_KEY}
 import org.apache.spark.sql.types._
 
 /**
@@ -90,7 +90,9 @@ object FlintDataType {
       case JString("byte") => ByteType
       case JString("double") => DoubleType
       case JString("float") => FloatType
-      case JString("half_float") => FloatType
+      case JString("half_float") =>
+        metadataBuilder.putString(OS_TYPE_KEY, "half_float")
+        FloatType
 
       // Date
       case JString("date") =>
@@ -184,7 +186,12 @@ object FlintDataType {
       case ShortType => JObject("type" -> JString("short"))
       case ByteType => JObject("type" -> JString("byte"))
       case DoubleType => JObject("type" -> JString("double"))
-      case FloatType => JObject("type" -> JString("float"))
+      case FloatType =>
+        if (metadata.isHalfFloatField) {
+          JObject("type" -> JString("half_float"))
+        } else {
+          JObject("type" -> JString("float"))
+        }
       case DecimalType() => JObject("type" -> JString("double"))
 
       // Date

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -90,6 +90,7 @@ object FlintDataType {
       case JString("byte") => ByteType
       case JString("double") => DoubleType
       case JString("float") => FloatType
+      case JString("half_float") => FloatType
 
       // Date
       case JString("date") =>

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintMetadataExtensions.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintMetadataExtensions.scala
@@ -18,6 +18,7 @@ object FlintMetadataExtensions {
   // OpenSearch field types. https://opensearch.org/docs/latest/field-types/supported-field-types/index/
   val TEXT_TYPE = "text"
   val KEYWORD_TYPE = "keyword"
+  val HALF_FLOAT_TYPE = "half_float"
 
   implicit class MetadataExtension(val metadata: Metadata) {
 
@@ -51,6 +52,9 @@ object FlintMetadataExtensions {
         None
       }
     }
+
+    def isHalfFloatField: Boolean =
+      metadata.contains(OS_TYPE_KEY) && metadata.getString(OS_TYPE_KEY) == HALF_FLOAT_TYPE
   }
 
   implicit class MetadataBuilderExtension(val builder: MetadataBuilder) {
@@ -88,6 +92,17 @@ object FlintMetadataExtensions {
           nestedBuilder.putStringArray(fieldType, entries.keys.toArray)
         }
       builder.putMetadata(FIELDS_NAMES_KEY, nestedBuilder.build())
+      builder
+    }
+
+    /**
+     * Marks the field as a half_float field in OpenSearch metadata.
+     *
+     * @return
+     *   the modified [[MetadataBuilder]] instance for method chaining
+     */
+    def withHalfFloat(): MetadataBuilder = {
+      builder.putString(OS_TYPE_KEY, HALF_FLOAT_TYPE)
       builder
     }
   }

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
@@ -41,6 +41,9 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
                           |    "floatField": {
                           |      "type": "float"
                           |    },
+                          |    "halfFloatField": {
+                          |      "type": "half_float"
+                          |    },
                           |    "textField": {
                           |      "type": "text"
                           |    },
@@ -59,6 +62,11 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
         StructField("byteField", ByteType, true) ::
         StructField("doubleField", DoubleType, true) ::
         StructField("floatField", FloatType, true) ::
+        StructField(
+          "halfFloatField",
+          FloatType,
+          true,
+          new MetadataBuilder().putString("osType", "half_float").build()) ::
         StructField(
           "textField",
           StringType,
@@ -360,5 +368,4 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
     aliasField.metadata.contains("aliasPath") shouldBe true
     aliasField.metadata.getString("aliasPath") shouldEqual "distance"
   }
-
 }

--- a/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
@@ -121,4 +121,19 @@ class OpenSearchTableQueryITSuite
       checkKeywordsExistsInExplain(df, expectedPlanFragment: _*)
     }
   }
+
+  test("Query index with half_float data type") {
+    val indexName = "t0001"
+    val table = s"${catalogName}.default.$indexName"
+    withIndexName(indexName) {
+      indexWithNumericFields(indexName)
+
+      var df = spark.sql(s"""SELECT id, floatField, halfFloatField FROM ${table}""")
+      checkAnswer(df, Seq(Row(1, 1.1f, 1.2f), Row(2, 2.1f, 2.2f)))
+
+      df = spark.sql(s"""SELECT id, floatField, halfFloatField FROM ${table} WHERE halfFloatField < 2.0""")
+      checkPushedInfo(df, "halfFloatField IS NOT NULL, halfFloatField < 2.0")
+      checkAnswer(df, Seq(Row(1, 1.1f, 1.2f)))
+    }
+  }
 }

--- a/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
@@ -131,7 +131,8 @@ class OpenSearchTableQueryITSuite
       var df = spark.sql(s"""SELECT id, floatField, halfFloatField FROM ${table}""")
       checkAnswer(df, Seq(Row(1, 1.1f, 1.2f), Row(2, 2.1f, 2.2f)))
 
-      df = spark.sql(s"""SELECT id, floatField, halfFloatField FROM ${table} WHERE halfFloatField < 2.0""")
+      df = spark.sql(
+        s"""SELECT id, floatField, halfFloatField FROM ${table} WHERE halfFloatField < 2.0""")
       checkPushedInfo(df, "halfFloatField IS NOT NULL, halfFloatField < 2.0")
       checkAnswer(df, Seq(Row(1, 1.1f, 1.2f)))
     }

--- a/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
@@ -181,6 +181,35 @@ trait OpenSearchSuite extends BeforeAndAfterAll {
     index(indexName, oneNodeSetting, mappings, docs)
   }
 
+  def indexWithNumericFields(indexName: String): Unit = {
+    val mappings = """{
+                     |  "properties": {
+                     |    "id": {
+                     |      "type": "integer"
+                     |    },
+                     |    "floatField": {
+                     |      "type": "float"
+                     |    },
+                     |    "halfFloatField": {
+                     |      "type": "half_float"
+                     |    }
+                     |  }
+                     |}""".stripMargin
+    val docs = Seq("""{
+                     |  "id": 1,
+                     |  "floatField": 1.1,
+                     |  "halfFloatField": 1.2
+                     |}""".stripMargin,
+                  """{
+                    |  "id": 2,
+                    |  "floatField": 2.1,
+                    |  "halfFloatField": 2.2
+                    |}""".stripMargin
+    )
+    index(indexName, oneNodeSetting, mappings, docs)
+  }
+
+
   def index(index: String, settings: String, mappings: String, docs: Seq[String]): Unit = {
     openSearchClient.indices.create(
       new CreateIndexRequest(index)

--- a/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
@@ -195,20 +195,19 @@ trait OpenSearchSuite extends BeforeAndAfterAll {
                      |    }
                      |  }
                      |}""".stripMargin
-    val docs = Seq("""{
+    val docs = Seq(
+      """{
                      |  "id": 1,
                      |  "floatField": 1.1,
                      |  "halfFloatField": 1.2
                      |}""".stripMargin,
-                  """{
+      """{
                     |  "id": 2,
                     |  "floatField": 2.1,
                     |  "halfFloatField": 2.2
-                    |}""".stripMargin
-    )
+                    |}""".stripMargin)
     index(indexName, oneNodeSetting, mappings, docs)
   }
-
 
   def index(index: String, settings: String, mappings: String, docs: Seq[String]): Unit = {
     openSearchClient.indices.create(


### PR DESCRIPTION
### Description
- Support half_float data type in OpenSearch
- half_float is mapped to float in Spark

### Related Issues
https://github.com/opensearch-project/opensearch-spark/issues/1048

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
