### PR TITLE
[WIP] Improve E2E Test Suite logic

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -46,7 +46,7 @@ export AWS_EMRS_EXECUTION_ROLE=xxx
 export AWS_S3_CODE_BUCKET=xxx
 export AWS_S3_CODE_PREFIX=xxx
 export AWS_OPENSEARCH_RESULT_INDEX=query_execution_result_glue
-export AWS_OPENSEARCH_RESULT_INDEX=.query_execution_request_glue
+export AWS_OPENSEARCH_REQUEST_INDEX=.query_execution_request_glue
 ```
 And run the following command:
 ```

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -46,6 +46,7 @@ export AWS_EMRS_EXECUTION_ROLE=xxx
 export AWS_S3_CODE_BUCKET=xxx
 export AWS_S3_CODE_PREFIX=xxx
 export AWS_OPENSEARCH_RESULT_INDEX=query_execution_result_glue
+export AWS_OPENSEARCH_RESULT_INDEX=.query_execution_request_glue
 ```
 And run the following command:
 ```

--- a/e2e-test/src/test/scala/org/opensearch/spark/e2e/EndToEndITSuite.scala
+++ b/e2e-test/src/test/scala/org/opensearch/spark/e2e/EndToEndITSuite.scala
@@ -98,6 +98,27 @@ class EndToEndITSuite extends AnyFlatSpec with TableDrivenPropertyChecks with Be
 
     logInfo("Started docker cluster")
 
+    // Wait for services to be ready
+    waitForService("localhost", 9000)  // MinIO
+    waitForService("localhost", SPARK_CONNECT_PORT)  // Spark
+    waitForService("localhost", dockerEnv.getProperty("OPENSEARCH_PORT").toInt)  // OpenSearch
+
+    // Wait for S3 service to be available before proceeding
+    if (!waitForS3Available()) {
+      throw new IllegalStateException("S3 service did not become available")
+    }
+
+    // Add these lines to verify and create required buckets
+    try {
+    ensureBucketExists(INTEG_TEST_BUCKET)      // "XXXXXXXXXX" bucket
+    logInfo(s"Successfully verified/created bucket '$INTEG_TEST_BUCKET'")
+    ensureBucketExists(TEST_RESOURCES_BUCKET)   // "XXXXXXXXXXXXXX" bucket
+    logInfo(s"Successfully verified/created bucket '$TEST_RESOURCES_BUCKET'")
+  } catch {
+    case e: Exception =>
+      logError(s"Failed to ensure buckets exist: ${e.getMessage}", e)
+      throw e
+  }
     createTables()
     createIndices()
   }
@@ -159,21 +180,72 @@ class EndToEndITSuite extends AnyFlatSpec with TableDrivenPropertyChecks with Be
    * The tables are created as external tables with the data stored in the MinIO(S3) container.
    */
   def createTables(): Unit = {
+    def withRetry[T](operation: => T, maxAttempts: Int = 5, initialWait: Long = 2000): T = {
+      def retry(remainingAttempts: Int, wait: Long): T = {
+        try {
+          operation
+        } catch {
+          case e: Exception if remainingAttempts > 1 =>
+            logInfo(s"Operation failed, retrying in ${wait}ms. ${remainingAttempts - 1} attempts remaining")
+            Thread.sleep(wait)
+            retry(remainingAttempts - 1, wait * 2)
+          case e: Exception =>
+            logError("Operation failed after all retry attempts", e)
+            throw e
+        }
+      }
+      retry(maxAttempts, initialWait)
+    }
+
     try {
       val tablesDir = new File("e2e-test/src/test/resources/spark/tables")
       tablesDir.listFiles((_, name) => name.endsWith(".parquet")).foreach(f => {
         val tableName = f.getName.substring(0, f.getName.length() - 8)
-        getS3Client().putObject(TEST_RESOURCES_BUCKET, "spark/tables/" + f.getName, f)
-
-        try {
-          val df = getSparkSession().read.parquet(s"s3a://$TEST_RESOURCES_BUCKET/spark/tables/" + f.getName)
-          df.write.option("path", s"s3a://$INTEG_TEST_BUCKET/$tableName").saveAsTable(tableName)
-        } catch {
-          case e: Exception => logError("Unable to create table", e)
+        withRetry {
+          getS3Client().putObject(TEST_RESOURCES_BUCKET, "spark/tables/" + f.getName, f)
+          try {
+            val df = getSparkSession().read.parquet(s"s3a://$TEST_RESOURCES_BUCKET/spark/tables/" + f.getName)
+            df.write
+            .mode("ignore")  // use "ignore" to skip existing tables
+            .option("path", s"s3a://$INTEG_TEST_BUCKET/$tableName").saveAsTable(tableName)
+          } catch {
+            case e: Exception => logError("Unable to create table", e)
+            throw e
+          }
         }
       })
     } catch {
       case e: Exception => logError("Failure", e)
+      throw e
+    }
+  }
+
+  /**
+  * Waits for a network service to become available at the specified host and port.
+  * This method attempts to establish a socket connection repeatedly until successful
+  * or until the timeout is reached.
+  *
+  * @param host      The hostname or IP address of the service to connect to
+  * @param port      The port number of the service
+  * @param timeoutMs The maximum time to wait in milliseconds before giving up (defaults to 60000ms/60 seconds)
+  * @throws IllegalStateException if the service is not available within the specified timeout period
+  */
+  def waitForService(host: String, port: Int, timeoutMs: Long = 60000): Unit = {
+    val endTime = System.currentTimeMillis() + timeoutMs
+    var connected = false
+    while (!connected && System.currentTimeMillis() < endTime) {
+      try {
+        val socket = new java.net.Socket()
+        socket.connect(new java.net.InetSocketAddress(host, port), 1000)
+        socket.close()
+        connected = true
+      } catch {
+        case _: Exception =>
+          Thread.sleep(2000)
+      }
+    }
+    if (!connected) {
+      throw new IllegalStateException(s"Service $host:$port not available after ${timeoutMs}ms")
     }
   }
 
@@ -215,6 +287,37 @@ class EndToEndITSuite extends AnyFlatSpec with TableDrivenPropertyChecks with Be
         bulkInsertRequest.send(backend)
       }
     })
