### PR TITLE
Remove unsupported dedup consecutive paramaters from doc

### DIFF
--- a/docs/ppl-lang/ppl-dedup-command.md
+++ b/docs/ppl-lang/ppl-dedup-command.md
@@ -8,7 +8,6 @@
     - [Example 1: Dedup by one field](#example-1-dedup-by-one-field)
     - [Example 2: Keep 2 duplicates documents](#example-2-keep-2-duplicates-documents)
     - [Example 3: Keep or Ignore the empty field by default](#example-3-keep-or-ignore-the-empty-field-by-default)
-    - [Example 4: Dedup in consecutive document](#example-4-dedup-in-consecutive-document)
 - [Limitation](#limitation)
 
 ### Description
@@ -18,12 +17,11 @@ Using `dedup` command to remove identical document defined by field from the sea
 ### Syntax
 
 ```sql
-dedup [int] <field-list> [keepempty=<bool>] [consecutive=<bool>]
+dedup [int] <field-list> [keepempty=<bool>]
 ```
 
 * int: optional. The ``dedup`` command retains multiple events for each combination when you specify <int>. The number for <int> must be greater than 0. If you do not specify a number, only the first occurring event is kept. All other duplicates are removed from the results. **Default:** 1
 * keepempty: optional. if true, keep the document if the any field in the field-list has NULL value or field is MISSING. **Default:** false.
-* consecutive: optional. If set to true, removes only events with duplicate combinations of values that are consecutive. **Default:** false.
 * field-list: mandatory. The comma-delimited field list. At least one field is required.
 
 
@@ -91,23 +89,6 @@ PPL query:
     +------------------+-----------------------+
 
 
-### Example 4: Dedup in consecutive document
-
-The example show dedup the consecutive document.
-
-PPL query:
-
-    os> source=accounts | dedup gender consecutive=true | fields account_number, gender;
-    fetched rows / total rows = 3/3
-    +------------------+----------+
-    | account_number   | gender   |
-    |------------------+----------|
-    | 1                | M        |
-    | 13               | F        |
-    | 18               | M        |
-    +------------------+----------+
-
-
 ### Additional Examples
 
 - `source = table | dedup a | fields a,b,c`
@@ -122,7 +103,6 @@ PPL query:
 - `source = table | dedup 2 a,b | fields a,b,c`
 - `source = table | dedup 2 a keepempty=true | fields a,b,c`
 - `source = table | dedup 2 a,b keepempty=true | fields a,b,c`
-- `source = table | dedup 1 a consecutive=true| fields a,b,c` (Consecutive deduplication is unsupported)
 
 ### Limitation:
 


### PR DESCRIPTION
### Description
Remove [unsupported dedup consecutive paramaters](https://github.com/opensearch-project/opensearch-spark/blob/main/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLDedupeITSuite.scala#L176) from doc. 

### Related Issues
_List any issues this PR will resolve, e.g. Resolves [...]._

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
