### PR TITLE
Support QUARTER interval in date_add/date_sub

### DIFF
--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBuiltInDateTimeFunctionITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLBuiltInDateTimeFunctionITSuite.scala
@@ -247,6 +247,12 @@ class FlintSparkPPLBuiltInDateTimeFunctionITSuite
                         | """.stripMargin)
     assertSameRows(Seq(Row(Date.valueOf("2022-08-26"))), frame4)
 
+    val frame5 = sql(s"""
+                        | source = $testPartitionedStateCountryTable | eval `'2020-08-26' + 2q` = DATE_ADD(DATE('2020-08-26'), INTERVAL 2 QUARTER)
+                        | | fields `'2020-08-26' + 2q` | head 1
+                        | """.stripMargin)
+    assertSameRows(Seq(Row(Date.valueOf("2021-02-26"))), frame5)
+
     val ex = intercept[AnalysisException](sql(s"""
                                                  | source = $testPartitionedStateCountryTable | eval `'2020-08-26 01:01:01' + 2h` = DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), INTERVAL 2 HOUR)
                                                  | | fields `'2020-08-26 01:01:01' + 2h` | head 1
@@ -278,6 +284,12 @@ class FlintSparkPPLBuiltInDateTimeFunctionITSuite
                         | | fields `'2020-08-26' - 2y` | head 1
                         | """.stripMargin)
     assertSameRows(Seq(Row(Date.valueOf("2018-08-26"))), frame4)
+
+    val frame5 = sql(s"""
+                        | source = $testPartitionedStateCountryTable | eval `'2020-08-26' - 2q` = DATE_SUB(DATE('2020-08-26'), INTERVAL 2 QUARTER)
+                        | | fields `'2020-08-26' - 2q` | head 1
+                        | """.stripMargin)
+    assertSameRows(Seq(Row(Date.valueOf("2020-02-26"))), frame5)
 
     val ex = intercept[AnalysisException](sql(s"""
                                                  | source = $testPartitionedStateCountryTable | eval `'2020-08-26 01:01:01' - 2h` = DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), INTERVAL 2 HOUR)

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/BuiltinFunctionTransformer.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/utils/BuiltinFunctionTransformer.java
@@ -12,10 +12,14 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction$;
 import org.apache.spark.sql.catalyst.expressions.CurrentTimeZone$;
 import org.apache.spark.sql.catalyst.expressions.CurrentTimestamp$;
 import org.apache.spark.sql.catalyst.expressions.DateAddInterval$;
+import org.apache.spark.sql.catalyst.expressions.Divide;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.GreaterThanOrEqual$;
 import org.apache.spark.sql.catalyst.expressions.LessThanOrEqual$;
+import org.apache.spark.sql.catalyst.expressions.Literal;
 import org.apache.spark.sql.catalyst.expressions.Literal$;
+import org.apache.spark.sql.catalyst.expressions.Multiply;
+import org.apache.spark.sql.catalyst.expressions.Multiply$;
 import org.apache.spark.sql.catalyst.expressions.TimestampAdd$;
 import org.apache.spark.sql.catalyst.expressions.TimestampDiff$;
 import org.apache.spark.sql.catalyst.expressions.ToUTCTimestamp$;
@@ -30,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.ADD;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.ADDDATE;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.APPROX_COUNT_DISTINCT;
@@ -280,12 +285,15 @@ public interface BuiltinFunctionTransformer {
         Arrays.fill(args, Literal$.MODULE$.apply(0));
         switch (unit) {
             case YEAR:   args[0] = value; break;
+            case QUARTER:args[1] = new Multiply(value, Literal.create(3, IntegerType)); break;
             case MONTH:  args[1] = value; break;
             case WEEK:   args[2] = value; break;
             case DAY:    args[3] = value; break;
             case HOUR:   args[4] = value; break;
             case MINUTE: args[5] = value; break;
             case SECOND: args[6] = value; break;
+            case MICROSECOND: args[6] = new Divide(value, Literal.create(1000, IntegerType)); break;
+            case MILLISECOND: args[6] = new Divide(value, Literal.create(1000000, IntegerType)); break;
             default:
                 throw new IllegalArgumentException("Unsupported Interval unit: " + unit);
         }


### PR DESCRIPTION
### Description
Support QUARTER interval in date_add/date_sub

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-spark/issues/1098

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
