### PR TITLE
Add geo_point OpenSearch type support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -226,6 +226,7 @@ lazy val flintSparkIntegration = (project in file("flint-spark-integration"))
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-java-sdk" % "1.12.397" % "provided"
         exclude ("com.fasterxml.jackson.core", "jackson-databind"),
+      "org.locationtech.jts" % "jts-core" % "1.20.0",
       "org.scalactic" %% "scalactic" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "org.scalatest" %% "scalatest-flatspec" % "3.2.15" % "test",

--- a/docs/opensearch-table.md
+++ b/docs/opensearch-table.md
@@ -73,6 +73,7 @@ The following table defines the data type mapping between OpenSearch index field
 | object                   | StructType                        |
 | alias                    | Inherits referenced field type    |
 | ip                       | IPAddress(UDT)                    |
+| geo_point                | GeoPoint (UDT)                    |
 
 * OpenSearch data type date is mapped to Spark data type based on the format:
     * Map to DateType if format = strict_date, (we also support format = date, may change in future)
@@ -88,6 +89,7 @@ The following table defines the data type mapping between OpenSearch index field
 * OpenSearch alias fields allow alternative names for existing fields in the schema without duplicating data. They inherit the data type and nullability of the referenced field and resolve dynamically to the primary field in queries.
 * OpenSearch multi-fields on text field is supported. These multi-fields are stored as part of the field's metadata and cannot be directly selected. Instead, they are automatically utilized during the DSL query translation process.
 * IPAddress type cannot be directly compared with string type literal/field (e.g. '192.168.10.10'). Use `cidrmatch` function like `cidrmatch(ip, '192.168.0.10/32')`
