### PR TITLE
Call processDataframe before writeDataFrame for non Streaming Or Batch queries

### DIFF
--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -149,7 +149,8 @@ case class JobOperator(
             writeDataFrameToOpensearch(df, resultIndex, osClient)
           } else {
             val queryResultWriter = instantiateQueryResultWriter(sparkSession, commandContext)
-            queryResultWriter.writeDataFrame(df, statement)
+            val processedDataFrame = queryResultWriter.processDataFrame(df, statement, startTime)
+            queryResultWriter.writeDataFrame(processedDataFrame, statement)
           }
         })
       } catch {


### PR DESCRIPTION
**…results**

### Description
This change ensures correct DataFrame formatting for non-streaming/batch queries by calling the processing step before writing results. Following the same standard here as pre #979 FlintREPL which was responsible for handling these queries. 
### Related Issues
NA

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [x] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