+  }
+
+  /**
+  * Attempts to verify S3 service availability by trying to list buckets with exponential backoff.
+  *
+  * This method makes multiple attempts to connect to S3, implementing an exponential backoff
+  * strategy between attempts. It will try up to 10 times, with increasing delay between
+  * each attempt.
+  *
+  * @return true if S3 service becomes available within the maximum number of attempts,
+  *         false if the service remains unavailable after all attempts
+  */
+  def waitForS3Available(): Boolean = {
+    val maxRetries = 10
+    val initialBackoffMs = 1000
+    for (attempt <- 1 to maxRetries) {
+      try {
+        // Try a simple operation like listing buckets
+        getS3Client().listBuckets()
+        logInfo(s"S3 service available after $attempt attempts")
+        return true
+      } catch {
+        case e: Exception =>
+          val backoffTime = initialBackoffMs * Math.pow(2, attempt - 1).toInt
+          logInfo(s"S3 service not available yet (attempt $attempt/$maxRetries), waiting ${backoffTime}ms: ${e.getMessage}")
+          Thread.sleep(backoffTime)
+      }
+    }
+
+    logError(s"S3 service not available after $maxRetries attempts")
+    false
   }
 
   /**

--- a/e2e-test/src/test/scala/org/opensearch/spark/e2e/S3ClientTrait.scala
+++ b/e2e-test/src/test/scala/org/opensearch/spark/e2e/S3ClientTrait.scala
@@ -8,11 +8,14 @@ package org.opensearch.spark.e2e
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.s3.model.HeadBucketRequest
+import org.apache.logging.log4j.{Logger, LogManager}
 
 /**
  * Provides a method for obtaining an S3 client.
  */
 trait S3ClientTrait {
+  private val log: Logger = LogManager.getLogger(getClass)
   var s3Client : AmazonS3 = null
 
   /**
@@ -48,6 +51,42 @@ trait S3ClientTrait {
       }
 
       s3Client
+    }
+  }
+
+   /**
+   * Checks if an S3 bucket exists and is accessible
+   *
+   * @param bucketName name of the bucket to check
+   * @return true if bucket exists and is accessible, false otherwise
+   */
+  def doesBucketExist(bucketName: String): Boolean = {
+    try {
+      getS3Client().headBucket(new HeadBucketRequest(bucketName))
+      true
+    } catch {
+      case e: com.amazonaws.services.s3.model.AmazonS3Exception =>
+        log.error(s"Error checking bucket '$bucketName': ${e.getMessage}")
+        false
+    }
+  }
+
+  /**
+   * Ensures a bucket exists, creates it if it doesn't
+   *
+   * @param bucketName name of the bucket to check/create
+   */
+  def ensureBucketExists(bucketName: String): Unit = {
+    if (!doesBucketExist(bucketName)) {
+      log.info(s"Bucket '$bucketName' does not exist or is not accessible")
+      try {
+        getS3Client().createBucket(bucketName)
+        log.info(s"Created bucket '$bucketName'")
+      } catch {
+        case e: Exception =>
+          log.error(s"Failed to create bucket: ${e.getMessage}")
+          throw e
+      }
     }
   }
 }

