### PR TITLE
[Vended Dashboards] Enable config of meta data cache by default

### DIFF
--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -314,7 +314,7 @@ object FlintSparkConf {
       .createOptional()
   val METADATA_CACHE_WRITE = FlintConfig("spark.flint.metadataCacheWrite.enabled")
     .doc("Enable Flint metadata cache write to Flint index mappings")
-    .createWithDefault("false")
+    .createWithDefault("true")
 
   val CUSTOM_SESSION_MANAGER =
     FlintConfig("spark.flint.job.customSessionManager")

--- a/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
@@ -63,12 +63,12 @@ trait FlintSuite extends SharedSparkSession {
     }
   }
 
-  protected def withMetadataCacheWriteEnabled(block: => Unit): Unit = {
-    setFlintSparkConf(METADATA_CACHE_WRITE, "true")
+  protected def withMetadataCacheWriteDisabled(block: => Unit): Unit = {
+    setFlintSparkConf(METADATA_CACHE_WRITE, "false")
     try {
       block
     } finally {
-      setFlintSparkConf(METADATA_CACHE_WRITE, "false")
+      setFlintSparkConf(METADATA_CACHE_WRITE, "true")
     }
   }
 

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/metadatacache/FlintOpenSearchMetadataCacheWriterITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/metadatacache/FlintOpenSearchMetadataCacheWriterITSuite.scala
@@ -63,15 +63,15 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
   }
 
   test("build disabled metadata cache writer") {
-    FlintMetadataCacheWriterBuilder
-      .build(FlintSparkConf()) shouldBe a[FlintDisabledMetadataCacheWriter]
+    withMetadataCacheWriteDisabled {
+      FlintMetadataCacheWriterBuilder
+        .build(FlintSparkConf()) shouldBe a[FlintDisabledMetadataCacheWriter]
+    }
   }
 
   test("build opensearch metadata cache writer") {
-    withMetadataCacheWriteEnabled {
       FlintMetadataCacheWriterBuilder
         .build(FlintSparkConf()) shouldBe a[FlintOpenSearchMetadataCacheWriter]
-    }
   }
 
   test("write metadata cache to index mappings") {
@@ -345,7 +345,6 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
          |""".stripMargin)).foreach { case (refreshMode, optionsMap, expectedJson) =>
     test(s"write metadata cache for $refreshMode") {
       withExternalSchedulerEnabled {
-        withMetadataCacheWriteEnabled {
           val flint: FlintSpark = new FlintSpark(spark)
           withTempDir { checkpointDir =>
             // update checkpoint_location if available in optionsMap
@@ -371,13 +370,11 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
               compact(render(getPropertiesJValue(testFlintIndex) \ "lastRefreshTime")).toLong
             lastRefreshTime should be > 0L
           }
-        }
       }
     }
   }
 
   test("write metadata cache for auto refresh index with internal scheduler") {
-    withMetadataCacheWriteEnabled {
       val flint: FlintSpark = new FlintSpark(spark)
       withTempDir { checkpointDir =>
         flint
@@ -406,7 +403,6 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
         flint.refreshIndex(testFlintIndex)
         compact(render(getPropertiesJValue(testFlintIndex))) should not include "lastRefreshTime"
       }
-    }
   }
 
   private def getPropertiesJValue(indexName: String): JValue = {

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/metadatacache/FlintOpenSearchMetadataCacheWriterITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/metadatacache/FlintOpenSearchMetadataCacheWriterITSuite.scala
@@ -70,8 +70,8 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
   }
 
   test("build opensearch metadata cache writer") {
-      FlintMetadataCacheWriterBuilder
-        .build(FlintSparkConf()) shouldBe a[FlintOpenSearchMetadataCacheWriter]
+    FlintMetadataCacheWriterBuilder
+      .build(FlintSparkConf()) shouldBe a[FlintOpenSearchMetadataCacheWriter]
   }
 
   test("write metadata cache to index mappings") {
@@ -345,54 +345,53 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
          |""".stripMargin)).foreach { case (refreshMode, optionsMap, expectedJson) =>
     test(s"write metadata cache for $refreshMode") {
       withExternalSchedulerEnabled {
-          val flint: FlintSpark = new FlintSpark(spark)
-          withTempDir { checkpointDir =>
-            // update checkpoint_location if available in optionsMap
-            val indexOptions = FlintSparkIndexOptions(
-              optionsMap
-                .get("checkpoint_location")
-                .map(_ =>
-                  optionsMap.updated("checkpoint_location", checkpointDir.getAbsolutePath))
-                .getOrElse(optionsMap))
+        val flint: FlintSpark = new FlintSpark(spark)
+        withTempDir { checkpointDir =>
+          // update checkpoint_location if available in optionsMap
+          val indexOptions = FlintSparkIndexOptions(
+            optionsMap
+              .get("checkpoint_location")
+              .map(_ => optionsMap.updated("checkpoint_location", checkpointDir.getAbsolutePath))
+              .getOrElse(optionsMap))
 
-            flint
-              .skippingIndex()
-              .onTable(testTable)
-              .addMinMax("age")
-              .options(indexOptions, testFlintIndex)
-              .create()
+          flint
+            .skippingIndex()
+            .onTable(testTable)
+            .addMinMax("age")
+            .options(indexOptions, testFlintIndex)
+            .create()
 
-            val propertiesJson = compact(render(getPropertiesJValue(testFlintIndex)))
-            propertiesJson should matchJson(expectedJson)
+          val propertiesJson = compact(render(getPropertiesJValue(testFlintIndex)))
+          propertiesJson should matchJson(expectedJson)
 
-            flint.refreshIndex(testFlintIndex)
-            val lastRefreshTime =
-              compact(render(getPropertiesJValue(testFlintIndex) \ "lastRefreshTime")).toLong
-            lastRefreshTime should be > 0L
-          }
+          flint.refreshIndex(testFlintIndex)
+          val lastRefreshTime =
+            compact(render(getPropertiesJValue(testFlintIndex) \ "lastRefreshTime")).toLong
+          lastRefreshTime should be > 0L
+        }
       }
     }
   }
 
   test("write metadata cache for auto refresh index with internal scheduler") {
-      val flint: FlintSpark = new FlintSpark(spark)
-      withTempDir { checkpointDir =>
-        flint
-          .skippingIndex()
-          .onTable(testTable)
-          .addMinMax("age")
-          .options(
-            FlintSparkIndexOptions(
-              Map(
-                "auto_refresh" -> "true",
-                "scheduler_mode" -> "internal",
-                "refresh_interval" -> "10 Minute",
-                "checkpoint_location" -> checkpointDir.getAbsolutePath)),
-            testFlintIndex)
-          .create()
+    val flint: FlintSpark = new FlintSpark(spark)
+    withTempDir { checkpointDir =>
+      flint
+        .skippingIndex()
+        .onTable(testTable)
+        .addMinMax("age")
+        .options(
+          FlintSparkIndexOptions(
+            Map(
+              "auto_refresh" -> "true",
+              "scheduler_mode" -> "internal",
+              "refresh_interval" -> "10 Minute",
+              "checkpoint_location" -> checkpointDir.getAbsolutePath)),
+          testFlintIndex)
+        .create()
 
-        val propertiesJson = compact(render(getPropertiesJValue(testFlintIndex)))
-        propertiesJson should matchJson(s"""
+      val propertiesJson = compact(render(getPropertiesJValue(testFlintIndex)))
+      propertiesJson should matchJson(s"""
             | {
             |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
             |   "refreshInterval": 600,
@@ -400,9 +399,9 @@ class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Mat
             | }
             |""".stripMargin)
 
-        flint.refreshIndex(testFlintIndex)
-        compact(render(getPropertiesJValue(testFlintIndex))) should not include "lastRefreshTime"
-      }
+      flint.refreshIndex(testFlintIndex)
+      compact(render(getPropertiesJValue(testFlintIndex))) should not include "lastRefreshTime"
+    }
   }
 
   private def getPropertiesJValue(indexName: String): JValue = {


### PR DESCRIPTION
### Description
Enable config of meta data cache

### Related Issues
_List any issues this PR will resolve, e.g. Resolves [...]._

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
