### PR TITLE
Pass execptionType in error message

### DIFF
--- a/integ-test/src/integration/scala/org/apache/spark/sql/FlintREPLITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/sql/FlintREPLITSuite.scala
@@ -502,7 +502,7 @@ class FlintREPLITSuite extends SparkFunSuite with OpenSearchSuite with JobTest {
           statement => {
             statement.error match {
               case Some(error)
-                  if error == """{"Message":"Fail to run query. Cause: No FileSystem for scheme \"s3\""}""" =>
+                  if error == """{"message":"Fail to run query. Cause: No FileSystem for scheme \"s3\"","exception.type":"org.apache.hadoop.fs.UnsupportedFileSystemException"}""" =>
               // Assertion passed
               case _ =>
                 fail(s"Statement error is: ${statement.error}")

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -451,9 +451,10 @@ trait FlintJobExecutor {
 
     val errorMessage = s"$messagePrefix: ${t.getMessage}"
     val errorDetails = new java.util.LinkedHashMap[String, String]()
-    errorDetails.put("Message", errorMessage)
+    errorDetails.put("message", errorMessage)
     errorSource.foreach(es => errorDetails.put("ErrorSource", es))
-    statusCode.foreach(code => errorDetails.put("StatusCode", code.toString))
+    statusCode.foreach(code => errorDetails.put("statusCode", code.toString))
+    errorDetails.put("exception.type", t.getClass.getName)
 
     val errorJson = mapper.writeValueAsString(errorDetails)
     // Record the processed error message

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -581,9 +581,9 @@ class FlintREPLTest
 
     val mockFlintStatement = mock[FlintStatement]
     val expectedError = (
-      """{"Message":"Fail to read data from Glue. Cause: Access denied in AWS Glue service. Please check permissions. (Service: AWSGlue; """ +
+      """{"message":"Fail to read data from Glue. Cause: Access denied in AWS Glue service. Please check permissions. (Service: AWSGlue; """ +
         """Status Code: 400; Error Code: AccessDeniedException; Request ID: null; Proxy: null)",""" +
-        """"ErrorSource":"AWSGlue","StatusCode":"400"}"""
+        """"ErrorSource":"AWSGlue","statusCode":"400","exception.type":"com.amazonaws.services.glue.model.AccessDeniedException"}"""
     )
 
     val result = FlintREPL.processQueryException(exception, mockFlintStatement)
@@ -606,7 +606,7 @@ class FlintREPLTest
     val result = FlintREPL.processQueryException(exception, mockFlintCommand)
 
     val expectedError =
-      """{"Message":"Fail to run query. Cause: Access denied in AWS Glue service. Please check permissions."}"""
+      """{"message":"Fail to run query. Cause: Access denied in AWS Glue service. Please check permissions.","exception.type":"java.lang.SecurityException"}"""
 
     result shouldEqual expectedError
     verify(mockFlintCommand).fail()


### PR DESCRIPTION
### Description
Pass execptionType in error message in case of queryFailure

### Related Issues
 * We pass exception type to error message so upstream services can use the exception type from the error message to parse

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
