### PR TITLE
Fix AWS EMR-S integration test

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -46,6 +46,7 @@ export AWS_EMRS_EXECUTION_ROLE=xxx
 export AWS_S3_CODE_BUCKET=xxx
 export AWS_S3_CODE_PREFIX=xxx
 export AWS_OPENSEARCH_RESULT_INDEX=query_execution_result_glue
+export AWS_OPENSEARCH_RESULT_INDEX=.query_execution_request_glue
 ```
 And run the following command:
 ```

--- a/integ-test/src/aws-integration/scala/org/opensearch/flint/spark/aws/AWSEmrServerlessAccessTestSuite.scala
+++ b/integ-test/src/aws-integration/scala/org/opensearch/flint/spark/aws/AWSEmrServerlessAccessTestSuite.scala
@@ -37,6 +37,7 @@ class AWSEmrServerlessAccessTestSuite
   lazy val testS3CodeBucket: String = System.getenv("AWS_S3_CODE_BUCKET")
   lazy val testS3CodePrefix: String = System.getenv("AWS_S3_CODE_PREFIX")
   lazy val testResultIndex: String = System.getenv("AWS_OPENSEARCH_RESULT_INDEX")
+  lazy val testRequestIndex: String = System.getenv("AWS_OPENSEARCH_REQUEST_INDEX")
 
   "EMR Serverless job with AOS" should "run successfully" in {
     val s3Client = AmazonS3ClientBuilder.standard().withRegion(testRegion).build()
@@ -103,6 +104,7 @@ class AWSEmrServerlessAccessTestSuite
               conf("spark.datasource.flint.port", s"$testPort"),
               conf("spark.datasource.flint.scheme", testScheme),
               conf("spark.datasource.flint.auth", testAuth),
+              conf("spark.datasource.flint.region", testRegion),
               conf("spark.datasource.flint.auth.servicename", authServiceName),
               conf("spark.sql.catalog.glue", "org.opensearch.sql.FlintDelegatingSessionCatalog"),
               conf("spark.flint.datasource.name", "glue"),


### PR DESCRIPTION
### Description
`AWSEmrServerlessAccessTestSuite` wouldn't run due to misconfigured spark properties in submitted spark job.

We don't test this in CI, so new requirements for spark properties in the future might still break this suite unnoticed.

### Check List
- [x] Updated documentation
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [x] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
