### PR TITLE
Add default subquery aliases in join condition for lookup command

### DIFF
--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
@@ -65,7 +65,9 @@ class FlintSparkPPLLookupITSuite
 
     val lookupProject =
       Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
-    val joinCondition = EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uid"), UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
+    val joinCondition = EqualTo(
+      UnresolvedAttribute("__auto_generated_subquery_name_l.uid"),
+      UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
     val projectAfterJoin = Project(
       Seq(
@@ -98,7 +100,9 @@ class FlintSparkPPLLookupITSuite
 
     val lookupProject =
       Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
-    val joinCondition = EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uid"), UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
+    val joinCondition = EqualTo(
+      UnresolvedAttribute("__auto_generated_subquery_name_l.uid"),
+      UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
     val coalesceExpr =
       Coalesce(
@@ -135,7 +139,9 @@ class FlintSparkPPLLookupITSuite
 
     val lookupProject =
       Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
-    val joinCondition = EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uid"), UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
+    val joinCondition = EqualTo(
+      UnresolvedAttribute("__auto_generated_subquery_name_l.uid"),
+      UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
     val projectAfterJoin = Project(
       Seq(
@@ -167,7 +173,9 @@ class FlintSparkPPLLookupITSuite
 
     val lookupProject =
       Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
-    val joinCondition = EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uid"), UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
+    val joinCondition = EqualTo(
+      UnresolvedAttribute("__auto_generated_subquery_name_l.uid"),
+      UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
     val coalesceExpr =
       Coalesce(
@@ -211,7 +219,9 @@ class FlintSparkPPLLookupITSuite
         lookupAlias)
     val joinCondition =
       And(
-        EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uID"), UnresolvedAttribute("__auto_generated_subquery_name_s.id")),
+        EqualTo(
+          UnresolvedAttribute("__auto_generated_subquery_name_l.uID"),
+          UnresolvedAttribute("__auto_generated_subquery_name_s.id")),
         EqualTo(
           UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
           UnresolvedAttribute("__auto_generated_subquery_name_s.name")))
@@ -256,7 +266,9 @@ class FlintSparkPPLLookupITSuite
         lookupAlias)
     val joinCondition =
       And(
-        EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uid"), UnresolvedAttribute("__auto_generated_subquery_name_s.ID")),
+        EqualTo(
+          UnresolvedAttribute("__auto_generated_subquery_name_l.uid"),
+          UnresolvedAttribute("__auto_generated_subquery_name_s.ID")),
         EqualTo(
           UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
           UnresolvedAttribute("__auto_generated_subquery_name_s.name")))
@@ -561,10 +573,7 @@ class FlintSparkPPLLookupITSuite
            | """.stripMargin)
     val frame =
       sql("source = s | LOOKUP l id as uid REPLACE name")
-    val expectedResults: Array[Row] = Array(
-      Row(4, "x"),
-      Row(5, "xx"),
-      Row(6, null))
+    val expectedResults: Array[Row] = Array(Row(4, "x"), Row(5, "xx"), Row(6, null))
     assertSameRows(expectedResults, frame)
   }
 }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
@@ -23,11 +23,14 @@ class FlintSparkPPLLookupITSuite
   /** Test table and index name */
   private val sourceTable = "spark_catalog.default.flint_ppl_test1"
   private val lookupTable = "spark_catalog.default.flint_ppl_test2"
+  private val sourceTable2 = "spark_catalog.default.flint_ppl_test3"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
     createPeopleTable(sourceTable)
     createWorkInformationTable(lookupTable)
+    createPeopleTable(sourceTable2)
+
   }
 
   protected override def afterEach(): Unit = {
@@ -62,7 +65,7 @@ class FlintSparkPPLLookupITSuite
 
     val lookupProject =
       Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
-    val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
+    val joinCondition = EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uid"), UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
     val projectAfterJoin = Project(
       Seq(
@@ -95,7 +98,7 @@ class FlintSparkPPLLookupITSuite
 
     val lookupProject =
       Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
-    val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
+    val joinCondition = EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uid"), UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
     val coalesceExpr =
       Coalesce(
@@ -132,7 +135,7 @@ class FlintSparkPPLLookupITSuite
 
     val lookupProject =
       Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
-    val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
+    val joinCondition = EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uid"), UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
     val projectAfterJoin = Project(
       Seq(
@@ -164,7 +167,7 @@ class FlintSparkPPLLookupITSuite
 
     val lookupProject =
       Project(Seq(UnresolvedAttribute("department"), UnresolvedAttribute("uid")), lookupAlias)
-    val joinCondition = EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("id"))
+    val joinCondition = EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uid"), UnresolvedAttribute("__auto_generated_subquery_name_s.id"))
     val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
     val coalesceExpr =
       Coalesce(
@@ -208,7 +211,7 @@ class FlintSparkPPLLookupITSuite
         lookupAlias)
     val joinCondition =
       And(
-        EqualTo(UnresolvedAttribute("uID"), UnresolvedAttribute("id")),
+        EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uID"), UnresolvedAttribute("__auto_generated_subquery_name_s.id")),
         EqualTo(
           UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
           UnresolvedAttribute("__auto_generated_subquery_name_s.name")))
@@ -253,7 +256,7 @@ class FlintSparkPPLLookupITSuite
         lookupAlias)
     val joinCondition =
       And(
-        EqualTo(UnresolvedAttribute("uid"), UnresolvedAttribute("ID")),
+        EqualTo(UnresolvedAttribute("__auto_generated_subquery_name_l.uid"), UnresolvedAttribute("__auto_generated_subquery_name_s.ID")),
         EqualTo(
           UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
           UnresolvedAttribute("__auto_generated_subquery_name_s.name")))
@@ -518,5 +521,50 @@ class FlintSparkPPLLookupITSuite
     assert(
       ex.getMessage.contains(
         "A column or function parameter with name `new_col` cannot be resolved"))
+  }
+
+  test("test LOOKUP lookupTable name as id shouldn't throw exception") {
+    sql(s"""
+           | DROP TABLE IF EXISTS s
+           | """.stripMargin)
+    sql(s"""
+           | DROP TABLE IF EXISTS l
+           | """.stripMargin)
+    sql(s"""
+           | CREATE TABLE s
+           | (
+           |   id INT,
+           |   uid INT,
+           |   name STRING
+           | )
+           | USING $tableType $tableOptions
+           |""".stripMargin)
+    sql(s"""
+           | INSERT INTO s
+           | VALUES (1, 4, 'b'),
+           |        (2, 5, 'bb'),
+           |        (3, 6, 'ccc')
+           | """.stripMargin)
+
+    sql(s"""
+           | CREATE TABLE l
+           | (
+           |   id INT,
+           |   name STRING
+           | )
+           | USING $tableType $tableOptions
+           |""".stripMargin)
+    sql(s"""
+           | INSERT INTO l
+           | VALUES (4, 'x'),
+           |        (5, 'xx')
+           | """.stripMargin)
+    val frame =
+      sql("source = s | LOOKUP l id as uid REPLACE name")
+    val expectedResults: Array[Row] = Array(
+      Row(4, "x"),
+      Row(5, "xx"),
+      Row(6, null))
+    assertSameRows(expectedResults, frame)
   }
 }

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/LookupTransformer.java
@@ -62,15 +62,10 @@ public interface LookupTransformer {
         for (Map.Entry<Field, Field> entry : node.getLookupMappingMap().entrySet()) {
             Expression lookupNamedExpression;
             Expression sourceNamedExpression;
-            if (entry.getKey().getField() == entry.getValue().getField()) {
-                Field lookupWithAlias = buildFieldWithLookupSubqueryAlias(node, entry.getKey());
-                Field sourceWithAlias = buildFieldWithSourceSubqueryAlias(node, entry.getValue());
-                lookupNamedExpression = expressionAnalyzer.visitField(lookupWithAlias, context);
-                sourceNamedExpression = expressionAnalyzer.visitField(sourceWithAlias, context);
-            } else {
-                lookupNamedExpression = expressionAnalyzer.visitField(entry.getKey(), context);
-                sourceNamedExpression = expressionAnalyzer.visitField(entry.getValue(), context);
-            }
+            Field lookupWithAlias = buildFieldWithLookupSubqueryAlias(node, entry.getKey());
+            Field sourceWithAlias = buildFieldWithSourceSubqueryAlias(node, entry.getValue());
+            lookupNamedExpression = expressionAnalyzer.visitField(lookupWithAlias, context);
+            sourceNamedExpression = expressionAnalyzer.visitField(sourceWithAlias, context);
 
             Expression equalTo = EqualTo$.MODULE$.apply(lookupNamedExpression, sourceNamedExpression);
             equiConditions.add(equalTo);


### PR DESCRIPTION
### Description
Add default subquery aliases in join condition for lookup command

### Related Issues
Resolves #1078 

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [ ] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
