### PR TITLE
Fields identifier in PPL should be case sensitive

### DIFF
--- a/docker/integ-test/queries.scala
+++ b/docker/integ-test/queries.scala
@@ -411,11 +411,11 @@
 
     spark.sql("source = myglue_test.default.people| LOOKUP myglue_test.default.work_info uid AS id APPEND department AS country | stats distinct_count(country)")
 
-    spark.sql("source = myglue_test.default.people| LOOKUP myglue_test.default.work_info uID AS id, name REPLACE department | stats distinct_count(department)")
+    spark.sql("source = myglue_test.default.people| LOOKUP myglue_test.default.work_info uid AS id, name REPLACE department | stats distinct_count(department)")
 
-    spark.sql("source = myglue_test.default.people| LOOKUP myglue_test.default.work_info uid AS ID, name APPEND department | stats distinct_count(department)")
+    spark.sql("source = myglue_test.default.people| LOOKUP myglue_test.default.work_info uid AS id, name APPEND department | stats distinct_count(department)")
 
-    spark.sql("source = myglue_test.default.people| LOOKUP myglue_test.default.work_info uID AS id, name | head 10")
+    spark.sql("source = myglue_test.default.people| LOOKUP myglue_test.default.work_info uid AS id, name | head 10")
 
     spark.sql("source = myglue_test.default.people | eval major = occupation | fields id, name, major, country, salary | LOOKUP myglue_test.default.work_info name REPLACE occupation AS major | stats distinct_count(major)")
 

--- a/e2e-test/src/test/resources/opensearch/queries/ppl/query_123.ppl
+++ b/e2e-test/src/test/resources/opensearch/queries/ppl/query_123.ppl
@@ -1,1 +1,1 @@
-source = mys3.default.people| LOOKUP mys3.default.work_info uID AS id, name REPLACE department | stats distinct_count(department)
+source = mys3.default.people| LOOKUP mys3.default.work_info uid AS id, name REPLACE department | stats distinct_count(department)

--- a/e2e-test/src/test/resources/opensearch/queries/ppl/query_124.ppl
+++ b/e2e-test/src/test/resources/opensearch/queries/ppl/query_124.ppl
@@ -1,1 +1,1 @@
-source = mys3.default.people| LOOKUP mys3.default.work_info uid AS ID, name APPEND department | stats distinct_count(department)
+source = mys3.default.people| LOOKUP mys3.default.work_info uid AS id, name APPEND department | stats distinct_count(department)

--- a/e2e-test/src/test/resources/spark/queries/ppl/query_123.ppl
+++ b/e2e-test/src/test/resources/spark/queries/ppl/query_123.ppl
@@ -1,1 +1,1 @@
-source = dev.default.people| LOOKUP dev.default.work_info uID AS id, name REPLACE department | stats distinct_count(department)
+source = dev.default.people| LOOKUP dev.default.work_info uid AS id, name REPLACE department | stats distinct_count(department)

--- a/e2e-test/src/test/resources/spark/queries/ppl/query_124.ppl
+++ b/e2e-test/src/test/resources/spark/queries/ppl/query_124.ppl
@@ -1,1 +1,1 @@
-source = dev.default.people| LOOKUP dev.default.work_info uid AS ID, name APPEND department | stats distinct_count(department)
+source = dev.default.people| LOOKUP dev.default.work_info uid AS id, name APPEND department | stats distinct_count(department)

--- a/integ-test/script/test_cases.csv
+++ b/integ-test/script/test_cases.csv
@@ -186,9 +186,9 @@ source=dev.default.people | LOOKUP dev.default.work_info uid AS id REPLACE depar
 source = dev.default.people| LOOKUP dev.default.work_info uid AS id APPEND department | stats distinct_count(department),SUCCESS
 source = dev.default.people| LOOKUP dev.default.work_info uid AS id REPLACE department AS country | stats distinct_count(country),SUCCESS
 source = dev.default.people| LOOKUP dev.default.work_info uid AS id APPEND department AS country | stats distinct_count(country),SUCCESS
