### PR TITLE
Fix doc typo for aws integration test

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -46,7 +46,7 @@ export AWS_EMRS_EXECUTION_ROLE=xxx
 export AWS_S3_CODE_BUCKET=xxx
 export AWS_S3_CODE_PREFIX=xxx
 export AWS_OPENSEARCH_RESULT_INDEX=query_execution_result_glue
-export AWS_OPENSEARCH_RESULT_INDEX=.query_execution_request_glue
+export AWS_OPENSEARCH_REQUEST_INDEX=.query_execution_request_glue
 ```
 And run the following command:
 ```


### PR DESCRIPTION
### Description
Fixes typo in #1125 

Will close existing auto backport for #1125 and instead manual backport both these PRs

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
