### PR TITLE
tweak: Reduce status retry logging

### DIFF
--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/HttpStatusCodeResultPredicate.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/HttpStatusCodeResultPredicate.java
@@ -34,7 +34,7 @@ public class HttpStatusCodeResultPredicate<T> implements CheckedPredicate<T> {
   public boolean test(T result) throws Throwable {
     int statusCode = ((HttpResponse) result).getStatusLine().getStatusCode();
     boolean isRetryable = retryableStatusCodes.contains(statusCode);
-    LOG.info(statusCode + (isRetryable ? " is " : " is not ") + "retryable");
+    LOG.info("HTTP " + statusCode + (isRetryable ? " is " : " is not ") + "retryable");
     return isRetryable;
   }
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/HttpStatusCodeResultPredicate.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/HttpStatusCodeResultPredicate.java
@@ -33,10 +33,8 @@ public class HttpStatusCodeResultPredicate<T> implements CheckedPredicate<T> {
   @Override
   public boolean test(T result) throws Throwable {
     int statusCode = ((HttpResponse) result).getStatusLine().getStatusCode();
-    LOG.info("Checking if status code is retryable: " + statusCode);
-
     boolean isRetryable = retryableStatusCodes.contains(statusCode);
-    LOG.info("Status code " + statusCode + " check result: " + isRetryable);
+    LOG.info(statusCode + (isRetryable ? " is " : " is not ") + "retryable");
     return isRetryable;
   }
 }


### PR DESCRIPTION
### Description
I noticed a lot of log lines in the EMR logs are repeating things like

```
25/04/09 22:03:26 INFO HttpStatusCodeResultPredicate: Checking if status code is retryable: 200
25/04/09 22:03:26 INFO HttpStatusCodeResultPredicate: Status code 200 check result: false
25/04/09 22:03:27 INFO HttpStatusCodeResultPredicate: Checking if status code is retryable: 200
25/04/09 22:03:27 INFO HttpStatusCodeResultPredicate: Status code 200 check result: false
```

Duplicates of these lines make up ~17% of the log.

This PR cuts that number in half. The lines now look like:

```
25/04/09 22:25:09 INFO HttpStatusCodeResultPredicate: 200 is not retryable
25/04/09 22:25:10 INFO HttpStatusCodeResultPredicate: 200 is not retryable
```

We should log 2xx statuses as `debug` instead of `info`, but I'm erring to the side of preserving the current behavior.

### Related Issues
N/A

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [X] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