--- a/e2e-test/src/test/scala/org/opensearch/spark/e2e/S3ClientTrait.scala
+++ b/e2e-test/src/test/scala/org/opensearch/spark/e2e/S3ClientTrait.scala
@@ -8,14 +8,11 @@ package org.opensearch.spark.e2e
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
-import com.amazonaws.services.s3.model.HeadBucketRequest
-import org.apache.logging.log4j.{Logger, LogManager}
 
 /**
  * Provides a method for obtaining an S3 client.
  */
 trait S3ClientTrait {
-  private val log: Logger = LogManager.getLogger(getClass)
   var s3Client : AmazonS3 = null
 
   /**
@@ -51,42 +48,6 @@ trait S3ClientTrait {
       }
 
       s3Client
-    }
-  }
-
-   /**
-   * Checks if an S3 bucket exists and is accessible
-   *
-   * @param bucketName name of the bucket to check
-   * @return true if bucket exists and is accessible, false otherwise
-   */
-  def doesBucketExist(bucketName: String): Boolean = {
-    try {
-      getS3Client().headBucket(new HeadBucketRequest(bucketName))
-      true
-    } catch {
-      case e: com.amazonaws.services.s3.model.AmazonS3Exception =>
-        log.error(s"Error checking bucket '$bucketName': ${e.getMessage}")
-        false
-    }
-  }
-
-  /**
-   * Ensures a bucket exists, creates it if it doesn't
-   *
-   * @param bucketName name of the bucket to check/create
-   */
-  def ensureBucketExists(bucketName: String): Unit = {
-    if (!doesBucketExist(bucketName)) {
-      log.info(s"Bucket '$bucketName' does not exist or is not accessible")
-      try {
-        getS3Client().createBucket(bucketName)
-        log.info(s"Created bucket '$bucketName'")
-      } catch {
-        case e: Exception =>
-          log.error(s"Failed to create bucket: ${e.getMessage}")
-          throw e
-      }
     }
   }
 }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -110,6 +110,22 @@ public class FlintOptions implements Serializable {
   public static final String DEFAULT_SUPPORT_SHARD = "true";
 
   private static final String UNKNOWN = "UNKNOWN";
+  
+  /**
+   * Cached AWS account ID from the cluster name environment variable.
+   */
+  public static final String AWS_ACCOUNT_ID = initializeAWSAccountId();
+  
+  /**
+   * Initialize the AWS account ID from the cluster name environment variable.
+   * This is called once during class loading.
+   * @return the AWS account ID or "UNKNOWN" if not available
+   */
+  private static String initializeAWSAccountId() {
+    String clusterName = System.getenv().getOrDefault("FLINT_CLUSTER_NAME", UNKNOWN + ":" + UNKNOWN);
+    String[] parts = clusterName.split(":");
+    return parts.length == 2 ? parts[0] : UNKNOWN;
+  }
 
   public static final String BULK_REQUEST_RATE_LIMIT_PER_NODE_ENABLED = "write.bulk.rate_limit_per_node.enabled";
   public static final String DEFAULT_BULK_REQUEST_RATE_LIMIT_PER_NODE_ENABLED = "false";
@@ -208,9 +224,7 @@ public class FlintOptions implements Serializable {
    * @return the AWS accountId
    */
   public String getAWSAccountId() {
-    String clusterName = System.getenv().getOrDefault("FLINT_CLUSTER_NAME", UNKNOWN + ":" + UNKNOWN);
-    String[] parts = clusterName.split(":");
-    return parts.length == 2 ? parts[0] : UNKNOWN;
+    return AWS_ACCOUNT_ID;
   }
 
   public String getSystemIndexName() {

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metrics/MetricsSparkListener.scala
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metrics/MetricsSparkListener.scala
@@ -67,28 +67,17 @@ class MetricsSparkListener extends SparkListener with Logging {
    *   as a dimensioned name
    */
   def addAccountDimension(metricName: String): String = {
-    val accountId = getClusterAccountId()
+    // Use the static AWS account ID directly from FlintOptions without instantiation
     DimensionedName
       .withName(metricName)
-      .withDimension("accountId", accountId)
+      .withDimension("accountId", FlintOptions.AWS_ACCOUNT_ID)
       .build()
       .toString()
-  }
-
-  /**
-   * Gets the AWS account ID from the cluster name environment variable. This method is extracted
-   * to make the class more testable.
-   *
-   * @return
-   *   The AWS account ID or "UNKNOWN" if not available
-   */
-  protected def getClusterAccountId(): String = {
-    val flintOptions = new FlintOptions(new java.util.HashMap[String, String]())
-    flintOptions.getAWSAccountId()
   }
 }
 
 object MetricsSparkListener {
+
   def withMetrics[T](spark: SparkSession, lambda: () => T): T = {
     val listener = new MetricsSparkListener()
     spark.sparkContext.addSparkListener(listener)

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metrics/MetricsSparkListener.scala
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metrics/MetricsSparkListener.scala
@@ -42,12 +42,14 @@ class MetricsSparkListener extends SparkListener with Logging {
       taskEnd.taskMetrics.jvmGCTime)
   }
 
-   def emitMetrics(): Unit = {
+  def emitMetrics(): Unit = {
     logInfo(s"Input: totalBytesRead=${bytesRead}, totalRecordsRead=${recordsRead}")
     logInfo(s"Output: totalBytesWritten=${bytesWritten}, totalRecordsWritten=${recordsWritten}")
     logInfo(s"totalJvmGcTime=${totalJvmGcTime}")
-     // Use the dimensioned metric name for bytesRead
-    MetricsUtil.addHistoricGauge(addAccountDimension(MetricConstants.INPUT_TOTAL_BYTES_READ), bytesRead)
+    // Use the dimensioned metric name for bytesRead
+    MetricsUtil.addHistoricGauge(
+      addAccountDimension(MetricConstants.INPUT_TOTAL_BYTES_READ),
+      bytesRead)
     // Original metrics remain unchanged
     MetricsUtil.addHistoricGauge(MetricConstants.INPUT_TOTAL_RECORDS_READ, recordsRead)
     MetricsUtil.addHistoricGauge(MetricConstants.OUTPUT_TOTAL_BYTES_WRITTEN, bytesWritten)
@@ -56,25 +58,29 @@ class MetricsSparkListener extends SparkListener with Logging {
   }
 
   /**
-  * Adds an AWS account dimension to the given metric name.
-  *
-  * @param metricName The name of the metric to which the account dimension will be added
-  * @return A string representation of the metric name with the account dimension attached,
-  *         formatted as a dimensioned name
-  */
+   * Adds an AWS account dimension to the given metric name.
+   *
+   * @param metricName
+   *   The name of the metric to which the account dimension will be added
+   * @return
+   *   A string representation of the metric name with the account dimension attached, formatted
+   *   as a dimensioned name
+   */
   def addAccountDimension(metricName: String): String = {
     val accountId = getClusterAccountId()
-    DimensionedName.withName(metricName)
+    DimensionedName
+      .withName(metricName)
       .withDimension("accountId", accountId)
       .build()
       .toString()
   }
 
   /**
-   * Gets the AWS account ID from the cluster name environment variable.
-   * This method is extracted to make the class more testable.
+   * Gets the AWS account ID from the cluster name environment variable. This method is extracted
+   * to make the class more testable.
    *
-   * @return The AWS account ID or "UNKNOWN" if not available
+   * @return
+   *   The AWS account ID or "UNKNOWN" if not available
    */
   protected def getClusterAccountId(): String = {
     val flintOptions = new FlintOptions(new java.util.HashMap[String, String]())

--- a/flint-core/src/main/scala/org/opensearch/flint/core/metrics/MetricsSparkListener.scala
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/metrics/MetricsSparkListener.scala
@@ -77,7 +77,6 @@ class MetricsSparkListener extends SparkListener with Logging {
 }
 
 object MetricsSparkListener {
-
   def withMetrics[T](spark: SparkSession, lambda: () => T): T = {
     val listener = new MetricsSparkListener()
     spark.sparkContext.addSparkListener(listener)

--- a/flint-core/src/test/scala/org/opensearch/flint/core/metrics/MetricsSparkListenerTest.scala
+++ b/flint-core/src/test/scala/org/opensearch/flint/core/metrics/MetricsSparkListenerTest.scala
@@ -7,8 +7,8 @@ package org.opensearch.flint.core.metrics
 
 import java.util.{HashMap => JHashMap}
 
-import org.junit.jupiter.api.{BeforeEach, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, when}
 import org.opensearch.flint.core.FlintOptions
@@ -20,7 +20,6 @@ class MetricsSparkListenerTest {
   class TestableMetricsSparkListener(accountId: String) extends MetricsSparkListener {
     // Override the addAccountDimension method to use our custom account ID
     override def addAccountDimension(metricName: String): String = {
-      import org.opensearch.flint.core.metrics.reporter.DimensionedName
       DimensionedName
         .withName(metricName)
         .withDimension("accountId", accountId)

--- a/flint-core/src/test/scala/org/opensearch/flint/core/metrics/MetricsSparkListenerTest.scala
+++ b/flint-core/src/test/scala/org/opensearch/flint/core/metrics/MetricsSparkListenerTest.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core.metrics
+
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.mockito.Mockito.{mock, when}
+import org.opensearch.flint.core.FlintOptions
+import org.opensearch.flint.core.metrics.reporter.DimensionedName
+
+import java.util.{HashMap => JHashMap}
+import org.mockito.ArgumentMatchers.any
+
+class MetricsSparkListenerTest {
+
+  // Create a testable subclass that overrides the getClusterAccountId method
+  class TestableMetricsSparkListener(accountId: String) extends MetricsSparkListener {
+    override protected def getClusterAccountId(): String = accountId
+  }
+
+  private var metricsSparkListener: MetricsSparkListener = _
+
+  @BeforeEach
+  def setup(): Unit = {
+    // Default instance for tests that don't need a specific account ID
+    metricsSparkListener = new MetricsSparkListener()
+  }
+
+  /**
+   * Test for the addAccountDimension method.
+   * This test verifies that the method correctly adds an AWS account dimension to a metric name.
+   */
+  @Test
+  def testAddAccountDimension(): Unit = {
+    // Create a testable instance with a specific account ID
+    val expectedAccountId = "123456789012"
+    val testListener = new TestableMetricsSparkListener(expectedAccountId)
+    
+    // Call the method directly (no reflection needed)
+    val metricName = "test.metric"
+    val result = testListener.addAccountDimension(metricName)
+
+    // Verify the result
+    assertTrue(result.contains(metricName), s"Result should contain the original metric name: $result")
+    assertTrue(result.contains("accountId##" + expectedAccountId), 
+      s"Result should contain the account ID dimension: $result")
+
+    // Decode the result to verify the structure
+    val dimensionedName = DimensionedName.decode(result)
+    assertEquals(metricName, dimensionedName.getName())
+    assertEquals(1, dimensionedName.getDimensions().size())
+    
+    val dimension = dimensionedName.getDimensions().iterator().next()
+    assertEquals("accountId", dimension.getName())
+    assertEquals(expectedAccountId, dimension.getValue())
+  }
+
+  /**
+   * Test for the addAccountDimension method when the FLINT_CLUSTER_NAME environment variable is not set.
+   * This test verifies that the method uses "UNKNOWN" as the account ID when the environment variable is missing.
+   */
+  @Test
+  def testAddAccountDimensionWithMissingEnvVar(): Unit = {
+    // Create a testable instance with "UNKNOWN" as the account ID
+    val expectedAccountId = "UNKNOWN"
+    val testListener = new TestableMetricsSparkListener(expectedAccountId)
+    
+    // Call the method directly
+    val metricName = "test.metric"
+    val result = testListener.addAccountDimension(metricName)
+
+    // Verify the result uses "UNKNOWN" as the account ID
+    assertTrue(result.contains(metricName), s"Result should contain the original metric name: $result")
+    assertTrue(result.contains("accountId##" + expectedAccountId), 
+      s"Result should contain UNKNOWN as the account ID: $result")
+
+    // Decode the result to verify the structure
+    val dimensionedName = DimensionedName.decode(result)
+    assertEquals(metricName, dimensionedName.getName())
+    assertEquals(1, dimensionedName.getDimensions().size())
+    
+    val dimension = dimensionedName.getDimensions().iterator().next()
+    assertEquals("accountId", dimension.getName())
+    assertEquals(expectedAccountId, dimension.getValue())
+  }
+
+  /**
+   * Test for the addAccountDimension method with an invalid FLINT_CLUSTER_NAME format.
+   * This test verifies that the method handles malformed cluster name values correctly.
+   */
+  @Test
+  def testAddAccountDimensionWithInvalidClusterNameFormat(): Unit = {
+    // Create a testable instance with "UNKNOWN" as the account ID
+    // This simulates what would happen with an invalid cluster name format
+    val expectedAccountId = "UNKNOWN"
+    val testListener = new TestableMetricsSparkListener(expectedAccountId)
+    
+    // Call the method directly
+    val metricName = "test.metric"
+    val result = testListener.addAccountDimension(metricName)
+
+    // Verify the result uses "UNKNOWN" as the account ID for invalid format
+    assertTrue(result.contains(metricName), s"Result should contain the original metric name: $result")
+    assertTrue(result.contains("accountId##" + expectedAccountId), 
+      s"Result should contain UNKNOWN as the account ID for invalid format: $result")
+      
+    // Decode the result to verify the structure
+    val dimensionedName = DimensionedName.decode(result)
+    assertEquals(metricName, dimensionedName.getName())
+    assertEquals(1, dimensionedName.getDimensions().size())
+    
+    val dimension = dimensionedName.getDimensions().iterator().next()
+    assertEquals("accountId", dimension.getName())
+    assertEquals(expectedAccountId, dimension.getValue())
+  }
+}

--- a/flint-core/src/test/scala/org/opensearch/flint/core/metrics/MetricsSparkListenerTest.scala
+++ b/flint-core/src/test/scala/org/opensearch/flint/core/metrics/MetricsSparkListenerTest.scala
@@ -5,25 +5,33 @@
 
 package org.opensearch.flint.core.metrics
 
+import java.util.{HashMap => JHashMap}
+
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, when}
 import org.opensearch.flint.core.FlintOptions
 import org.opensearch.flint.core.metrics.reporter.DimensionedName
 
-import java.util.{HashMap => JHashMap}
-import org.mockito.ArgumentMatchers.any
-
 class MetricsSparkListenerTest {
 
-  // Create a testable subclass that overrides the getClusterAccountId method
+  // Create a testable subclass that provides a custom account ID
   class TestableMetricsSparkListener(accountId: String) extends MetricsSparkListener {
-    override protected def getClusterAccountId(): String = accountId
+    // Override the addAccountDimension method to use our custom account ID
+    override def addAccountDimension(metricName: String): String = {
+      import org.opensearch.flint.core.metrics.reporter.DimensionedName
+      DimensionedName
+        .withName(metricName)
+        .withDimension("accountId", accountId)
+        .build()
+        .toString()
+    }
   }
 
-  // Create a testable subclass that exposes the protected getClusterAccountId method
+  // Create a testable subclass that exposes the AWS account ID
   class GetClusterAccountIdTestableListener extends MetricsSparkListener {
-    def publicGetClusterAccountId(): String = getClusterAccountId()
+    def publicGetClusterAccountId(): String = FlintOptions.AWS_ACCOUNT_ID
   }
 
   private var metricsSparkListener: MetricsSparkListener = _
@@ -35,95 +43,105 @@ class MetricsSparkListenerTest {
   }
 
   /**
-   * Test for the addAccountDimension method.
-   * This test verifies that the method correctly adds an AWS account dimension to a metric name.
+   * Test for the addAccountDimension method. This test verifies that the method correctly adds an
+   * AWS account dimension to a metric name.
    */
   @Test
   def testAddAccountDimension(): Unit = {
     // Create a testable instance with a specific account ID
     val expectedAccountId = "123456789012"
     val testListener = new TestableMetricsSparkListener(expectedAccountId)
-    
+
     // Call the method directly (no reflection needed)
     val metricName = "test.metric"
     val result = testListener.addAccountDimension(metricName)
 
     // Verify the result
-    assertTrue(result.contains(metricName), s"Result should contain the original metric name: $result")
-    assertTrue(result.contains("accountId##" + expectedAccountId), 
+    assertTrue(
+      result.contains(metricName),
+      s"Result should contain the original metric name: $result")
+    assertTrue(
+      result.contains("accountId##" + expectedAccountId),
       s"Result should contain the account ID dimension: $result")
 
     // Decode the result to verify the structure
     val dimensionedName = DimensionedName.decode(result)
     assertEquals(metricName, dimensionedName.getName())
     assertEquals(1, dimensionedName.getDimensions().size())
-    
+
     val dimension = dimensionedName.getDimensions().iterator().next()
     assertEquals("accountId", dimension.getName())
     assertEquals(expectedAccountId, dimension.getValue())
   }
 
   /**
-   * Test for the addAccountDimension method with a complex metric name.
-   * This test verifies that the method correctly handles metric names with special characters.
+   * Test for the addAccountDimension method with a complex metric name. This test verifies that
+   * the method correctly handles metric names with special characters.
    */
   @Test
   def testAddAccountDimensionWithComplexMetricName(): Unit = {
     // Create a testable instance with a specific account ID
     val expectedAccountId = "123456789012"
     val testListener = new TestableMetricsSparkListener(expectedAccountId)
-    
+
     // Call the method with a complex metric name
     val metricName = "test.metric.with.dots-and-dashes"
     val result = testListener.addAccountDimension(metricName)
 
     // Verify the result
-    assertTrue(result.contains(metricName), s"Result should contain the original complex metric name: $result")
-    assertTrue(result.contains("accountId##" + expectedAccountId), 
+    assertTrue(
+      result.contains(metricName),
+      s"Result should contain the original complex metric name: $result")
+    assertTrue(
+      result.contains("accountId##" + expectedAccountId),
       s"Result should contain the account ID dimension: $result")
 
     // Decode the result to verify the structure
     val dimensionedName = DimensionedName.decode(result)
     assertEquals(metricName, dimensionedName.getName())
     assertEquals(1, dimensionedName.getDimensions().size())
-    
+
     val dimension = dimensionedName.getDimensions().iterator().next()
     assertEquals("accountId", dimension.getName())
     assertEquals(expectedAccountId, dimension.getValue())
   }
 
   /**
-   * Test for the addAccountDimension method when the FLINT_CLUSTER_NAME environment variable is not set.
-   * This test verifies that the method uses "UNKNOWN" as the account ID when the environment variable is missing.
+   * Test for the addAccountDimension method when the FLINT_CLUSTER_NAME environment variable is
+   * not set. This test verifies that the method uses "UNKNOWN" as the account ID when the
+   * environment variable is missing.
    */
   @Test
   def testAddAccountDimensionWithMissingEnvVar(): Unit = {
     // Create a testable instance with "UNKNOWN" as the account ID
     val expectedAccountId = "UNKNOWN"
     val testListener = new TestableMetricsSparkListener(expectedAccountId)
-    
+
     // Call the method directly
     val metricName = "test.metric"
     val result = testListener.addAccountDimension(metricName)
 
     // Verify the result uses "UNKNOWN" as the account ID
-    assertTrue(result.contains(metricName), s"Result should contain the original metric name: $result")
-    assertTrue(result.contains("accountId##" + expectedAccountId), 
+    assertTrue(
+      result.contains(metricName),
+      s"Result should contain the original metric name: $result")
+    assertTrue(
+      result.contains("accountId##" + expectedAccountId),
       s"Result should contain UNKNOWN as the account ID: $result")
 
     // Decode the result to verify the structure
     val dimensionedName = DimensionedName.decode(result)
     assertEquals(metricName, dimensionedName.getName())
     assertEquals(1, dimensionedName.getDimensions().size())
-    
+
     val dimension = dimensionedName.getDimensions().iterator().next()
     assertEquals("accountId", dimension.getName())
     assertEquals(expectedAccountId, dimension.getValue())
   }
 
   /**
-   * Test for the addAccountDimension method with an invalid FLINT_CLUSTER_NAME format.
-   * This test verifies that the method handles malformed cluster name values correctly.
+   * Test for the addAccountDimension method with an invalid FLINT_CLUSTER_NAME format. This test
+   * verifies that the method handles malformed cluster name values correctly.
    */
   @Test
   def testAddAccountDimensionWithInvalidClusterNameFormat(): Unit = {
@@ -131,29 +149,32 @@ class MetricsSparkListenerTest {
     // This simulates what would happen with an invalid cluster name format
     val expectedAccountId = "UNKNOWN"
     val testListener = new TestableMetricsSparkListener(expectedAccountId)
-    
+
     // Call the method directly
     val metricName = "test.metric"
     val result = testListener.addAccountDimension(metricName)
 
     // Verify the result uses "UNKNOWN" as the account ID for invalid format
-    assertTrue(result.contains(metricName), s"Result should contain the original metric name: $result")
-    assertTrue(result.contains("accountId##" + expectedAccountId), 
+    assertTrue(
+      result.contains(metricName),
+      s"Result should contain the original metric name: $result")
+    assertTrue(
+      result.contains("accountId##" + expectedAccountId),
       s"Result should contain UNKNOWN as the account ID for invalid format: $result")
-      
+
     // Decode the result to verify the structure
     val dimensionedName = DimensionedName.decode(result)
     assertEquals(metricName, dimensionedName.getName())
     assertEquals(1, dimensionedName.getDimensions().size())
-    
+
     val dimension = dimensionedName.getDimensions().iterator().next()
     assertEquals("accountId", dimension.getName())
     assertEquals(expectedAccountId, dimension.getValue())
   }
 
   /**
-   * Test for the getClusterAccountId method when the FLINT_CLUSTER_NAME environment variable is set.
-   * This test verifies that the method correctly extracts the account ID from the environment variable.
+   * Test for the AWS account ID retrieval when the FLINT_CLUSTER_NAME environment variable is
+   * set. This test verifies that the correct account ID is retrieved.
    */
   @Test
   def testGetClusterAccountId(): Unit = {
@@ -161,23 +182,21 @@ class MetricsSparkListenerTest {
     val mockFlintOptions = mock(classOf[FlintOptions])
     val expectedAccountId = "123456789012"
     when(mockFlintOptions.getAWSAccountId()).thenReturn(expectedAccountId)
-    
-    // Create a testable instance that uses the mocked FlintOptions
+
+    // Create a testable instance that returns our expected account ID
     val testListener = new GetClusterAccountIdTestableListener() {
-      override protected def getClusterAccountId(): String = {
-        // Return the mocked value instead of creating a new FlintOptions
-        expectedAccountId
-      }
+      override def publicGetClusterAccountId(): String = expectedAccountId
     }
-    
+
     // Call the method and verify the result
     val result = testListener.publicGetClusterAccountId()
     assertEquals(expectedAccountId, result, "Should return the expected account ID")
   }
 
   /**
-   * Test for the getClusterAccountId method when the FLINT_CLUSTER_NAME environment variable is not set.
-   * This test verifies that the method returns "UNKNOWN" when the environment variable is missing.
+   * Test for the AWS account ID retrieval when the FLINT_CLUSTER_NAME environment variable is
+   * not set. This test verifies that "UNKNOWN" is returned when the environment variable
+   * is missing.
    */
   @Test
   def testGetClusterAccountIdWithMissingEnvVar(): Unit = {
@@ -185,23 +204,21 @@ class MetricsSparkListenerTest {
     val mockFlintOptions = mock(classOf[FlintOptions])
     val expectedAccountId = "UNKNOWN"
     when(mockFlintOptions.getAWSAccountId()).thenReturn(expectedAccountId)
-    
-    // Create a testable instance that uses the mocked FlintOptions
+
+    // Create a testable instance that returns our expected account ID
     val testListener = new GetClusterAccountIdTestableListener() {
-      override protected def getClusterAccountId(): String = {
-        // Return the mocked value instead of creating a new FlintOptions
-        expectedAccountId
-      }
+      override def publicGetClusterAccountId(): String = expectedAccountId
     }
-    
+
     // Call the method and verify the result
     val result = testListener.publicGetClusterAccountId()
     assertEquals(expectedAccountId, result, "Should return UNKNOWN when env var is missing")
   }
 
   /**
-   * Test for the getClusterAccountId method with an invalid FLINT_CLUSTER_NAME format.
-   * This test verifies that the method returns "UNKNOWN" when the environment variable has an invalid format.
+   * Test for the AWS account ID retrieval with an invalid FLINT_CLUSTER_NAME format. This test
+   * verifies that "UNKNOWN" is returned when the environment variable has an invalid
+   * format.
    */
   @Test
   def testGetClusterAccountIdWithInvalidClusterNameFormat(): Unit = {
@@ -209,15 +226,12 @@ class MetricsSparkListenerTest {
     val mockFlintOptions = mock(classOf[FlintOptions])
     val expectedAccountId = "UNKNOWN"
     when(mockFlintOptions.getAWSAccountId()).thenReturn(expectedAccountId)
-    
-    // Create a testable instance that uses the mocked FlintOptions
+
+    // Create a testable instance that returns our expected account ID
     val testListener = new GetClusterAccountIdTestableListener() {
-      override protected def getClusterAccountId(): String = {
-        // Return the mocked value instead of creating a new FlintOptions
-        expectedAccountId
-      }
+      override def publicGetClusterAccountId(): String = expectedAccountId
     }
-    
+
     // Call the method and verify the result
     val result = testListener.publicGetClusterAccountId()
     assertEquals(expectedAccountId, result, "Should return UNKNOWN for invalid format")

--- a/flint-core/src/test/scala/org/opensearch/flint/core/metrics/MetricsSparkListenerTest.scala
+++ b/flint-core/src/test/scala/org/opensearch/flint/core/metrics/MetricsSparkListenerTest.scala
@@ -7,8 +7,8 @@ package org.opensearch.flint.core.metrics
 
 import java.util.{HashMap => JHashMap}
 
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, when}
 import org.opensearch.flint.core.FlintOptions
@@ -193,9 +193,8 @@ class MetricsSparkListenerTest {
   }
 
   /**
-   * Test for the AWS account ID retrieval when the FLINT_CLUSTER_NAME environment variable is
-   * not set. This test verifies that "UNKNOWN" is returned when the environment variable
-   * is missing.
+   * Test for the AWS account ID retrieval when the FLINT_CLUSTER_NAME environment variable is not
+   * set. This test verifies that "UNKNOWN" is returned when the environment variable is missing.
    */
   @Test
   def testGetClusterAccountIdWithMissingEnvVar(): Unit = {
@@ -216,8 +215,7 @@ class MetricsSparkListenerTest {
 
   /**
    * Test for the AWS account ID retrieval with an invalid FLINT_CLUSTER_NAME format. This test
-   * verifies that "UNKNOWN" is returned when the environment variable has an invalid
-   * format.
+   * verifies that "UNKNOWN" is returned when the environment variable has an invalid format.
    */
   @Test
   def testGetClusterAccountIdWithInvalidClusterNameFormat(): Unit = {

--- a/integ-test/src/aws-integration/scala/org/opensearch/flint/spark/aws/AWSEmrServerlessAccessTestSuite.scala
+++ b/integ-test/src/aws-integration/scala/org/opensearch/flint/spark/aws/AWSEmrServerlessAccessTestSuite.scala
@@ -37,6 +37,7 @@ class AWSEmrServerlessAccessTestSuite
   lazy val testS3CodeBucket: String = System.getenv("AWS_S3_CODE_BUCKET")
   lazy val testS3CodePrefix: String = System.getenv("AWS_S3_CODE_PREFIX")
   lazy val testResultIndex: String = System.getenv("AWS_OPENSEARCH_RESULT_INDEX")
+  lazy val testRequestIndex: String = System.getenv("AWS_OPENSEARCH_REQUEST_INDEX")
 
   "EMR Serverless job with AOS" should "run successfully" in {
     val s3Client = AmazonS3ClientBuilder.standard().withRegion(testRegion).build()
@@ -103,6 +104,7 @@ class AWSEmrServerlessAccessTestSuite
               conf("spark.datasource.flint.port", s"$testPort"),
               conf("spark.datasource.flint.scheme", testScheme),
               conf("spark.datasource.flint.auth", testAuth),
+              conf("spark.datasource.flint.region", testRegion),
               conf("spark.datasource.flint.auth.servicename", authServiceName),
               conf("spark.sql.catalog.glue", "org.opensearch.sql.FlintDelegatingSessionCatalog"),
               conf("spark.flint.datasource.name", "glue"),

--- a/integ-test/src/integration/scala/org/apache/spark/opensearch/index/OpenSearchIndexITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/opensearch/index/OpenSearchIndexITSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.opensearch.index
+
+import scala.collection.JavaConverters._
+
+import org.opensearch.flint.core.FlintOptions
+
+import org.apache.spark.opensearch.table.OpenSearchCatalogSuite
+import org.apache.spark.sql.{FlintJob, OSClient}
+
+class OpenSearchIndexITSuite extends OpenSearchCatalogSuite {
+
+  var osClient: OSClient = _
+  val indexName = "test_index"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    osClient = new OSClient(new FlintOptions(openSearchOptions.asJava))
+  }
+
+  protected override def afterEach(): Unit = {
+    super.afterEach()
+    deleteTestIndex(indexName)
+  }
+
+  test("FlintJobExecutor creating index with malformed settings should fail") {
+    val mappings =
+      """{
+        |  "properties": {
+        |    "accountId": {
+        |      "type": "keyword"
+        |    },
+        |    "eventName": {
+        |      "type": "keyword"
+        |    },
+        |    "eventSource": {
+        |      "type": "keyword"
+        |    }
+        |  }
+        |}""".stripMargin
+
+    // invalid JSON
+    val settings =
+      """{
+        |  "index": {
+        |    "refresh_interval": "1s"
+        |}""".stripMargin
+
+    val result = FlintJob.createResultIndex(osClient, indexName, mappings, settings)
+    result match {
+      case Left(str) => assert(str == s"Failed to create result index $indexName")
+      case Right(_) => fail("passing in invalid settings did not fail")
+    }
+  }
+
+  test("FlintJobExecutor creating index with malformed mappings should fail") {
+    val osClient = new OSClient(new FlintOptions(openSearchOptions.asJava))
+
+    // invalid JSON
+    val mappings =
+      """{
+        |  "properties": {
+        |    "accountId": {
+        |      "type": "keyword"
+        |    },
+        |    "eventName": {
+        |      "type": "keyword"
+        |    },
+        |    "eventSource": {
+        |      "type": "keyword"
+        |    }
+        |}""".stripMargin
+
+    val settings =
+      """{
+        |  "index": {
+        |    "refresh_interval": "1s"
+        |  }
+        |}""".stripMargin
+
+    val result = FlintJob.createResultIndex(osClient, indexName, mappings, settings)
+    result match {
+      case Left(str) => assert(str == s"Failed to create result index $indexName")
+      case Right(_) => fail("passing in invalid mappings did not fail")
+    }
+  }
+}

--- a/integ-test/src/integration/scala/org/apache/spark/sql/JobTest.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/sql/JobTest.scala
@@ -65,6 +65,7 @@ trait JobTest extends Logging { self: OpenSearchSuite =>
 
         Thread.sleep(2000) // 2 seconds
       }
+      verifyFastRefresh(resultIndex)
       if (System.currentTimeMillis() - startTime >= timeoutMillis) {
         assert(
           false,
@@ -85,4 +86,13 @@ trait JobTest extends Logging { self: OpenSearchSuite =>
     // \\s+ is a regular expression that matches one or more whitespace characters, including spaces, tabs, and newlines.
     s.replaceAll("\\s+", " ")
   } // Replace all whitespace characters with empty string
+
+  def verifyFastRefresh(resultIndex: String): Unit = {
+    val fastRefreshSettingKey = "index.refresh_interval"
+    val fastRefreshSettingVal = "1s"
+
+    val settings = getIndexSettings(resultIndex)
+    assert(settings.hasValue(fastRefreshSettingKey))
+    assert(settings.get(fastRefreshSettingKey) == fastRefreshSettingVal)
+  }
 }

--- a/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/OpenSearchSuite.scala
@@ -14,6 +14,7 @@ import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.support.WriteRequest.RefreshPolicy
 import org.opensearch.client.{RequestOptions, RestClient, RestHighLevelClient}
 import org.opensearch.client.indices.{CreateIndexRequest, GetIndexRequest}
+import org.opensearch.common.settings.Settings
 import org.opensearch.common.xcontent.XContentType
 import org.opensearch.testcontainers.OpenSearchContainer
 import org.scalatest.{BeforeAndAfterAll, Suite}
@@ -308,5 +309,13 @@ trait OpenSearchSuite extends BeforeAndAfterAll {
         !response.hasFailures,
         s"bulk index docs to $index failed: ${response.buildFailureMessage()}")
     }
+  }
+
+  def getIndexSettings(index: String): Settings = {
+    val getIndexResponse =
+      openSearchClient.indices().get(new GetIndexRequest(index), RequestOptions.DEFAULT)
+    val indexToSettings = getIndexResponse.getSettings
+    assume(indexToSettings.containsKey(index), s"index $index not found")
+    indexToSettings.get(index)
   }
 }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -108,6 +108,15 @@ trait FlintJobExecutor {
       }
     }""".stripMargin
 
+  // Fast refresh index setting for OpenSearch index. Eliminates index refresh as a source
+  // of latency for interactive queries.
+  val resultIndexSettings =
+    """{
+      "index": {
+        "refresh_interval": "1s"
+      }
+    }""".stripMargin
+
   // Define the data schema
   val schema = StructType(
     Seq(
@@ -199,7 +208,7 @@ trait FlintJobExecutor {
     if (osClient.doesIndexExist(resultIndex)) {
       writeData(resultData, resultIndex, refreshPolicy)
     } else {
-      createResultIndex(osClient, resultIndex, resultIndexMapping)
+      createResultIndex(osClient, resultIndex, resultIndexMapping, resultIndexSettings)
       writeData(resultData, resultIndex, refreshPolicy)
     }
   }
@@ -375,7 +384,7 @@ trait FlintJobExecutor {
       case e: IllegalStateException
           if e.getCause != null &&
             e.getCause.getMessage.contains("index_not_found_exception") =>
-        createResultIndex(osClient, resultIndex, resultIndexMapping)
+        createResultIndex(osClient, resultIndex, resultIndexMapping, resultIndexSettings)
       case e: InterruptedException =>
         val error = s"Interrupted by the main thread: ${e.getMessage}"
         Thread.currentThread().interrupt() // Preserve the interrupt status
@@ -391,10 +400,11 @@ trait FlintJobExecutor {
   def createResultIndex(
       osClient: OSClient,
       resultIndex: String,
-      mapping: String): Either[String, Unit] = {
+      mapping: String,
+      settings: String): Either[String, Unit] = {
     try {
       logInfo(s"create $resultIndex")
-      osClient.createIndex(resultIndex, mapping)
+      osClient.createIndex(resultIndex, mapping, settings)
       logInfo(s"create $resultIndex successfully")
       Right(())
     } catch {

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/OSClient.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/OSClient.scala
@@ -61,16 +61,18 @@ class OSClient(val flintOptions: FlintOptions) extends Logging {
    *   the name of the index
    * @param mapping
    *   the mapping of the index
+   * @param settings
+   *   * the index settings as a JSON string
    * @return
    *   use Either for representing success or failure. A Right value indicates success, while a
    *   Left value indicates an error.
    */
-  def createIndex(osIndexName: String, mapping: String): Unit = {
+  def createIndex(osIndexName: String, mapping: String, settings: String): Unit = {
     logInfo(s"create $osIndexName")
 
     using(flintClient.createClient()) { client =>
       val request = new CreateIndexRequest(osIndexName)
-      request.mapping(mapping, XContentType.JSON)
+      request.mapping(mapping, XContentType.JSON).settings(settings, XContentType.JSON)
 
       try {
         client.createIndex(request, RequestOptions.DEFAULT)


### PR DESCRIPTION
### Description
* Add a retry mechanism with backoff: Modify the createTables()  method to include retry logic when connecting to the S3 service.
* Add explicit wait for S3 service availability: Before attempting to create tables, add a check that waits for the MinIO service to be available.
* Increase timeout for container startup: The current code waits for 20 minutes for docker-compose to complete, but you might need additional time for services to initialize.

### Related Issues
_List any issues this PR will resolve, e.g. Resolves [...]._

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
