### PR TITLE
Support OpenSearch ip field type (UDT)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -232,6 +232,7 @@ lazy val flintSparkIntegration = (project in file("flint-spark-integration"))
       "org.scalatestplus" %% "mockito-4-6" % "3.2.15.0" % "test",
       "org.mockito" % "mockito-inline" % "4.6.0" % "test",
       "com.stephenn" %% "scalatest-json-jsonassert" % "0.2.5" % "test",
+      "com.github.seancfoley" % "ipaddress" % "5.5.1",
       "com.github.sbt" % "junit-interface" % "0.13.3" % "test"),
     libraryDependencies ++= deps(sparkVersion),
     // ANTLR settings

--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -87,7 +87,7 @@ The following table defines the data type mapping between OpenSearch index field
   type *double* only maps to DoubleType.
 * OpenSearch alias fields allow alternative names for existing fields in the schema without duplicating data. They inherit the data type and nullability of the referenced field and resolve dynamically to the primary field in queries.
 * OpenSearch multi-fields on text field is supported. These multi-fields are stored as part of the field's metadata and cannot be directly selected. Instead, they are automatically utilized during the DSL query translation process.
-* IPAddress type cannot be directly compared with string type literal/field (e.g. '192.168.10.10'). Use `ip_equal` function like `ip_equal(ip, '192.168.0.10')`
+* IPAddress type cannot be directly compared with string type literal/field (e.g. '192.168.10.10'). Use `cidrmatch` function like `cidrmatch(ip, '192.168.0.10/32')`
 
 ## Limitation
 ### catalog operation

--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -87,6 +87,7 @@ The following table defines the data type mapping between OpenSearch index field
   type *double* only maps to DoubleType.
 * OpenSearch alias fields allow alternative names for existing fields in the schema without duplicating data. They inherit the data type and nullability of the referenced field and resolve dynamically to the primary field in queries.
 * OpenSearch multi-fields on text field is supported. These multi-fields are stored as part of the field's metadata and cannot be directly selected. Instead, they are automatically utilized during the DSL query translation process.
+* IPAddress type cannot be directly compared with string type literal/field (e.g. '192.168.10.10'). Use `ip_equal` function like `ip_equal(ip, '192.168.0.10')`
 
 ## Limitation
 ### catalog operation

--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -72,6 +72,7 @@ The following table defines the data type mapping between OpenSearch index field
 | text                     | StringType(meta(osType)=text)     |
 | object                   | StructType                        |
 | alias                    | Inherits referenced field type    |
+| ip                       | IPAddress(UDT)                    |
 
 * OpenSearch data type date is mapped to Spark data type based on the format:
     * Map to DateType if format = strict_date, (we also support format = date, may change in future)

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -10,6 +10,7 @@ import org.json4s.JsonAST.{JNothing, JObject, JString}
 import org.json4s.JsonAST.JBool.True
 import org.json4s.jackson.JsonMethods
 import org.json4s.native.Serialization
+import org.opensearch.flint.spark.udt.IPAddressUDT
 
 import org.apache.spark.sql.catalyst.util.DateFormatter
 import org.apache.spark.sql.flint.datatype.FlintMetadataExtensions.{MetadataBuilderExtension, MetadataExtension, OS_TYPE_KEY}
@@ -118,6 +119,9 @@ object FlintDataType {
       // binary types
       case JString("binary") => BinaryType
 
+      // ip type
+      case JString("ip") => IPAddressUDT
+
       // not supported
       case unknown => throw new IllegalStateException(s"unsupported data type: $unknown")
     }
@@ -216,6 +220,10 @@ object FlintDataType {
           "type" -> JString("binary"),
           "doc_values" -> True // enable doc value required by painless script filtering
         )