-"source = dev.default.people| LOOKUP dev.default.work_info uID AS id, name REPLACE department | stats distinct_count(department)",SUCCESS
-"source = dev.default.people| LOOKUP dev.default.work_info uid AS ID, name APPEND department | stats distinct_count(department)",SUCCESS
-"source = dev.default.people| LOOKUP dev.default.work_info uID AS id, name | head 10",SUCCESS
+"source = dev.default.people| LOOKUP dev.default.work_info uid AS id, name REPLACE department | stats distinct_count(department)",SUCCESS
+"source = dev.default.people| LOOKUP dev.default.work_info uid AS id, name APPEND department | stats distinct_count(department)",SUCCESS
+"source = dev.default.people| LOOKUP dev.default.work_info uid AS id, name | head 10",SUCCESS
 "source = dev.default.people | eval major = occupation | fields id, name, major, country, salary | LOOKUP dev.default.work_info name REPLACE occupation AS major | stats distinct_count(major)",SUCCESS
 "source = dev.default.people | eval major = occupation | fields id, name, major, country, salary | LOOKUP dev.default.work_info name APPEND occupation AS major | stats distinct_count(major)",SUCCESS
 "source = dev.default.http_logs | eval res = json('{""account_number"":1,""balance"":39225,""age"":32,""gender"":""M""}') | head 1 | fields res",SUCCESS