+* OpenSearch geo_point will lose original notation type information such as WKT, GeoJSON, geohash, etc. and stored as `GeoPoint(lattitude, longitude)` (serialized as `Array[Double]`)
 
 ## Limitation
 ### catalog operation

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -35,7 +35,7 @@ object FlintDataType {
 
   val METADATA_ALIAS_PATH_NAME = "aliasPath"
 
-  val UNSUPPORTED_OPENSEARCH_FIELD_TYPE = Set()
+  val UNSUPPORTED_OPENSEARCH_FIELD_TYPE = Set.empty[String]
 
   /**
    * parse Flint metadata and extract properties to StructType.

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -35,7 +35,7 @@ object FlintDataType {
 
   val METADATA_ALIAS_PATH_NAME = "aliasPath"
 
-  val UNSUPPORTED_OPENSEARCH_FIELD_TYPE = Set("nothing")
+  val UNSUPPORTED_OPENSEARCH_FIELD_TYPE = Set()
 
   /**
    * parse Flint metadata and extract properties to StructType.

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -10,8 +10,8 @@ import org.json4s.JsonAST.{JNothing, JObject, JString}
 import org.json4s.JsonAST.JBool.True
 import org.json4s.jackson.JsonMethods
 import org.json4s.native.Serialization
-import org.opensearch.flint.spark.udt.IPAddressUDT
 import org.opensearch.flint.spark.udt.GeoPointUDT
+import org.opensearch.flint.spark.udt.IPAddressUDT
 
 import org.apache.spark.sql.catalyst.util.DateFormatter
 import org.apache.spark.sql.flint.datatype.FlintMetadataExtensions.{MetadataBuilderExtension, MetadataExtension, OS_TYPE_KEY}

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -230,8 +230,7 @@ object FlintDataType {
         JObject("type" -> JString("ip"))
 
       // geo_point
-      case GeoPointUDT =>
-        JObject("type" -> JString("geo_point"))
+      case GeoPointUDT => JObject("type" -> JString("geo_point"))
 
       case unknown => throw new IllegalStateException(s"unsupported data type: ${unknown.sql}")
     }

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -11,6 +11,7 @@ import org.json4s.JsonAST.JBool.True
 import org.json4s.jackson.JsonMethods
 import org.json4s.native.Serialization
 import org.opensearch.flint.spark.udt.IPAddressUDT
+import org.opensearch.flint.spark.udt.GeoPointUDT
 
 import org.apache.spark.sql.catalyst.util.DateFormatter
 import org.apache.spark.sql.flint.datatype.FlintMetadataExtensions.{MetadataBuilderExtension, MetadataExtension, OS_TYPE_KEY}
@@ -34,7 +35,7 @@ object FlintDataType {
 
   val METADATA_ALIAS_PATH_NAME = "aliasPath"
 
-  val UNSUPPORTED_OPENSEARCH_FIELD_TYPE = Set("geo_point")
+  val UNSUPPORTED_OPENSEARCH_FIELD_TYPE = Set("nothing")
 
   /**
    * parse Flint metadata and extract properties to StructType.
@@ -121,6 +122,9 @@ object FlintDataType {
 
       // ip type
       case JString("ip") => IPAddressUDT
+
+      // geo_point type
+      case JString("geo_point") => GeoPointUDT
 
       // not supported
       case unknown => throw new IllegalStateException(s"unsupported data type: $unknown")
@@ -224,6 +228,10 @@ object FlintDataType {
       // ip
       case IPAddressUDT =>
         JObject("type" -> JString("ip"))
+
+      // geo_point
+      case GeoPointUDT =>
+        JObject("type" -> JString("geo_point"))
 
       case unknown => throw new IllegalStateException(s"unsupported data type: ${unknown.sql}")
     }

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/json/FlintJacksonParser.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/json/FlintJacksonParser.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.core._
-import org.opensearch.flint.spark.udt.{IPAddress, IPAddressUDT}
+import org.opensearch.flint.spark.udt.{IPAddress, IPAddressUDT, GeoPointConverter, GeoPointUDT}
 
 import org.apache.spark.SparkUpgradeException
 import org.apache.spark.internal.Logging
@@ -358,6 +358,13 @@ class FlintJacksonParser(
       (parser: JsonParser) =>
         parseJsonToken[UTF8String](parser, dataType) { case VALUE_STRING =>
           IPAddressUDT.serialize(IPAddress(parser.getText))
+        }
+
+    case geoPoint: GeoPointUDT =>
+      (parser: JsonParser) =>
+        parseJsonToken[ArrayData](parser, dataType) { case _ =>
+          new GenericArrayData(
+            GeoPointUDT.serialize(GeoPointConverter.fromJsonParser(parser).get))
         }
 
     case st: StructType =>

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/json/FlintJacksonParser.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/json/FlintJacksonParser.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.core._
-import org.opensearch.flint.spark.udt.{IPAddress, IPAddressUDT, GeoPointConverter, GeoPointUDT}
+import org.opensearch.flint.spark.udt.{GeoPointConverter, GeoPointUDT, IPAddress, IPAddressUDT}
 
 import org.apache.spark.SparkUpgradeException
 import org.apache.spark.internal.Logging

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkExtensions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkExtensions.scala
@@ -5,8 +5,10 @@
 
 package org.opensearch.flint.spark
 
+import org.opensearch.common.geo.GeoPoint
 import org.opensearch.flint.spark.function.TumbleFunction
 import org.opensearch.flint.spark.sql.FlintSparkSqlParser
+import org.opensearch.flint.spark.udt.GeoPointUDT
 import org.opensearch.flint.spark.udt.{IPAddress, IPAddressUDT}
 
 import org.apache.spark.sql.SparkSessionExtensions
@@ -30,5 +32,6 @@ class FlintSparkExtensions extends (SparkSessionExtensions => Unit) {
 
     // Register UDTs
     UDTRegistration.register(classOf[IPAddress].getName, classOf[IPAddressUDT].getName)
+    UDTRegistration.register(classOf[GeoPoint].getName, classOf[GeoPointUDT].getName)
   }
 }

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkExtensions.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkExtensions.scala
@@ -8,8 +8,8 @@ package org.opensearch.flint.spark
 import org.opensearch.common.geo.GeoPoint
 import org.opensearch.flint.spark.function.TumbleFunction
 import org.opensearch.flint.spark.sql.FlintSparkSqlParser
-import org.opensearch.flint.spark.udt.GeoPointUDT
 import org.opensearch.flint.spark.udt.{IPAddress, IPAddressUDT}
+import org.opensearch.flint.spark.udt.GeoPointUDT
 
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.types.UDTRegistration

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/GeoPoint.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/GeoPoint.scala
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.udt
+
+import org.apache.spark.sql.types.{SQLUserDefinedType, UserDefinedType}
+
+@SQLUserDefinedType(udt = classOf[GeoPointUDT])
+case class GeoPoint(lat: Double, lon: Double) {}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/GeoPointConverter.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/GeoPointConverter.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.udt
+
+import java.util.Locale
+
+import scala.util.Try
+
+import com.fasterxml.jackson.core.{JsonParser, JsonToken}
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.io.WKTReader
+import org.opensearch.geometry.utils.Geohash
+
+object GeoPointConverter {
+  def fromJsonParser(parser: JsonParser): Option[GeoPoint] = {
+    parser.currentToken() match {
+      case JsonToken.VALUE_STRING =>
+        parseString(parser.getText)
+
+      case JsonToken.START_ARRAY =>
+        parseArray(parser)
+
+      case JsonToken.START_OBJECT =>
+        parseObject(parser)
+
+      case _ =>
+        None
+    }
+  }
+
+  private def parseString(text: String): Option[GeoPoint] = {
+    val trimmed = text.trim
+    if (trimmed.toUpperCase(Locale.ROOT).startsWith("POINT")) {
+      parseWKT(trimmed)
+    } else if (trimmed.contains(",")) {
+      // Format: "lat,lon" or "lat lon"
+      val parts = trimmed.split(",\\s*")
+      if (parts.length == 2) {
+        for {
+          lat <- Try(parts(0).toDouble).toOption
+          lon <- Try(parts(1).toDouble).toOption
+        } yield GeoPoint(lat, lon)
+      } else {
+        None
+      }
+    } else if (isGeohash(trimmed)) {
+      decodeGeohash(trimmed)
+    } else {
+      None
+    }
+  }
+
+  private def parseArray(parser: JsonParser): Option[GeoPoint] = {
+    val coords = scala.collection.mutable.ListBuffer[Double]()
+    while (parser.nextToken() != JsonToken.END_ARRAY) {
+      if (parser.currentToken().isNumeric) {
+        coords += parser.getDoubleValue
+      }
+    }
+    if (coords.length == 2) {
+      // Assuming format: [lon, lat]
+      Some(GeoPoint(coords(1), coords(0)))
+    } else {
+      None
+    }
+  }
+
+  private def parseObject(parser: JsonParser): Option[GeoPoint] = {
+    var latOpt: Option[Double] = None
+    var lonOpt: Option[Double] = None
+    var typeOpt: Option[String] = None
+    var coordinatesOpt: Option[(Double, Double)] = None
+
+    while (parser.nextToken() != JsonToken.END_OBJECT) {
+      val fieldName = parser.getCurrentName
+      parser.nextToken()
+      fieldName match {
+        case "lat" => latOpt = Try(parser.getDoubleValue).toOption
+        case "lon" => lonOpt = Try(parser.getDoubleValue).toOption
+        case "type" => typeOpt = Some(parser.getText)
+        case "coordinates" =>
+          val coords = parseCoordinatesArray(parser)
+          coordinatesOpt = coords
+        case _ => parser.skipChildren()
+      }
+    }
+
+    (latOpt, lonOpt) match {
+      case (Some(lat), Some(lon)) => Some(GeoPoint(lat, lon))
+      case _ =>
+        (typeOpt, coordinatesOpt) match {
+          case (Some("Point"), Some((lon, lat))) => Some(GeoPoint(lat, lon))
+          case _ => None
+        }
+    }
+  }
+
+  private def parseCoordinatesArray(parser: JsonParser): Option[(Double, Double)] = {
+    if (parser.currentToken() != JsonToken.START_ARRAY) return None
+    val coords = scala.collection.mutable.ListBuffer[Double]()
+    while (parser.nextToken() != JsonToken.END_ARRAY) {
+      if (parser.currentToken().isNumeric) {
+        coords += parser.getDoubleValue
+      }
+    }
+    if (coords.length >= 2) {
+      Some((coords(0), coords(1)))
+    } else {
+      None
+    }
+  }
+
+  private def isGeohash(text: String): Boolean = {
+    val geohashPattern = "^[0-9b-hj-np-z]+$".r
+    text.toLowerCase(Locale.ROOT) match {
+      case geohashPattern() => true
+      case _ => false
+    }
+  }
+
+  private def decodeGeohash(hash: String): Option[GeoPoint] = {
+    Some(GeoPoint(Geohash.decodeLatitude(hash), Geohash.decodeLongitude(hash)))
+  }
+
+  private def parseWKT(wkt: String): Option[GeoPoint] = {
+    val reader = new WKTReader()
+    Try {
+      val geom = reader.read(wkt)
+      geom match {
+        case point: Point => GeoPoint(point.getY, point.getX)
+        case _ => null
+      }
+    }.toOption
+  }
+
+}

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/GeoPointUDT.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/udt/GeoPointUDT.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.udt
+
+import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.types.{ArrayType, DataType, DoubleType, UserDefinedType}
+
+class GeoPointUDT extends UserDefinedType[GeoPoint] {
+
+  override def sqlType: DataType = ArrayType(DoubleType, containsNull = false)
+
+  override def serialize(obj: GeoPoint): Array[Double] = Array(obj.lat, obj.lon)
+
+  override def deserialize(datum: Any): GeoPoint = datum match {
+    case arr: ArrayData if arr.numElements() == 2 =>
+      val lat = arr.getDouble(0)
+      val lon = arr.getDouble(1)
+      GeoPoint(lat, lon)
+    case _ =>
+      throw new IllegalArgumentException(s"Cannot deserialize $datum to GeoPoint")
+  }
+
+  override def userClass: Class[GeoPoint] = classOf[GeoPoint]
+
+  override def typeName: String = "geo_point"
+
+  override def equals(o: Any): Boolean = {
+    o match {
+      case _: GeoPointUDT => true
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = getClass.getName.hashCode()
+}
+
+case object GeoPointUDT extends GeoPointUDT

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
@@ -7,6 +7,7 @@ package org.apache.spark.sql.flint.datatype
 
 import org.json4s.JValue
 import org.json4s.jackson.JsonMethods
+import org.opensearch.flint.spark.udt.GeoPointUDT
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.FlintSuite
@@ -367,5 +368,23 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
     aliasField.dataType shouldEqual LongType
     aliasField.metadata.contains("aliasPath") shouldBe true
     aliasField.metadata.getString("aliasPath") shouldEqual "distance"
+  }
+
+  test("geo_point field deserialize") {
+    val flintDataType =
+      """{
+        |  "properties": {
+        |    "location": {
+        |      "type": "geo_point"
+        |    }
+        |  }
+        |}""".stripMargin
+
+    val expectedStructType = StructType(StructField("location", GeoPointUDT, true) :: Nil)
+
+    val deserialized = FlintDataType.deserialize(flintDataType)
+
+    deserialized.fields should have length (1)
+    deserialized.fields(0) shouldEqual expectedStructType.fields(0)
   }
 }

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/udt/GeoPointConverterSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/udt/GeoPointConverterSuite.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.udt
+
+import com.fasterxml.jackson.core.{JsonFactory, JsonParser}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class GeoPointConverterSuite extends AnyFlatSpec with Matchers {
+
+  val jsonFactory = new JsonFactory()
+
+  def parseJson(json: String): JsonParser = {
+    val parser = jsonFactory.createParser(json)
+    parser.nextToken() // Advance to the first token
+    parser
+  }
+
+  "GeoPointConverter" should "parse string format 'lat,lon'" in {
+    val parser = parseJson("\"47.6062,-122.3321\"")
+    val result = GeoPointConverter.fromJsonParser(parser)
+    result shouldBe Some(GeoPoint(47.6062, -122.3321))
+  }
+
+  it should "parse array format [lon, lat]" in {
+    val parser = parseJson("[-122.3321, 47.6062]")
+    val result = GeoPointConverter.fromJsonParser(parser)
+    result shouldBe Some(GeoPoint(47.6062, -122.3321))
+  }
+
+  it should "parse object with 'lat' and 'lon' fields" in {
+    val parser = parseJson("""{"lat": 47.6062, "lon": -122.3321}""")
+    val result = GeoPointConverter.fromJsonParser(parser)
+    result shouldBe Some(GeoPoint(47.6062, -122.3321))
+  }
+
+  it should "parse GeoJSON Point object" in {
+    val parser = parseJson("""{"type": "Point", "coordinates": [-122.3321, 47.6062]}""")
+    val result = GeoPointConverter.fromJsonParser(parser)
+    result shouldBe Some(GeoPoint(47.6062, -122.3321))
+  }
+
+  it should "parse WKT Point string" in {
+    val parser = parseJson("\"POINT (-122.3321 47.6062)\"")
+    val result = GeoPointConverter.fromJsonParser(parser)
+    result shouldBe Some(GeoPoint(47.6062, -122.3321))
+  }
+
+  it should "return None for invalid string" in {
+    val parser = parseJson("\"invalid\"")
+    val result = GeoPointConverter.fromJsonParser(parser)
+    result shouldBe None
+  }
+
+  it should "return None for incomplete object" in {
+    val parser = parseJson("""{"lat": 47.6062}""")
+    val result = GeoPointConverter.fromJsonParser(parser)
+    result shouldBe None
+  }
+
+  it should "return None for invalid array" in {
+    val parser = parseJson("[47.6062]")
+    val result = GeoPointConverter.fromJsonParser(parser)
+    result shouldBe None
+  }
+}

--- a/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
@@ -181,6 +181,52 @@ trait OpenSearchSuite extends BeforeAndAfterAll {
     index(indexName, oneNodeSetting, mappings, docs)
   }
 
+  def indexGeoPointFields(indexName: String): Unit = {
+    val mappings = """{
+                     |  "properties": {
+                     |    "id": {
+                     |      "type": "integer"
+                     |    },
+                     |    "location": {
+                     |      "type": "geo_point"
+                     |    }
+                     |  }
+                     |}""".stripMargin
+    val docs = Seq(
+      // A JSON object with "lat" and "lon" fields
+      """{
+                     |  "id": 1,
+                     |  "location": {
+                     |    "lat": 40.12,
+                     |    "lon": -71.34
+                     |  }
+                     |}""".stripMargin,
+      // A string in the "latitude,longitude" format
+      """{
+                     |  "id": 2,
+                     |  "location": "40.12,-71.34"
+                     |}""".stripMargin,
+      // A string in the "geohash" format
+      """{
+                     |  "id": 3,
+                     |  "location": "drjk0"
+                     |}""".stripMargin,
+      // A string in the "WKT" format
+      """{
+                     |  "id": 4,
+                     |  "location": "POINT (-71.34 40.12)"
+                     |}""".stripMargin,
+      // A string in the "GeoJSON" format
+      """{
+                     |  "id": 5,
+                     |  "location": {
+                     |    "type": "Point",
+                     |    "coordinates": [-71.34,40.12]
+                     |  }
+                     |}""".stripMargin)
+    index(indexName, oneNodeSetting, mappings, docs)
+  }
+
   def indexWithNumericFields(indexName: String): Unit = {
     val mappings = """{
                      |  "properties": {


### PR DESCRIPTION
### Description
- Add geo_point OpenSearch type support
- geo_point is implemented as UDT to prioritize type compatibility with OpenSearch

### Related Issues
https://github.com/opensearch-project/opensearch-spark/issues/1047

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [x] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