+
+      // ip
+      case IPAddressUDT =>
+        JObject("type" -> JString("ip"))
 
       case unknown => throw new IllegalStateException(s"unsupported data type: ${unknown.sql}")
     }

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/json/FlintJacksonParser.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/json/FlintJacksonParser.scala
@@ -356,7 +356,7 @@ class FlintJacksonParser(
 
     case ip: IPAddressUDT =>
       (parser: JsonParser) =>
-        parseJsonToken[InternalRow](parser, dataType) { case VALUE_STRING =>
+        parseJsonToken[UTF8String](parser, dataType) { case VALUE_STRING =>
           IPAddressUDT.serialize(IPAddress(parser.getText))
         }
 

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/json/FlintJacksonParser.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/json/FlintJacksonParser.scala
@@ -12,6 +12,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.core._
+import org.opensearch.flint.spark.udt.{IPAddress, IPAddressUDT}
 
 import org.apache.spark.SparkUpgradeException
 import org.apache.spark.internal.Logging
@@ -351,6 +352,12 @@ class FlintJacksonParser(
         parseJsonToken[java.lang.Long](parser, dataType) { case VALUE_STRING =>
           val expr = Cast(Literal(parser.getText), dt)
           java.lang.Long.valueOf(expr.eval(EmptyRow).asInstanceOf[Long])
+        }
+
+    case ip: IPAddressUDT =>
+      (parser: JsonParser) =>
+        parseJsonToken[InternalRow](parser, dataType) { case VALUE_STRING =>
+          IPAddressUDT.serialize(IPAddress(parser.getText))
         }
 
     case st: StructType =>

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkExtensions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkExtensions.scala
@@ -7,8 +7,10 @@ package org.opensearch.flint.spark
 
 import org.opensearch.flint.spark.function.TumbleFunction
 import org.opensearch.flint.spark.sql.FlintSparkSqlParser
+import org.opensearch.flint.spark.udt.{IPAddress, IPAddressUDT}
 
 import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.types.UDTRegistration
 
 /**
  * Flint Spark extension entrypoint.
@@ -25,5 +27,8 @@ class FlintSparkExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule { spark =>
       new FlintSparkOptimizer(spark)
     }
+
+    // Register UDTs
+    UDTRegistration.register(classOf[IPAddress].getName, classOf[IPAddressUDT].getName)
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPAddress.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPAddress.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.udt
+
+import java.net.{InetAddress, UnknownHostException}
+
+import org.apache.spark.sql.types.SQLUserDefinedType
+
+/**
+ * A wrapper for IP address.
+ * @param address
+ *   IP address which could be IPv4 or IPv6.
+ */
+@SQLUserDefinedType(udt = classOf[IPAddressUDT])
+case class IPAddress(address: String) extends Ordered[IPAddress] {
+
+  def normalized: String = {
+    try {
+      InetAddress.getByName(address).getHostAddress
+    } catch {
+      case _: UnknownHostException => address // fallback
+    }
+  }
+
+  override def compare(that: IPAddress): Int = {
+    this.normalized.compare(that.normalized)
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case other: IPAddress => this.normalized == other.normalized
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = normalized.hashCode
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPAddressUDT.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPAddressUDT.scala
@@ -5,29 +5,22 @@
 
 package org.opensearch.flint.spark.udt
 
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-// Implement IpAddressUDT with StructType as sqlType
 class IPAddressUDT extends UserDefinedType[IPAddress] {
 
-  // Use StructType to avoid implicit equality check with String type
-  override def sqlType: DataType = StructType(
-    Seq(StructField("address", StringType, nullable = false)))
+  override def sqlType: DataType = StringType
 
-  override def serialize(obj: IPAddress): InternalRow = {
-    val row = new GenericInternalRow(Array[Any](UTF8String.fromString(obj.address)))
-    row
-  }
+  override def serialize(obj: IPAddress): UTF8String = UTF8String.fromString(obj.address)
 
   override def deserialize(datum: Any): IPAddress = datum match {
-    case row: InternalRow => IPAddress(row.getString(0))
+    case row: UTF8String => IPAddress(row.toString)
   }
+
   override def userClass: Class[IPAddress] = classOf[IPAddress]
 
-  override def typeName: String = "ipaddress"
+  override def typeName: String = "ip"
 
   override def equals(o: Any): Boolean = {
     o match {

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPAddressUDT.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPAddressUDT.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.udt
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+
+// Implement IpAddressUDT with StructType as sqlType
+class IPAddressUDT extends UserDefinedType[IPAddress] {
+
+  // Use StructType to avoid implicit equality check with String type
+  override def sqlType: DataType = StructType(
+    Seq(StructField("address", StringType, nullable = false)))
+
+  override def serialize(obj: IPAddress): InternalRow = {
+    val row = new GenericInternalRow(Array[Any](UTF8String.fromString(obj.address)))
+    row
+  }
+
+  override def deserialize(datum: Any): IPAddress = datum match {
+    case row: InternalRow => IPAddress(row.getString(0))
+  }
+  override def userClass: Class[IPAddress] = classOf[IPAddress]
+
+  override def typeName: String = "ipaddress"
+
+  override def equals(o: Any): Boolean = {
+    o match {
+      case v: IPAddressUDT => true
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = getClass.getName.hashCode()
+}
+
+case object IPAddressUDT extends IPAddressUDT

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPFunctions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPFunctions.scala
@@ -18,15 +18,11 @@ object IPFunctions {
   val ipToString = (ip: IPAddress) => { ip.address }
 
   // Match IPAddress with String. This will match different notation.
-  val ipStringMatch = (ip1: IPAddress, ip2: String) => { ip1.compare(IPAddress(ip2)) == 0 }
-
-  // Match String with IPAddress. This will match different notation.
-  val stringIpMatch = (ip1: String, ip2: IPAddress) => { IPAddress(ip1).compare(ip2) == 0 }
+  val ipEqual = (ip1: IPAddress, ip2: String) => { ip1.compare(IPAddress(ip2)) == 0 }
 
   def registerFunctions(spark: SparkSession): Unit = {
     spark.udf.register("string_to_ip", stringToIp)
     spark.udf.register("ip_to_string", ipToString)
-    spark.udf.register("ip_string_match", ipStringMatch)
-    spark.udf.register("string_ip_match", stringIpMatch)
+    spark.udf.register("ip_equal", ipEqual)
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPFunctions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPFunctions.scala
@@ -22,7 +22,7 @@ object IPFunctions {
     .toParams;
 
   /**
-   * TODO: come up with common implementation for both SQL and PPL {@ref SerializableUdf}
+   * TODO: come up with common implementation for both SQL and PPL {@link SerializableUdf}
    */
   val cidrMatch = (ipAddress: IPAddress, cidrBlock: String) => {
     val parsedIpAddress = new IPAddressString(ipAddress.address, valOptions)

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPFunctions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/IPFunctions.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.udt
+
+import org.apache.spark.sql.SparkSession
+
+/**
+ * UDFs related to IPAddress UDT
+ */
+object IPFunctions {
+  // Convert String to IPAddress
+  val stringToIp = (ip: String) => { IPAddress(ip) }
+
+  // Convert IPAddress to String
+  val ipToString = (ip: IPAddress) => { ip.address }
+
+  // Match IPAddress with String. This will match different notation.
+  val ipStringMatch = (ip1: IPAddress, ip2: String) => { ip1.compare(IPAddress(ip2)) == 0 }
+
+  // Match String with IPAddress. This will match different notation.
+  val stringIpMatch = (ip1: String, ip2: IPAddress) => { IPAddress(ip1).compare(ip2) == 0 }
+
+  def registerFunctions(spark: SparkSession): Unit = {
+    spark.udf.register("string_to_ip", stringToIp)
+    spark.udf.register("ip_to_string", ipToString)
+    spark.udf.register("ip_string_match", ipStringMatch)
+    spark.udf.register("string_ip_match", stringIpMatch)
+  }
+}

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/udt/IPAddressTest.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/udt/IPAddressTest.scala
@@ -32,7 +32,7 @@ class IPAddressTest extends SparkFunSuite {
     assert(ipv6_1.compare(ipv6_2) < 0)
   }
 
-  test("Different IPv6 addresses comparison") {
+  test("Same IPv6 addresses comparison") {
     val ipv6_1 = IPAddress("::1")
     val ipv6_2 = IPAddress("::1")
     assert(ipv6_1 == ipv6_2)

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/udt/IPAddressTest.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/udt/IPAddressTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.udt
+
+import org.apache.spark.SparkFunSuite
+
+class IPAddressTest extends SparkFunSuite {
+  test("IPAddress normalization") {
+    val ip1 = IPAddress("192.168.0.1")
+    val ip2 = IPAddress("192.168.0.1")
+    assert(ip1 == ip2)
+  }
+
+  test("IPAddress comparison") {
+    val ip1 = IPAddress("192.168.0.1")
+    val ip2 = IPAddress("192.168.0.2")
+    assert(ip1.compare(ip2) < 0)
+  }
+
+  test("IPv4 and IPv6 comparison") {
+    val ipv4 = IPAddress("192.168.0.1")
+    val ipv6 = IPAddress("::ffff:c0a8:1")
+    assert(ipv4 == ipv6)
+  }
+
+  test("Different IPv6 addresses comparison") {
+    val ipv6_1 = IPAddress("::1")
+    val ipv6_2 = IPAddress("::2")
+    assert(ipv6_1.compare(ipv6_2) < 0)
+  }
+
+  test("Different IPv6 addresses comparison") {
+    val ipv6_1 = IPAddress("::1")
+    val ipv6_2 = IPAddress("::1")
+    assert(ipv6_1 == ipv6_2)
+  }
+}

--- a/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
@@ -165,11 +165,7 @@ class OpenSearchTableQueryITSuite
         Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
 
       testQuery(
-        s"SELECT client, server FROM $tableName WHERE ip_string_match(client, '192.168.0.10')",
-        Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
-
-      testQuery(
-        s"SELECT client, server FROM $tableName WHERE string_ip_match('192.168.0.10', client)",
+        s"SELECT client, server FROM $tableName WHERE ip_equal(client, '192.168.0.10')",
         Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
 
       // Equality check is done by string equality (limitation of Spark UDT), and it won't match
@@ -177,9 +173,9 @@ class OpenSearchTableQueryITSuite
         s"SELECT client, server FROM $tableName WHERE client = string_to_ip('::ffff:192.168.0.10')",
         Seq())
 
-      // Need to use ip_string_match/string_ip_match to match different notation
+      // Need to use ip_equal to match different notation
       testQuery(
-        s"SELECT client, server FROM $tableName WHERE ip_string_match(client, '::ffff:192.168.0.10')",
+        s"SELECT client, server FROM $tableName WHERE ip_equal(client, '::ffff:192.168.0.10')",
         Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
     }
   }

--- a/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchTableQueryITSuite.scala
@@ -150,42 +150,36 @@ class OpenSearchTableQueryITSuite
     withIndexName(index1) {
       indexWithIp(index1)
 
-      testQuery(
-        s"SELECT client, server FROM $tableName",
+      var df: DataFrame = null
+
+      df = spark.sql(s"SELECT client, server FROM $tableName")
+      checkAnswer(
+        df,
         Seq(
           Row(IPAddress(clientIp(0)), IPAddress(serverIp)),
           Row(IPAddress(clientIp(1)), IPAddress(serverIp))))
 
-      testQuery(
-        s"SELECT client, server FROM $tableName WHERE client = string_to_ip('192.168.0.10')",
-        Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
+      df = spark.sql(
+        s"SELECT client, server FROM $tableName WHERE client = string_to_ip('192.168.0.10')")
+      checkAnswer(df, Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
 
-      testQuery(
-        s"SELECT client, server FROM $tableName WHERE ip_to_string(client) = '192.168.0.10'",
-        Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
+      df = spark.sql(
+        s"SELECT client, server FROM $tableName WHERE ip_to_string(client) = '192.168.0.10'")
+      checkAnswer(df, Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
 
-      testQuery(
-        s"SELECT client, server FROM $tableName WHERE ip_equal(client, '192.168.0.10')",
-        Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
+      df =
+        spark.sql(s"SELECT client, server FROM $tableName WHERE ip_equal(client, '192.168.0.10')")
+      checkAnswer(df, Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
 
       // Equality check is done by string equality (limitation of Spark UDT), and it won't match
-      testQuery(
-        s"SELECT client, server FROM $tableName WHERE client = string_to_ip('::ffff:192.168.0.10')",
-        Seq())
+      df = spark.sql(
+        s"SELECT client, server FROM $tableName WHERE client = string_to_ip('::ffff:192.168.0.10')")
+      checkAnswer(df, Seq())
 
       // Need to use ip_equal to match different notation
-      testQuery(
-        s"SELECT client, server FROM $tableName WHERE ip_equal(client, '::ffff:192.168.0.10')",
-        Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
+      df = spark.sql(
+        s"SELECT client, server FROM $tableName WHERE ip_equal(client, '::ffff:192.168.0.10')")
+      checkAnswer(df, Seq(Row(IPAddress(clientIp(0)), IPAddress(serverIp))))
     }
-  }
-
-  def testQuery(query: String, expected: Row): Unit = testQuery(query, Seq(expected))
-
-  def testQuery(query: String, expected: Seq[Row]): Unit = {
-    spark.sql(query).explain(true)
-    val df = spark.sql(query)
-    df.printSchema
-    checkAnswer(df, expected)
   }
 }

--- a/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
@@ -222,13 +222,17 @@ trait OpenSearchSuite extends BeforeAndAfterAll {
                      |}""".stripMargin
     val docs = Seq(
       """{
-                     |  "client": "192.168.0.10",
-                     |  "server": "100.10.12.123"
-                     |}""".stripMargin,
+                      |  "client": "192.168.0.10",
+                      |  "server": "100.10.12.123"
+                      |}""".stripMargin,
       """{
-                    |  "client": "192.168.0.11",
-                    |  "server": "100.10.12.123"
-                    |}""".stripMargin)
+                      |  "client": "192.168.0.11",
+                      |  "server": "100.10.12.123"
+                      |}""".stripMargin,
+      """{
+                      |  "client": "::ffff:192.168.0.10",
+                      |  "server": "::ffff:100.10.12.123"
+                      |}""".stripMargin)
     index(indexName, oneNodeSetting, mappings, docs)
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
@@ -209,6 +209,29 @@ trait OpenSearchSuite extends BeforeAndAfterAll {
     index(indexName, oneNodeSetting, mappings, docs)
   }
 
+  def indexWithIp(indexName: String): Unit = {
+    val mappings = """{
+                     |  "properties": {
+                     |    "client": {
+                     |      "type": "ip"
+                     |    },
+                     |    "server": {
+                     |      "type": "ip"
+                     |    }
+                     |  }
+                     |}""".stripMargin
+    val docs = Seq(
+      """{
+                     |  "client": "192.168.0.10",
+                     |  "server": "100.10.12.123"
+                     |}""".stripMargin,
+      """{
+                    |  "client": "192.168.0.11",
+                    |  "server": "100.10.12.123"
+                    |}""".stripMargin)
+    index(indexName, oneNodeSetting, mappings, docs)
+  }
+
   def index(index: String, settings: String, mappings: String, docs: Seq[String]): Unit = {
     openSearchClient.indices.create(
       new CreateIndexRequest(index)


### PR DESCRIPTION
### Description
- Support OpenSearch ip field type
- This PR implements ip field to be stored as UDT.
- It is using UDT to prioritize the type compatibility with OpenSearch.
- Pushdown logic will be implemented separately.
- Original PR (using string type): https://github.com/opensearch-project/opensearch-spark/pull/1044

### Related Issues
https://github.com/opensearch-project/opensearch-spark/issues/1034

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [x] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