--- a/integ-test/src/integration/resources/opensearch/dashboards_sample_data_flights_tests.json
+++ b/integ-test/src/integration/resources/opensearch/dashboards_sample_data_flights_tests.json
@@ -28,7 +28,7 @@
     {
       "do": {
         "sql": {
-          "query": "SELECT carrier, COUNT(*) as count FROM dev.default.flights GROUP BY Carrier ORDER BY count DESC"
+          "query": "SELECT Carrier, COUNT(*) as count FROM dev.default.flights GROUP BY Carrier ORDER BY count DESC"
         },
         "match": [ "[OpenSearch Dashboards Airlines,3]", "[Logstash Airways,2]" ]
       }

--- a/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchDashboardITSuite.scala
+++ b/integ-test/src/integration/scala/org/apache/spark/opensearch/table/OpenSearchDashboardITSuite.scala
@@ -38,7 +38,7 @@ class OpenSearchDashboardITSuite extends OpenSearchCatalogSuite with FlintPPLSui
         // Airline Carrier
         QueryTest(
           Seq(
-            s"""SELECT carrier, COUNT(*) as count
+            s"""SELECT Carrier, COUNT(*) as count
               FROM dev.default.$tbl
               GROUP BY Carrier ORDER BY count DESC""",
             s"""source=dev.default.$tbl

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLLookupITSuite.scala
@@ -200,54 +200,7 @@ class FlintSparkPPLLookupITSuite
 
   test("test LOOKUP lookupTable uid AS id, name REPLACE department") {
     val frame =
-      sql(s"source = $sourceTable| LOOKUP $lookupTable uID AS id, name REPLACE department")
-    val expectedResults: Array[Row] = Array(
-      Row(1000, "Jake", "Engineer", "England", 100000, "IT"),
-      Row(1001, "Hello", "Artist", "USA", 70000, null),
-      Row(1002, "John", "Doctor", "Canada", 120000, "DATA"),
-      Row(1003, "David", "Doctor", null, 120000, "HR"),
-      Row(1004, "David", null, "Canada", 0, null),
-      Row(1005, "Jane", "Scientist", "Canada", 90000, "DATA"))
-    assertSameRows(expectedResults, frame)
-
-    val lookupProject =
-      Project(
-        Seq(
-          UnresolvedAttribute("department"),
-          UnresolvedAttribute("uID"),
-          UnresolvedAttribute("name")),
-        lookupAlias)
-    val joinCondition =
-      And(
-        EqualTo(
-          UnresolvedAttribute("__auto_generated_subquery_name_l.uID"),
-          UnresolvedAttribute("__auto_generated_subquery_name_s.id")),
-        EqualTo(
-          UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
-          UnresolvedAttribute("__auto_generated_subquery_name_s.name")))
-    val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
-    val projectAfterJoin = Project(
-      Seq(
-        UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
-        Alias(
-          UnresolvedAttribute("__auto_generated_subquery_name_l.department"),
-          "department")()),
-      joinPlan)
-    val dropColumns = DataFrameDropColumns(
-      Seq(
-        UnresolvedAttribute("uID"),
-        UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
-        UnresolvedAttribute("__auto_generated_subquery_name_s.department")),
-      projectAfterJoin)
-    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropColumns)
-    val logicalPlan: LogicalPlan = frame.queryExecution.logical
-
-    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
-  }
-
-  test("test LOOKUP lookupTable uid AS id, name APPEND department") {
-    val frame =
-      sql(s"source = $sourceTable| LOOKUP $lookupTable uid AS ID, name APPEND department")
+      sql(s"source = $sourceTable| LOOKUP $lookupTable uid AS id, name REPLACE department")
     val expectedResults: Array[Row] = Array(
       Row(1000, "Jake", "Engineer", "England", 100000, "IT"),
       Row(1001, "Hello", "Artist", "USA", 70000, null),
@@ -268,7 +221,54 @@ class FlintSparkPPLLookupITSuite
       And(
         EqualTo(
           UnresolvedAttribute("__auto_generated_subquery_name_l.uid"),
-          UnresolvedAttribute("__auto_generated_subquery_name_s.ID")),
+          UnresolvedAttribute("__auto_generated_subquery_name_s.id")),
+        EqualTo(
+          UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
+          UnresolvedAttribute("__auto_generated_subquery_name_s.name")))
+    val joinPlan = Join(sourceAlias, lookupProject, LeftOuter, Some(joinCondition), JoinHint.NONE)
+    val projectAfterJoin = Project(
+      Seq(
+        UnresolvedStar(Some(Seq("__auto_generated_subquery_name_s"))),
+        Alias(
+          UnresolvedAttribute("__auto_generated_subquery_name_l.department"),
+          "department")()),
+      joinPlan)
+    val dropColumns = DataFrameDropColumns(
+      Seq(
+        UnresolvedAttribute("uid"),
+        UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
+        UnresolvedAttribute("__auto_generated_subquery_name_s.department")),
+      projectAfterJoin)
+    val expectedPlan = Project(Seq(UnresolvedStar(None)), dropColumns)
+    val logicalPlan: LogicalPlan = frame.queryExecution.logical
+
+    comparePlans(expectedPlan, logicalPlan, checkAnalysis = false)
+  }
+
+  test("test LOOKUP lookupTable uid AS id, name APPEND department") {
+    val frame =
+      sql(s"source = $sourceTable| LOOKUP $lookupTable uid AS id, name APPEND department")
+    val expectedResults: Array[Row] = Array(
+      Row(1000, "Jake", "Engineer", "England", 100000, "IT"),
+      Row(1001, "Hello", "Artist", "USA", 70000, null),
+      Row(1002, "John", "Doctor", "Canada", 120000, "DATA"),
+      Row(1003, "David", "Doctor", null, 120000, "HR"),
+      Row(1004, "David", null, "Canada", 0, null),
+      Row(1005, "Jane", "Scientist", "Canada", 90000, "DATA"))
+    assertSameRows(expectedResults, frame)
+
+    val lookupProject =
+      Project(
+        Seq(
+          UnresolvedAttribute("department"),
+          UnresolvedAttribute("uid"),
+          UnresolvedAttribute("name")),
+        lookupAlias)
+    val joinCondition =
+      And(
+        EqualTo(
+          UnresolvedAttribute("__auto_generated_subquery_name_l.uid"),
+          UnresolvedAttribute("__auto_generated_subquery_name_s.id")),
         EqualTo(
           UnresolvedAttribute("__auto_generated_subquery_name_l.name"),
           UnresolvedAttribute("__auto_generated_subquery_name_s.name")))
@@ -296,7 +296,7 @@ class FlintSparkPPLLookupITSuite
   }
 
   test("test LOOKUP lookupTable uid AS id, name") {
-    val frame = sql(s"source = $sourceTable| LOOKUP $lookupTable uID AS id, name")
+    val frame = sql(s"source = $sourceTable| LOOKUP $lookupTable uid AS id, name")
     val expectedResults: Array[Row] = Array(
       Row(1000, "Jake", "England", 100000, "IT", "Engineer"),
       Row(1001, "Hello", "USA", 70000, null, null),

--- a/ppl-spark-integration/src/main/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLParser.scala
+++ b/ppl-spark-integration/src/main/scala/org/opensearch/flint/spark/ppl/FlintSparkPPLParser.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.parser._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructType}
 
 /**
@@ -57,6 +58,7 @@ class FlintSparkPPLParser(sparkParser: ParserInterface, val spark: SparkSession)
     try {
       // if successful build ppl logical plan and translate to catalyst logical plan
       val context = new CatalystPlanContext
+      spark.conf.set(SQLConf.CASE_SENSITIVE.key, value = true)
       context.withSparkSession(spark)
       planTransformer.visit(plan(pplParser, sqlText), context)
       context.getPlan


### PR DESCRIPTION
### Description
Fields identifier in PPL should be case sensitive which is aligning with OpenSearch PPL. Ref https://github.com/opensearch-project/opensearch-spark/issues/1146

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-spark/issues/1146

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [x] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
