### PR TITLE
Multiple tables as join right without subsearch is not allowed

### DIFF
--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/CatalystQueryPlanVisitor.java
@@ -354,8 +354,9 @@ public class CatalystQueryPlanVisitor extends AbstractNodeVisitor<LogicalPlan, C
             Optional<Expression> joinCondition = node.getJoinCondition()
                 .map(c -> expressionAnalyzer.analyzeJoinCondition(c, context));
             context.resetNamedParseExpressions();
+            LogicalPlan join = join(left, right, node.getJoinType(), joinCondition, node.getJoinHint()).clone();
             context.retainAllPlans(p -> p);
-            return join(left, right, node.getJoinType(), joinCondition, node.getJoinHint());
+            return join;
         });
     }
 


### PR DESCRIPTION
### Description
Multiple tables as join right without subsearch is not allowed:
- `JOIN on id = uid table1,table2` is not allowed
- `JOIN on id = uid table1,table2 as t2` is not allowed
- `JOIN on id = uid [ source = table1,table2 ]` is allowed
- `JOIN on id = uid [ source = table1,table2 ] as t2` is allowed

### Related Issues
Resolves #1073 

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [x] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
