### PR TITLE
Rewrote Integration Test for VPC, CloudTrail and WAF to test without fetching data from _source

### DIFF
--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationCloudTrailITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationCloudTrailITSuite.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.search.aggregations.AggregationBuilders
+import org.opensearch.search.aggregations.BucketOrder
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval
+import org.opensearch.search.builder.SearchSourceBuilder
+
+import org.apache.spark.sql.Row
+
+class FlintSparkMaterializedViewIntegrationCloudTrailITSuite
+    extends FlintSparkMaterializedViewIntegrationsITSuite {
+
+  val mvQueryCT: String = s"""
+                             |SELECT
+                             |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
+                             |  `userIdentity.type` AS `aws.cloudtrail.userIdentity.type`,
+                             |  `userIdentity.accountId` AS `aws.cloudtrail.userIdentity.accountId`,
+                             |  `userIdentity.sessionContext.sessionIssuer.userName` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.userName`,
+                             |  `userIdentity.sessionContext.sessionIssuer.arn` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.arn`,
+                             |  `userIdentity.sessionContext.sessionIssuer.type` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.type`,
+                             |  awsRegion AS `aws.cloudtrail.awsRegion`,
+                             |  sourceIPAddress AS `aws.cloudtrail.sourceIPAddress`,
+                             |  eventSource AS `aws.cloudtrail.eventSource`,
+                             |  eventName AS `aws.cloudtrail.eventName`,
+                             |  eventCategory AS `aws.cloudtrail.eventCategory`,
+                             |  COUNT(*) AS `aws.cloudtrail.event_count`
+                             |FROM (
+                             |  SELECT
+                             |    CAST(eventTime AS TIMESTAMP) AS `@timestamp`,
+                             |    userIdentity.`type` AS `userIdentity.type`,
+                             |    userIdentity.`accountId` AS `userIdentity.accountId`,
+                             |    userIdentity.sessionContext.sessionIssuer.userName AS `userIdentity.sessionContext.sessionIssuer.userName`,
+                             |    userIdentity.sessionContext.sessionIssuer.arn AS `userIdentity.sessionContext.sessionIssuer.arn`,
+                             |    userIdentity.sessionContext.sessionIssuer.type AS `userIdentity.sessionContext.sessionIssuer.type`,
+                             |    awsRegion,
+                             |    sourceIPAddress,
+                             |    eventSource,
+                             |    eventName,
+                             |    eventCategory
+                             |  FROM
+                             |    $catalogName.default.cloud_trail_test
+                             |)
+                             |GROUP BY
+                             |  TUMBLE(`@timestamp`, '5 Minute'),
+                             |  `userIdentity.type`,
+                             |  `userIdentity.accountId`,
+                             |  `userIdentity.sessionContext.sessionIssuer.userName`,
+                             |  `userIdentity.sessionContext.sessionIssuer.arn`,
+                             |  `userIdentity.sessionContext.sessionIssuer.type`,
+                             |  awsRegion,
+                             |  sourceIPAddress,
+                             |  eventSource,
+                             |  eventName,
+                             |  eventCategory
+                             |""".stripMargin
+
+  val dslQueryBuilderCTTimeSeriesChart: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
+    val dateHistogramAgg = AggregationBuilders
+      .dateHistogram("2")
+      .field("start_time")
+      .fixedInterval(DateHistogramInterval.seconds(30))
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.cloudtrail.event_count")
+
+    dateHistogramAgg.subAggregation(sumAgg)
+    builder.aggregation(dateHistogramAgg)
+
+    builder
+  }
+
+  val dslQueryBuilderCTPieChart: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
+    val termsAgg = AggregationBuilders
+      .terms("2")
+      .field("aws.cloudtrail.sourceIPAddress")
+      .order(BucketOrder.aggregation("1", false))
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.cloudtrail.event_count")
+
+    termsAgg.subAggregation(sumAgg)
+    builder.aggregation(termsAgg)
+
+    builder
+  }
+
+  val expectedBucketsCTTimeSeriesChart: Seq[Map[String, Any]] = Seq(
+    Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1))
+
+  val expectedBucketsCTPieChart: Seq[Map[String, Any]] = Seq(
+    Map("key" -> "198.51.100.45", "doc_count" -> 1))
+
+  test(
+    "create aggregated materialized view for CloudTrail integration unfiltered time series chart") {
+    withIntegration("cloud_trail") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.cloud_trail_test")
+        .createMaterializedView(mvQueryCT, sourceDisabled = true)
+        .assertDslQueryTimeSeriesChart(
+          dslQueryBuilderCTTimeSeriesChart,
+          expectedBucketsCTTimeSeriesChart)
+    }
+  }
+
+  test("create aggregated materialized view for CloudTrail integration unfiltered pie chart") {
+    withIntegration("cloud_trail") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.cloud_trail_test")
+        .createMaterializedView(mvQueryCT, sourceDisabled = true)
+        .assertDslQueryPieChart(dslQueryBuilderCTPieChart, expectedBucketsCTPieChart)
+    }
+  }
+
+  test("create aggregated materialized view for CloudTrail integration") {
+    withIntegration("cloud_trail") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.cloud_trail_test")
+        .createMaterializedView(mvQueryCT, sourceDisabled = false)
+        .assertIndexData(Row(
+          timestampFromUTC("2023-11-01T05:00:00Z"),
+          "IAMUser",
+          "123456789012",
+          "MyRole",
+          "arn:aws:iam::123456789012:role/MyRole",
+          "Role",
+          "us-east-1",
+          "198.51.100.45",
+          "sts.amazonaws.com",
+          "AssumeRole",
+          "Management",
+          1))
+    }
+  }
+}

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationVPCITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationVPCITSuite.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.search.aggregations.AggregationBuilders
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval
+import org.opensearch.search.builder.SearchSourceBuilder
+
+import org.apache.spark.sql.Row
+
+class FlintSparkMaterializedViewIntegrationVPCITSuite
+    extends FlintSparkMaterializedViewIntegrationsITSuite {
+
+  val mvQueryVPC: String = s"""
+                              |SELECT
+                              |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
+                              |  action AS `aws.vpc.action`,
+                              |  srcAddr AS `aws.vpc.srcaddr`,
+                              |  dstAddr AS `aws.vpc.dstaddr`,
+                              |  protocol AS `aws.vpc.protocol`,
+                              |  COUNT(*) AS `aws.vpc.total_count`,
+                              |  SUM(bytes) AS `aws.vpc.total_bytes`,
+                              |  SUM(packets) AS `aws.vpc.total_packets`
+                              |FROM (
+                              |  SELECT
+                              |    action,
+                              |    srcAddr,
+                              |    dstAddr,
+                              |    bytes,
+                              |    packets,
+                              |    protocol,
+                              |    CAST(FROM_UNIXTIME(start) AS TIMESTAMP) AS `@timestamp`
+                              |  FROM
+                              |    $catalogName.default.vpc_low_test
+                              |)
+                              |GROUP BY
+                              |  TUMBLE(`@timestamp`, '5 Minute'),
+                              |  action,
+                              |  srcAddr,
+                              |  dstAddr,
+                              |  protocol
+                              |""".stripMargin
+
+  val dslQueryBuilderVPCTimeSeriesChart: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
+    val dateHistogramAgg = AggregationBuilders
+      .dateHistogram("2")
+      .field("start_time")
+      .minDocCount(1)
+      .fixedInterval(DateHistogramInterval.minutes(5))
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.vpc.total_bytes")
+
+    dateHistogramAgg.subAggregation(sumAgg)
+    builder.aggregation(dateHistogramAgg)
+
+    builder
+  }
+
+  val dslQueryBuilderVPCPieChart: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
+    val termsAgg = AggregationBuilders.terms("2").field("aws.vpc.srcaddr")
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.vpc.total_bytes")
+
+    termsAgg.subAggregation(sumAgg)
+    builder.aggregation(termsAgg)
+
+    builder
+  }
+
+  val expectedBucketsVPCTimeSeriesChart: Seq[Map[String, Any]] = Seq(
+    Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1),
+    Map("key_as_string" -> "2023-11-01T05:10:00.000Z", "doc_count" -> 2))
+
+  val expectedBucketsVPCPieChart: Seq[Map[String, Any]] = Seq(
+    Map("key" -> "10.0.0.1", "doc_count" -> 1),
+    Map("key" -> "10.0.0.3", "doc_count" -> 1),
+    Map("key" -> "10.0.0.5", "doc_count" -> 1))
+
+  test(
+    "create aggregated materialized view for VPC flow integration unfiltered time series chart") {
+    withIntegration("vpc_flow") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.vpc_low_test")
+        .createMaterializedView(mvQueryVPC, sourceDisabled = true)
+        .assertDslQueryTimeSeriesChart(
+          dslQueryBuilderVPCTimeSeriesChart,
+          expectedBucketsVPCTimeSeriesChart)
+    }
+  }
+
+  test("create aggregated materialized view for VPC flow integration unfiltered pie chart") {
+    withIntegration("vpc_flow") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.vpc_low_test")
+        .createMaterializedView(mvQueryVPC, sourceDisabled = true)
+        .assertDslQueryPieChart(dslQueryBuilderVPCPieChart, expectedBucketsVPCPieChart)
+    }
+  }
+
+  test("create aggregated materialized view for VPC flow integration") {
+    withIntegration("vpc_flow") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.vpc_low_test")
+        .createMaterializedView(mvQueryVPC, sourceDisabled = false)
+        .assertIndexData(
+          Row(
+            timestampFromUTC("2023-11-01T05:00:00Z"),
+            "ACCEPT",
+            "10.0.0.1",
+            "10.0.0.2",
+            6,
+            2,
+            350.0,
+            15),
+          Row(
+            timestampFromUTC("2023-11-01T05:10:00Z"),
+            "ACCEPT",
+            "10.0.0.3",
+            "10.0.0.4",
+            6,
+            1,
+            300.0,
+            15),
+          Row(
+            timestampFromUTC("2023-11-01T05:10:00Z"),
+            "REJECT",
+            "10.0.0.5",
+            "10.0.0.6",
+            6,
+            1,
+            400.0,
+            20))
+    }
+  }
+}

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationWAFITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationWAFITSuite.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark
+
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.search.aggregations.AggregationBuilders
+import org.opensearch.search.aggregations.BucketOrder
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval
+import org.opensearch.search.builder.SearchSourceBuilder
+
+import org.apache.spark.sql.Row
+
+class FlintSparkMaterializedViewIntegrationWAFITSuite
+    extends FlintSparkMaterializedViewIntegrationsITSuite {
+
+  val mvQueryWAF: String = s"""
+                              |SELECT
+                              |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
+                              |  webaclId AS `aws.waf.webaclId`,
+                              |  action AS `aws.waf.action`,
+                              |  `httpRequest.clientIp` AS `aws.waf.httpRequest.clientIp`,
+                              |  `httpRequest.country` AS `aws.waf.httpRequest.country`,
+                              |  `httpRequest.uri` AS `aws.waf.httpRequest.uri`,
+                              |  `httpRequest.httpMethod` AS `aws.waf.httpRequest.httpMethod`,
+                              |  httpSourceId AS `aws.waf.httpSourceId`,
+                              |  terminatingRuleId AS `aws.waf.terminatingRuleId`,
+                              |  terminatingRuleType AS `aws.waf.RuleType`,
+                              |  `ruleGroupList.ruleId` AS `aws.waf.ruleGroupList.ruleId`,
+                              |  COUNT(*) AS `aws.waf.event_count`
+                              |FROM (
+                              |  SELECT
+                              |    CAST(FROM_UNIXTIME(`timestamp`/1000) AS TIMESTAMP) AS `@timestamp`,
+                              |    webaclId,
+                              |    action,
+                              |    httpRequest.clientIp AS `httpRequest.clientIp`,
+                              |    httpRequest.country AS `httpRequest.country`,
+                              |    httpRequest.uri AS `httpRequest.uri`,
+                              |    httpRequest.httpMethod AS `httpRequest.httpMethod`,
+                              |    httpSourceId,
+                              |    terminatingRuleId,
+                              |    terminatingRuleType,
+                              |    ruleGroupList.ruleId AS `ruleGroupList.ruleId`
+                              |  FROM
+                              |    $catalogName.default.waf_test
+                              |)
+                              |GROUP BY
+                              |  TUMBLE(`@timestamp`, '5 Minute'),
+                              |  webaclId,
+                              |  action,
+                              |  `httpRequest.clientIp`,
+                              |  `httpRequest.country`,
+                              |  `httpRequest.uri`,
+                              |  `httpRequest.httpMethod`,
+                              |  httpSourceId,
+                              |  terminatingRuleId,
+                              |  terminatingRuleType,
+                              |  `ruleGroupList.ruleId`
+                              |""".stripMargin
+
+  val dslQueryBuilderWAFTimeSeriesChart: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
+
+    val termsAgg = AggregationBuilders
+      .terms("2")
+      .field("aws.waf.action")
+      .size(5)
+      .order(BucketOrder.aggregation("1", false))
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.waf.event_count")
+
+    val dateHistogramAgg = AggregationBuilders
+      .dateHistogram("3")
+      .field("start_time")
+      .fixedInterval(new DateHistogramInterval("30s"))
+      .minDocCount(1)
+
+    val innerSumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.waf.event_count")
+
+    dateHistogramAgg.subAggregation(innerSumAgg)
+    termsAgg.subAggregation(sumAgg)
+    termsAgg.subAggregation(dateHistogramAgg)
+
+    builder.aggregation(termsAgg)
+
+    builder
+  }
+
+  val dslQueryBuilderWAFPieChart: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
+    val termsAgg = AggregationBuilders
+      .terms("2")
+      .field("aws.waf.httpRequest.clientIp")
+      .order(BucketOrder.aggregation("1", false))
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.waf.event_count")
+
+    termsAgg.subAggregation(sumAgg)
+    builder.aggregation(termsAgg)
+
+    builder
+  }
+
+  val expectedBucketsWAFTimeSeriesChart: Seq[Map[String, Any]] = Seq(
+    Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1))
+
+  val expectedBucketsWAFPieChart: Seq[Map[String, Any]] = Seq(
+    Map("key" -> "192.0.2.1", "doc_count" -> 1))
+
+  test("create aggregated materialized view for WAF integration unfiltered time series chart") {
+    withIntegration("waf") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.waf_test")
+        .createMaterializedView(mvQueryWAF, sourceDisabled = true)
+        .assertDslQueryWAFTimeSeriesChart(
+          dslQueryBuilderWAFTimeSeriesChart,
+          expectedBucketsWAFTimeSeriesChart)
+    }
+  }
+
+  test("create aggregated materialized view for WAF integration unfiltered pie chart") {
+    withIntegration("waf") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.waf_test")
+        .createMaterializedView(mvQueryWAF, sourceDisabled = true)
+        .assertDslQueryPieChart(dslQueryBuilderWAFPieChart, expectedBucketsWAFPieChart)
+    }
+  }
+
+  test("create aggregated materialized view for WAF integration") {
+    withIntegration("waf") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.waf_test")
+        .createMaterializedView(mvQueryWAF, sourceDisabled = false)
+        .assertIndexData(Row(
+          timestampFromUTC("2023-11-01T05:00:00Z"),
+          "webacl-12345",
+          "ALLOW",
+          "192.0.2.1",
+          "US",
+          "/index.html",
+          "GET",
+          "source-1",
+          "rule-1",
+          "REGULAR",
+          Array("group-rule-1"),
+          1))
+    }
+  }
+}

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
@@ -349,35 +349,9 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     deleteTestIndex("flint_spark_catalog_default_cloud_trail_mv_test")
   }
 
-  val dslQueryQueryWAFTSC: String =
-    """
-      |{
-      |    "bool": {
-      |      "filter": [
-      |        {
-      |          "match_all": {}
-      |        }
-      |      ]
-      |    }
-      |}
-      |""".stripMargin
-
-  val dslQueryQueryWAFPC: String =
-    """
-      |{
-      |    "bool": {
-      |      "filter": [
-      |        {
-      |          "match_all": {}
-      |        }
-      |      ]
-      |    }
-      |}
-      |""".stripMargin
-
   val dslQueryBuilderWAFTSC: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryQueryWAFTSC))
+      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
 
     // 1. Main terms aggregation
     val termsAgg = AggregationBuilders

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
@@ -179,7 +179,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       |    }
       |}
       |""".stripMargin
-  // TSC refers to time series chart
+
   val dslQueryBuilderVPCTimeSeriesChart: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
       .query(QueryBuilders.wrapperQuery(dslQueryString))
@@ -198,7 +198,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
 
     builder
   }
-  // PC refers to pie chart
+
   val dslQueryBuilderVPCPieChart: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
       .query(QueryBuilders.wrapperQuery(dslQueryString))

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
@@ -179,7 +179,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       |    }
       |}
       |""".stripMargin
-  //TSC refers to time series chart
+  // TSC refers to time series chart
   val dslQueryBuilderVPCTSC: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
       .query(QueryBuilders.wrapperQuery(dslQueryString))
@@ -198,7 +198,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
 
     builder
   }
-  //PC refers to pie chart
+  // PC refers to pie chart
   val dslQueryBuilderVPCPC: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
       .query(QueryBuilders.wrapperQuery(dslQueryString))

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
@@ -180,7 +180,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       |}
       |""".stripMargin
   // TSC refers to time series chart
-  val dslQueryBuilderVPCTSC: SearchSourceBuilder = {
+  val dslQueryBuilderVPCTimeSeriesChart: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
       .query(QueryBuilders.wrapperQuery(dslQueryString))
     val dateHistogramAgg = AggregationBuilders
@@ -199,7 +199,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     builder
   }
   // PC refers to pie chart
-  val dslQueryBuilderVPCPC: SearchSourceBuilder = {
+  val dslQueryBuilderVPCPieChart: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
       .query(QueryBuilders.wrapperQuery(dslQueryString))
     val termsAgg = AggregationBuilders.terms("2").field("aws.vpc.srcaddr")
@@ -214,11 +214,11 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     builder
   }
 
-  val expectedBucketsVPCTSC: Seq[Map[String, Any]] = Seq(
+  val expectedBucketsVPCTimeSeriesChart: Seq[Map[String, Any]] = Seq(
     Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1),
     Map("key_as_string" -> "2023-11-01T05:10:00.000Z", "doc_count" -> 2))
 
-  val expectedBucketsVPCPC: Seq[Map[String, Any]] = Seq(
+  val expectedBucketsVPCPieChart: Seq[Map[String, Any]] = Seq(
     Map("key" -> "10.0.0.1", "doc_count" -> 1),
     Map("key" -> "10.0.0.3", "doc_count" -> 1),
     Map("key" -> "10.0.0.5", "doc_count" -> 1))
@@ -229,7 +229,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       integration
         .createSourceTable(s"$catalogName.default.vpc_low_test")
         .createMaterializedView(mvQueryVPC, sourceDisabled = true)
-        .assertDslQueryTSC(dslQueryBuilderVPCTSC, expectedBucketsVPCTSC)
+        .assertDslQueryTSC(dslQueryBuilderVPCTimeSeriesChart, expectedBucketsVPCTimeSeriesChart)
     }
     deleteTestIndex("flint_spark_catalog_default_vpc_flow_mv_test")
   }
@@ -239,7 +239,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       integration
         .createSourceTable(s"$catalogName.default.vpc_low_test")
         .createMaterializedView(mvQueryVPC, sourceDisabled = true)
-        .assertDslQueryPC(dslQueryBuilderVPCPC, expectedBucketsVPCPC)
+        .assertDslQueryPC(dslQueryBuilderVPCPieChart, expectedBucketsVPCPieChart)
     }
     deleteTestIndex("flint_spark_catalog_default_vpc_flow_mv_test")
   }
@@ -281,7 +281,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     deleteTestIndex("flint_spark_catalog_default_vpc_flow_mv_test")
   }
 
-  val dslQueryBuilderCTTSC: SearchSourceBuilder = {
+  val dslQueryBuilderCTTimeSeriesChart: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
       .query(QueryBuilders.wrapperQuery(dslQueryString))
     val dateHistogramAgg = AggregationBuilders
@@ -299,7 +299,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     builder
   }
 
-  val dslQueryBuilderCTPC: SearchSourceBuilder = {
+  val dslQueryBuilderCTPieChart: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
       .query(QueryBuilders.wrapperQuery(dslQueryString))
     val termsAgg = AggregationBuilders
@@ -317,10 +317,10 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     builder
   }
 
-  val expectedBucketsCTTSC: Seq[Map[String, Any]] = Seq(
+  val expectedBucketsCTTimeSeriesChart: Seq[Map[String, Any]] = Seq(
     Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1))
 
-  val expectedBucketsCTPC: Seq[Map[String, Any]] = Seq(
+  val expectedBucketsCTPieChart: Seq[Map[String, Any]] = Seq(
     Map("key" -> "198.51.100.45", "doc_count" -> 1))
 
   test(
@@ -329,7 +329,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       integration
         .createSourceTable(s"$catalogName.default.cloud_trail_test")
         .createMaterializedView(mvQueryCT, sourceDisabled = true)
-        .assertDslQueryTSC(dslQueryBuilderCTTSC, expectedBucketsCTTSC)
+        .assertDslQueryTSC(dslQueryBuilderCTTimeSeriesChart, expectedBucketsCTTimeSeriesChart)
     }
     deleteTestIndex("flint_spark_catalog_default_cloud_trail_mv_test")
   }
@@ -339,12 +339,12 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       integration
         .createSourceTable(s"$catalogName.default.cloud_trail_test")
         .createMaterializedView(mvQueryCT, sourceDisabled = true)
-        .assertDslQueryPC(dslQueryBuilderCTPC, expectedBucketsCTPC)
+        .assertDslQueryPC(dslQueryBuilderCTPieChart, expectedBucketsCTPieChart)
     }
     deleteTestIndex("flint_spark_catalog_default_cloud_trail_mv_test")
   }
 
-  val dslQueryBuilderWAFTSC: SearchSourceBuilder = {
+  val dslQueryBuilderWAFTimeSeriesChart: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
       .query(QueryBuilders.wrapperQuery(dslQueryString))
 
@@ -377,7 +377,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     builder
   }
 
-  val dslQueryBuilderWAFPC: SearchSourceBuilder = {
+  val dslQueryBuilderWAFPieChart: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
       .query(QueryBuilders.wrapperQuery(dslQueryString))
     val termsAgg = AggregationBuilders
@@ -395,10 +395,10 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     builder
   }
 
-  val expectedBucketsWAFTSC: Seq[Map[String, Any]] = Seq(
+  val expectedBucketsWAFTimeSeriesChart: Seq[Map[String, Any]] = Seq(
     Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1))
 
-  val expectedBucketsWAFPC: Seq[Map[String, Any]] = Seq(
+  val expectedBucketsWAFPieChart: Seq[Map[String, Any]] = Seq(
     Map("key" -> "192.0.2.1", "doc_count" -> 1))
 
   test("create aggregated materialized view for WAF integration unfiltered time series chart") {
@@ -406,7 +406,9 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       integration
         .createSourceTable(s"$catalogName.default.waf_test")
         .createMaterializedView(mvQueryWAF, sourceDisabled = true)
-        .assertDslQueryWAFTSC(dslQueryBuilderWAFTSC, expectedBucketsWAFTSC)
+        .assertDslQueryWAFTSC(
+          dslQueryBuilderWAFTimeSeriesChart,
+          expectedBucketsWAFTimeSeriesChart)
     }
     deleteTestIndex("flint_spark_catalog_default_waf_mv_test")
   }
@@ -416,7 +418,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       integration
         .createSourceTable(s"$catalogName.default.waf_test")
         .createMaterializedView(mvQueryWAF, sourceDisabled = true)
-        .assertDslQueryPC(dslQueryBuilderWAFPC, expectedBucketsWAFPC)
+        .assertDslQueryPC(dslQueryBuilderWAFPieChart, expectedBucketsWAFPieChart)
     }
     deleteTestIndex("flint_spark_catalog_default_waf_mv_test")
   }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
@@ -223,6 +223,11 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     Map("key" -> "10.0.0.3", "doc_count" -> 1),
     Map("key" -> "10.0.0.5", "doc_count" -> 1))
 
+  def afterEach(testIndex: String): Unit = {
+    super.afterEach()
+    deleteTestIndex(testIndex)
+  }
+
   test(
     "create aggregated materialized view for VPC flow integration unfiltered time series chart") {
     withIntegration("vpc_flow") { integration =>
@@ -231,6 +236,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
         .createMaterializedView(mvQueryVPC, sourceDisabled = true)
         .assertDslQueryTSC(dslQueryBuilderVPCTSC, expectedBucketsVPCTSC)
     }
+    deleteTestIndex("flint_spark_catalog_default_vpc_flow_mv_test")
   }
 
   test("create aggregated materialized view for VPC flow integration unfiltered pie chart") {
@@ -240,6 +246,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
         .createMaterializedView(mvQueryVPC, sourceDisabled = true)
         .assertDslQueryPC(dslQueryBuilderVPCPC, expectedBucketsVPCPC)
     }
+    deleteTestIndex("flint_spark_catalog_default_vpc_flow_mv_test")
   }
 
   test("create aggregated materialized view for VPC flow integration") {
@@ -276,6 +283,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
             400.0,
             20))
     }
+    deleteTestIndex("flint_spark_catalog_default_vpc_flow_mv_test")
   }
 
   val dslQueryBuilderCTTSC: SearchSourceBuilder = {
@@ -328,6 +336,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
         .createMaterializedView(mvQueryCT, sourceDisabled = true)
         .assertDslQueryTSC(dslQueryBuilderCTTSC, expectedBucketsCTTSC)
     }
+    deleteTestIndex("flint_spark_catalog_default_cloud_trail_mv_test")
   }
 
   test("create aggregated materialized view for CloudTrail integration unfiltered pie chart") {
@@ -337,6 +346,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
         .createMaterializedView(mvQueryCT, sourceDisabled = true)
         .assertDslQueryPC(dslQueryBuilderCTPC, expectedBucketsCTPC)
     }
+    deleteTestIndex("flint_spark_catalog_default_cloud_trail_mv_test")
   }
 
   val dslQueryQueryWAFTSC: String =
@@ -435,6 +445,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
         .createMaterializedView(mvQueryWAF, sourceDisabled = true)
         .assertDslQueryWAFTSC(dslQueryBuilderWAFTSC, expectedBucketsWAFTSC)
     }
+    deleteTestIndex("flint_spark_catalog_default_waf_mv_test")
   }
 
   test("create aggregated materialized view for WAF integration unfiltered pie chart") {
@@ -444,6 +455,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
         .createMaterializedView(mvQueryWAF, sourceDisabled = true)
         .assertDslQueryPC(dslQueryBuilderWAFPC, expectedBucketsWAFPC)
     }
+    deleteTestIndex("flint_spark_catalog_default_waf_mv_test")
   }
 
   test("create aggregated materialized view for CloudTrail integration") {
@@ -465,6 +477,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
           "Management",
           1))
     }
+    deleteTestIndex("flint_spark_catalog_default_cloud_trail_mv_test")
   }
 
   test("create aggregated materialized view for WAF integration") {
@@ -486,6 +499,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
           Array("group-rule-1"),
           1))
     }
+    deleteTestIndex("flint_spark_catalog_default_waf_mv_test")
   }
 
   /**

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
@@ -167,7 +167,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
                               |  `ruleGroupList.ruleId`
                               |""".stripMargin
 
-  val dslQueryQuery: String =
+  val dslQueryString: String =
     """
       |{
       |    "bool": {
@@ -179,10 +179,10 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       |    }
       |}
       |""".stripMargin
-
+  //TSC refers to time series chart
   val dslQueryBuilderVPCTSC: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
     val dateHistogramAgg = AggregationBuilders
       .dateHistogram("2")
       .field("start_time")
@@ -198,10 +198,10 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
 
     builder
   }
-
+  //PC refers to pie chart
   val dslQueryBuilderVPCPC: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
     val termsAgg = AggregationBuilders.terms("2").field("aws.vpc.srcaddr")
 
     val sumAgg = AggregationBuilders
@@ -222,11 +222,6 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     Map("key" -> "10.0.0.1", "doc_count" -> 1),
     Map("key" -> "10.0.0.3", "doc_count" -> 1),
     Map("key" -> "10.0.0.5", "doc_count" -> 1))
-
-  def afterEach(testIndex: String): Unit = {
-    super.afterEach()
-    deleteTestIndex(testIndex)
-  }
 
   test(
     "create aggregated materialized view for VPC flow integration unfiltered time series chart") {
@@ -288,7 +283,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
 
   val dslQueryBuilderCTTSC: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
     val dateHistogramAgg = AggregationBuilders
       .dateHistogram("2")
       .field("start_time")
@@ -306,7 +301,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
 
   val dslQueryBuilderCTPC: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
     val termsAgg = AggregationBuilders
       .terms("2")
       .field("aws.cloudtrail.sourceIPAddress")
@@ -351,7 +346,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
 
   val dslQueryBuilderWAFTSC: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
 
     val termsAgg = AggregationBuilders
       .terms("2")
@@ -384,7 +379,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
 
   val dslQueryBuilderWAFPC: SearchSourceBuilder = {
     val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+      .query(QueryBuilders.wrapperQuery(dslQueryString))
     val termsAgg = AggregationBuilders
       .terms("2")
       .field("aws.waf.httpRequest.clientIp")

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
@@ -15,9 +15,7 @@ import scala.jdk.CollectionConverters.asScalaBufferConverter
 import org.opensearch.action.search.SearchRequest
 import org.opensearch.client.RequestOptions
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.getFlintIndexName
-import org.opensearch.index.query.QueryBuilders
-import org.opensearch.search.aggregations.{AggregationBuilders, BucketOrder}
-import org.opensearch.search.aggregations.bucket.histogram.{DateHistogramInterval, ParsedDateHistogram}
+import org.opensearch.search.aggregations.bucket.histogram.ParsedDateHistogram
 import org.opensearch.search.aggregations.bucket.terms.ParsedStringTerms
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.scalatest.matchers.should.Matchers
@@ -27,145 +25,11 @@ import org.apache.spark.sql.catalyst.util.resourceToString
 import org.apache.spark.sql.flint.FlintDataSourceV2.FLINT_DATASOURCE
 
 /**
- * A sanity test for verifying Observability Integration dashboard with Flint MV. The
- * integration_name is used to load the corresponding SQL statement from the resource folder.
- *
- * Example:
- * {{{
- * test("create aggregated materialized view for {integration_name} integration") {
- *   withIntegration("{integration_name}") { integration =>
- *     integration
- *       .createSourceTable("catalog.default.{integration_name}_test")
- *       .createMaterializedView(
- *         s"""
- *            |SELECT ...
- *            |FROM ...
- *            |GROUP BY ...
- *            |""".stripMargin)
- *       .assertIndexData(...)
- *   }
- * }
- * }}}
+ * Base class for AWS integrations with Flint Materialized Views.
  */
-class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with Matchers {
-
-  val mvQueryVPC: String = s"""
-                              |SELECT
-                              |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
-                              |  action AS `aws.vpc.action`,
-                              |  srcAddr AS `aws.vpc.srcaddr`,
-                              |  dstAddr AS `aws.vpc.dstaddr`,
-                              |  protocol AS `aws.vpc.protocol`,
-                              |  COUNT(*) AS `aws.vpc.total_count`,
-                              |  SUM(bytes) AS `aws.vpc.total_bytes`,
-                              |  SUM(packets) AS `aws.vpc.total_packets`
-                              |FROM (
-                              |  SELECT
-                              |    action,
-                              |    srcAddr,
-                              |    dstAddr,
-                              |    bytes,
-                              |    packets,
-                              |    protocol,
-                              |    CAST(FROM_UNIXTIME(start) AS TIMESTAMP) AS `@timestamp`
-                              |  FROM
-                              |    $catalogName.default.vpc_low_test
-                              |)
-                              |GROUP BY
-                              |  TUMBLE(`@timestamp`, '5 Minute'),
-                              |  action,
-                              |  srcAddr,
-                              |  dstAddr,
-                              |  protocol
-                              |""".stripMargin
-
-  val mvQueryCT: String = s"""
-                             |SELECT
-                             |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
-                             |  `userIdentity.type` AS `aws.cloudtrail.userIdentity.type`,
-                             |  `userIdentity.accountId` AS `aws.cloudtrail.userIdentity.accountId`,
-                             |  `userIdentity.sessionContext.sessionIssuer.userName` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.userName`,
-                             |  `userIdentity.sessionContext.sessionIssuer.arn` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.arn`,
-                             |  `userIdentity.sessionContext.sessionIssuer.type` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.type`,
-                             |  awsRegion AS `aws.cloudtrail.awsRegion`,
-                             |  sourceIPAddress AS `aws.cloudtrail.sourceIPAddress`,
-                             |  eventSource AS `aws.cloudtrail.eventSource`,
-                             |  eventName AS `aws.cloudtrail.eventName`,
-                             |  eventCategory AS `aws.cloudtrail.eventCategory`,
-                             |  COUNT(*) AS `aws.cloudtrail.event_count`
-                             |FROM (
-                             |  SELECT
-                             |    CAST(eventTime AS TIMESTAMP) AS `@timestamp`,
-                             |    userIdentity.`type` AS `userIdentity.type`,
-                             |    userIdentity.`accountId` AS `userIdentity.accountId`,
-                             |    userIdentity.sessionContext.sessionIssuer.userName AS `userIdentity.sessionContext.sessionIssuer.userName`,
-                             |    userIdentity.sessionContext.sessionIssuer.arn AS `userIdentity.sessionContext.sessionIssuer.arn`,
-                             |    userIdentity.sessionContext.sessionIssuer.type AS `userIdentity.sessionContext.sessionIssuer.type`,
-                             |    awsRegion,
-                             |    sourceIPAddress,
-                             |    eventSource,
-                             |    eventName,
-                             |    eventCategory
-                             |  FROM
-                             |    $catalogName.default.cloud_trail_test
-                             |)
-                             |GROUP BY
-                             |  TUMBLE(`@timestamp`, '5 Minute'),
-                             |  `userIdentity.type`,
-                             |  `userIdentity.accountId`,
-                             |  `userIdentity.sessionContext.sessionIssuer.userName`,
-                             |  `userIdentity.sessionContext.sessionIssuer.arn`,
-                             |  `userIdentity.sessionContext.sessionIssuer.type`,
-                             |  awsRegion,
-                             |  sourceIPAddress,
-                             |  eventSource,
-                             |  eventName,
-                             |  eventCategory
-                             |""".stripMargin
-
-  val mvQueryWAF: String = s"""
-                              |SELECT
-                              |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
-                              |  webaclId AS `aws.waf.webaclId`,
-                              |  action AS `aws.waf.action`,
-                              |  `httpRequest.clientIp` AS `aws.waf.httpRequest.clientIp`,
-                              |  `httpRequest.country` AS `aws.waf.httpRequest.country`,
-                              |  `httpRequest.uri` AS `aws.waf.httpRequest.uri`,
-                              |  `httpRequest.httpMethod` AS `aws.waf.httpRequest.httpMethod`,
-                              |  httpSourceId AS `aws.waf.httpSourceId`,
-                              |  terminatingRuleId AS `aws.waf.terminatingRuleId`,
-                              |  terminatingRuleType AS `aws.waf.RuleType`,
-                              |  `ruleGroupList.ruleId` AS `aws.waf.ruleGroupList.ruleId`,
-                              |  COUNT(*) AS `aws.waf.event_count`
-                              |FROM (
-                              |  SELECT
-                              |    CAST(FROM_UNIXTIME(`timestamp`/1000) AS TIMESTAMP) AS `@timestamp`,
-                              |    webaclId,
-                              |    action,
-                              |    httpRequest.clientIp AS `httpRequest.clientIp`,
-                              |    httpRequest.country AS `httpRequest.country`,
-                              |    httpRequest.uri AS `httpRequest.uri`,
-                              |    httpRequest.httpMethod AS `httpRequest.httpMethod`,
-                              |    httpSourceId,
-                              |    terminatingRuleId,
-                              |    terminatingRuleType,
-                              |    ruleGroupList.ruleId AS `ruleGroupList.ruleId`
-                              |  FROM
-                              |    $catalogName.default.waf_test
-                              |)
-                              |GROUP BY
-                              |  TUMBLE(`@timestamp`, '5 Minute'),
-                              |  webaclId,
-                              |  action,
-                              |  `httpRequest.clientIp`,
-                              |  `httpRequest.country`,
-                              |  `httpRequest.uri`,
-                              |  `httpRequest.httpMethod`,
-                              |  httpSourceId,
-                              |  terminatingRuleId,
-                              |  terminatingRuleType,
-                              |  `ruleGroupList.ruleId`
-                              |""".stripMargin
+abstract class FlintSparkMaterializedViewIntegrationsITSuite
+    extends FlintSparkSuite
+    with Matchers {
 
   val dslQueryString: String =
     """
@@ -180,298 +44,8 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       |}
       |""".stripMargin
 
-  val dslQueryBuilderVPCTimeSeriesChart: SearchSourceBuilder = {
-    val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryString))
-    val dateHistogramAgg = AggregationBuilders
-      .dateHistogram("2")
-      .field("start_time")
-      .minDocCount(1)
-      .fixedInterval(DateHistogramInterval.minutes(5))
-
-    val sumAgg = AggregationBuilders
-      .sum("1")
-      .field("aws.vpc.total_bytes")
-
-    dateHistogramAgg.subAggregation(sumAgg)
-    builder.aggregation(dateHistogramAgg)
-
-    builder
-  }
-
-  val dslQueryBuilderVPCPieChart: SearchSourceBuilder = {
-    val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryString))
-    val termsAgg = AggregationBuilders.terms("2").field("aws.vpc.srcaddr")
-
-    val sumAgg = AggregationBuilders
-      .sum("1")
-      .field("aws.vpc.total_bytes")
-
-    termsAgg.subAggregation(sumAgg)
-    builder.aggregation(termsAgg)
-
-    builder
-  }
-
-  val expectedBucketsVPCTimeSeriesChart: Seq[Map[String, Any]] = Seq(
-    Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1),
-    Map("key_as_string" -> "2023-11-01T05:10:00.000Z", "doc_count" -> 2))
-
-  val expectedBucketsVPCPieChart: Seq[Map[String, Any]] = Seq(
-    Map("key" -> "10.0.0.1", "doc_count" -> 1),
-    Map("key" -> "10.0.0.3", "doc_count" -> 1),
-    Map("key" -> "10.0.0.5", "doc_count" -> 1))
-
-  test(
-    "create aggregated materialized view for VPC flow integration unfiltered time series chart") {
-    withIntegration("vpc_flow") { integration =>
-      integration
-        .createSourceTable(s"$catalogName.default.vpc_low_test")
-        .createMaterializedView(mvQueryVPC, sourceDisabled = true)
-        .assertDslQueryTSC(dslQueryBuilderVPCTimeSeriesChart, expectedBucketsVPCTimeSeriesChart)
-    }
-    deleteTestIndex("flint_spark_catalog_default_vpc_flow_mv_test")
-  }
-
-  test("create aggregated materialized view for VPC flow integration unfiltered pie chart") {
-    withIntegration("vpc_flow") { integration =>
-      integration
-        .createSourceTable(s"$catalogName.default.vpc_low_test")
-        .createMaterializedView(mvQueryVPC, sourceDisabled = true)
-        .assertDslQueryPC(dslQueryBuilderVPCPieChart, expectedBucketsVPCPieChart)
-    }
-    deleteTestIndex("flint_spark_catalog_default_vpc_flow_mv_test")
-  }
-
-  test("create aggregated materialized view for VPC flow integration") {
-    withIntegration("vpc_flow") { integration =>
-      integration
-        .createSourceTable(s"$catalogName.default.vpc_low_test")
-        .createMaterializedView(mvQueryVPC, sourceDisabled = false)
-        .assertIndexData(
-          Row(
-            timestampFromUTC("2023-11-01T05:00:00Z"),
-            "ACCEPT",
-            "10.0.0.1",
-            "10.0.0.2",
-            6,
-            2,
-            350.0,
-            15),
-          Row(
-            timestampFromUTC("2023-11-01T05:10:00Z"),
-            "ACCEPT",
-            "10.0.0.3",
-            "10.0.0.4",
-            6,
-            1,
-            300.0,
-            15),
-          Row(
-            timestampFromUTC("2023-11-01T05:10:00Z"),
-            "REJECT",
-            "10.0.0.5",
-            "10.0.0.6",
-            6,
-            1,
-            400.0,
-            20))
-    }
-    deleteTestIndex("flint_spark_catalog_default_vpc_flow_mv_test")
-  }
-
-  val dslQueryBuilderCTTimeSeriesChart: SearchSourceBuilder = {
-    val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryString))
-    val dateHistogramAgg = AggregationBuilders
-      .dateHistogram("2")
-      .field("start_time")
-      .fixedInterval(DateHistogramInterval.seconds(30))
-
-    val sumAgg = AggregationBuilders
-      .sum("1")
-      .field("aws.cloudtrail.event_count")
-
-    dateHistogramAgg.subAggregation(sumAgg)
-    builder.aggregation(dateHistogramAgg)
-
-    builder
-  }
-
-  val dslQueryBuilderCTPieChart: SearchSourceBuilder = {
-    val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryString))
-    val termsAgg = AggregationBuilders
-      .terms("2")
-      .field("aws.cloudtrail.sourceIPAddress")
-      .order(BucketOrder.aggregation("1", false))
-
-    val sumAgg = AggregationBuilders
-      .sum("1")
-      .field("aws.cloudtrail.event_count")
-
-    termsAgg.subAggregation(sumAgg)
-    builder.aggregation(termsAgg)
-
-    builder
-  }
-
-  val expectedBucketsCTTimeSeriesChart: Seq[Map[String, Any]] = Seq(
-    Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1))
-
-  val expectedBucketsCTPieChart: Seq[Map[String, Any]] = Seq(
-    Map("key" -> "198.51.100.45", "doc_count" -> 1))
-
-  test(
-    "create aggregated materialized view for CloudTrail integration unfiltered time series chart") {
-    withIntegration("cloud_trail") { integration =>
-      integration
-        .createSourceTable(s"$catalogName.default.cloud_trail_test")
-        .createMaterializedView(mvQueryCT, sourceDisabled = true)
-        .assertDslQueryTSC(dslQueryBuilderCTTimeSeriesChart, expectedBucketsCTTimeSeriesChart)
-    }
-    deleteTestIndex("flint_spark_catalog_default_cloud_trail_mv_test")
-  }
-
-  test("create aggregated materialized view for CloudTrail integration unfiltered pie chart") {
-    withIntegration("cloud_trail") { integration =>
-      integration
-        .createSourceTable(s"$catalogName.default.cloud_trail_test")
-        .createMaterializedView(mvQueryCT, sourceDisabled = true)
-        .assertDslQueryPC(dslQueryBuilderCTPieChart, expectedBucketsCTPieChart)
-    }
-    deleteTestIndex("flint_spark_catalog_default_cloud_trail_mv_test")
-  }
-
-  val dslQueryBuilderWAFTimeSeriesChart: SearchSourceBuilder = {
-    val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryString))
-
-    val termsAgg = AggregationBuilders
-      .terms("2")
-      .field("aws.waf.action")
-      .size(5)
-      .order(BucketOrder.aggregation("1", false))
-
-    val sumAgg = AggregationBuilders
-      .sum("1")
-      .field("aws.waf.event_count")
-
-    val dateHistogramAgg = AggregationBuilders
-      .dateHistogram("3")
-      .field("start_time")
-      .fixedInterval(new DateHistogramInterval("30s"))
-      .minDocCount(1)
-
-    val innerSumAgg = AggregationBuilders
-      .sum("1")
-      .field("aws.waf.event_count")
-
-    dateHistogramAgg.subAggregation(innerSumAgg)
-    termsAgg.subAggregation(sumAgg)
-    termsAgg.subAggregation(dateHistogramAgg)
-
-    builder.aggregation(termsAgg)
-
-    builder
-  }
-
-  val dslQueryBuilderWAFPieChart: SearchSourceBuilder = {
-    val builder = new SearchSourceBuilder()
-      .query(QueryBuilders.wrapperQuery(dslQueryString))
-    val termsAgg = AggregationBuilders
-      .terms("2")
-      .field("aws.waf.httpRequest.clientIp")
-      .order(BucketOrder.aggregation("1", false))
-
-    val sumAgg = AggregationBuilders
-      .sum("1")
-      .field("aws.waf.event_count")
-
-    termsAgg.subAggregation(sumAgg)
-    builder.aggregation(termsAgg)
-
-    builder
-  }
-
-  val expectedBucketsWAFTimeSeriesChart: Seq[Map[String, Any]] = Seq(
-    Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1))
-
-  val expectedBucketsWAFPieChart: Seq[Map[String, Any]] = Seq(
-    Map("key" -> "192.0.2.1", "doc_count" -> 1))
-
-  test("create aggregated materialized view for WAF integration unfiltered time series chart") {
-    withIntegration("waf") { integration =>
-      integration
-        .createSourceTable(s"$catalogName.default.waf_test")
-        .createMaterializedView(mvQueryWAF, sourceDisabled = true)
-        .assertDslQueryWAFTSC(
-          dslQueryBuilderWAFTimeSeriesChart,
-          expectedBucketsWAFTimeSeriesChart)
-    }
-    deleteTestIndex("flint_spark_catalog_default_waf_mv_test")
-  }
-
-  test("create aggregated materialized view for WAF integration unfiltered pie chart") {
-    withIntegration("waf") { integration =>
-      integration
-        .createSourceTable(s"$catalogName.default.waf_test")
-        .createMaterializedView(mvQueryWAF, sourceDisabled = true)
-        .assertDslQueryPC(dslQueryBuilderWAFPieChart, expectedBucketsWAFPieChart)
-    }
-    deleteTestIndex("flint_spark_catalog_default_waf_mv_test")
-  }
-
-  test("create aggregated materialized view for CloudTrail integration") {
-    withIntegration("cloud_trail") { integration =>
-      integration
-        .createSourceTable(s"$catalogName.default.cloud_trail_test")
-        .createMaterializedView(mvQueryCT, sourceDisabled = false)
-        .assertIndexData(Row(
-          timestampFromUTC("2023-11-01T05:00:00Z"),
-          "IAMUser",
-          "123456789012",
-          "MyRole",
-          "arn:aws:iam::123456789012:role/MyRole",
-          "Role",
-          "us-east-1",
-          "198.51.100.45",
-          "sts.amazonaws.com",
-          "AssumeRole",
-          "Management",
-          1))
-    }
-    deleteTestIndex("flint_spark_catalog_default_cloud_trail_mv_test")
-  }
-
-  test("create aggregated materialized view for WAF integration") {
-    withIntegration("waf") { integration =>
-      integration
-        .createSourceTable(s"$catalogName.default.waf_test")
-        .createMaterializedView(mvQueryWAF, sourceDisabled = false)
-        .assertIndexData(Row(
-          timestampFromUTC("2023-11-01T05:00:00Z"),
-          "webacl-12345",
-          "ALLOW",
-          "192.0.2.1",
-          "US",
-          "/index.html",
-          "GET",
-          "source-1",
-          "rule-1",
-          "REGULAR",
-          Array("group-rule-1"),
-          1))
-    }
-    deleteTestIndex("flint_spark_catalog_default_waf_mv_test")
-  }
-
   /**
-   * Executes a block of code within the context of a specific integration test. This method sets
-   * up the required temporary directory and passes an `IntegrationHelper` instance to the code
-   * block to facilitate actions like creating source tables, materialized views, and asserting
-   * results.
+   * Executes a block of code within the context of a specific integration test.
    *
    * @param name
    *   the name of the integration (e.g., "waf", "cloud_trail")
@@ -485,6 +59,10 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
         codeBlock(integration)
       } finally {
         sql(s"DROP TABLE ${integration.tableName}")
+        val indexName = integration.getIndexName
+        if (indexName != null) {
+          deleteTestIndex(indexName)
+        }
       }
     }
   }
@@ -492,16 +70,19 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
   /**
    * A helper class to facilitate actions like creating source tables, materialized views, and
    * asserting results.
-   *
-   * @param integrationName
-   *   the name of the integration (e.g., "waf", "cloud_trail")
-   * @param checkpointDir
-   *   the directory for Spark Streaming checkpointing
    */
   class IntegrationHelper(integrationName: String, checkpointDir: File) {
     var tableName: String = _
     private var mvName: String = _
     private var mvQuery: String = _
+
+    def getIndexName: String = {
+      if (mvName != null) {
+        org.opensearch.flint.spark.mv.FlintSparkMaterializedView.getFlintIndexName(mvName)
+      } else {
+        null
+      }
+    }
 
     def createSourceTable(tableName: String): IntegrationHelper = {
       this.tableName = tableName
@@ -570,7 +151,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       checkAnswer(actualRows, expectedRows)
     }
 
-    def assertDslQueryTSC(
+    def assertDslQueryTimeSeriesChart(
         dslQueryTSC: SearchSourceBuilder,
         expectedBuckets: Seq[Map[String, Any]]): Unit = {
       val flintIndexName =
@@ -591,7 +172,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       actualBuckets should equal(expectedBuckets)
     }
 
-    def assertDslQueryWAFTSC(
+    def assertDslQueryWAFTimeSeriesChart(
         dslQueryTSC: SearchSourceBuilder,
         expectedBuckets: Seq[Map[String, Any]]): Unit = {
       val flintIndexName =
@@ -618,7 +199,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       actualBuckets should equal(expectedBuckets)
     }
 
-    def assertDslQueryPC(
+    def assertDslQueryPieChart(
         dslQueryBuilder: SearchSourceBuilder,
         expectedBuckets: Seq[Map[String, Any]]): Unit = {
       val flintIndexName =
@@ -637,11 +218,10 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       }
 
       actualBuckets should equal(expectedBuckets)
-
     }
   }
 
-  private def timestampFromUTC(utcString: String): Timestamp = {
+  protected def timestampFromUTC(utcString: String): Timestamp = {
     val instant = ZonedDateTime.parse(utcString, DateTimeFormatter.ISO_DATE_TIME).toInstant
     Timestamp.from(instant)
   }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/FlintSparkMaterializedViewIntegrationsITSuite.scala
@@ -10,7 +10,16 @@ import java.sql.Timestamp
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
+import scala.jdk.CollectionConverters.asScalaBufferConverter
+
+import org.opensearch.action.search.SearchRequest
+import org.opensearch.client.RequestOptions
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.getFlintIndexName
+import org.opensearch.index.query.QueryBuilders
+import org.opensearch.search.aggregations.{AggregationBuilders, BucketOrder}
+import org.opensearch.search.aggregations.bucket.histogram.{DateHistogramInterval, ParsedDateHistogram}
+import org.opensearch.search.aggregations.bucket.terms.ParsedStringTerms
+import org.opensearch.search.builder.SearchSourceBuilder
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.sql.Row
@@ -40,39 +49,204 @@ import org.apache.spark.sql.flint.FlintDataSourceV2.FLINT_DATASOURCE
  */
 class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with Matchers {
 
+  val mvQueryVPC: String = s"""
+                              |SELECT
+                              |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
+                              |  action AS `aws.vpc.action`,
+                              |  srcAddr AS `aws.vpc.srcaddr`,
+                              |  dstAddr AS `aws.vpc.dstaddr`,
+                              |  protocol AS `aws.vpc.protocol`,
+                              |  COUNT(*) AS `aws.vpc.total_count`,
+                              |  SUM(bytes) AS `aws.vpc.total_bytes`,
+                              |  SUM(packets) AS `aws.vpc.total_packets`
+                              |FROM (
+                              |  SELECT
+                              |    action,
+                              |    srcAddr,
+                              |    dstAddr,
+                              |    bytes,
+                              |    packets,
+                              |    protocol,
+                              |    CAST(FROM_UNIXTIME(start) AS TIMESTAMP) AS `@timestamp`
+                              |  FROM
+                              |    $catalogName.default.vpc_low_test
+                              |)
+                              |GROUP BY
+                              |  TUMBLE(`@timestamp`, '5 Minute'),
+                              |  action,
+                              |  srcAddr,
+                              |  dstAddr,
+                              |  protocol
+                              |""".stripMargin
+
+  val mvQueryCT: String = s"""
+                             |SELECT
+                             |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
+                             |  `userIdentity.type` AS `aws.cloudtrail.userIdentity.type`,
+                             |  `userIdentity.accountId` AS `aws.cloudtrail.userIdentity.accountId`,
+                             |  `userIdentity.sessionContext.sessionIssuer.userName` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.userName`,
+                             |  `userIdentity.sessionContext.sessionIssuer.arn` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.arn`,
+                             |  `userIdentity.sessionContext.sessionIssuer.type` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.type`,
+                             |  awsRegion AS `aws.cloudtrail.awsRegion`,
+                             |  sourceIPAddress AS `aws.cloudtrail.sourceIPAddress`,
+                             |  eventSource AS `aws.cloudtrail.eventSource`,
+                             |  eventName AS `aws.cloudtrail.eventName`,
+                             |  eventCategory AS `aws.cloudtrail.eventCategory`,
+                             |  COUNT(*) AS `aws.cloudtrail.event_count`
+                             |FROM (
+                             |  SELECT
+                             |    CAST(eventTime AS TIMESTAMP) AS `@timestamp`,
+                             |    userIdentity.`type` AS `userIdentity.type`,
+                             |    userIdentity.`accountId` AS `userIdentity.accountId`,
+                             |    userIdentity.sessionContext.sessionIssuer.userName AS `userIdentity.sessionContext.sessionIssuer.userName`,
+                             |    userIdentity.sessionContext.sessionIssuer.arn AS `userIdentity.sessionContext.sessionIssuer.arn`,
+                             |    userIdentity.sessionContext.sessionIssuer.type AS `userIdentity.sessionContext.sessionIssuer.type`,
+                             |    awsRegion,
+                             |    sourceIPAddress,
+                             |    eventSource,
+                             |    eventName,
+                             |    eventCategory
+                             |  FROM
+                             |    $catalogName.default.cloud_trail_test
+                             |)
+                             |GROUP BY
+                             |  TUMBLE(`@timestamp`, '5 Minute'),
+                             |  `userIdentity.type`,
+                             |  `userIdentity.accountId`,
+                             |  `userIdentity.sessionContext.sessionIssuer.userName`,
+                             |  `userIdentity.sessionContext.sessionIssuer.arn`,
+                             |  `userIdentity.sessionContext.sessionIssuer.type`,
+                             |  awsRegion,
+                             |  sourceIPAddress,
+                             |  eventSource,
+                             |  eventName,
+                             |  eventCategory
+                             |""".stripMargin
+
+  val mvQueryWAF: String = s"""
+                              |SELECT
+                              |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
+                              |  webaclId AS `aws.waf.webaclId`,
+                              |  action AS `aws.waf.action`,
+                              |  `httpRequest.clientIp` AS `aws.waf.httpRequest.clientIp`,
+                              |  `httpRequest.country` AS `aws.waf.httpRequest.country`,
+                              |  `httpRequest.uri` AS `aws.waf.httpRequest.uri`,
+                              |  `httpRequest.httpMethod` AS `aws.waf.httpRequest.httpMethod`,
+                              |  httpSourceId AS `aws.waf.httpSourceId`,
+                              |  terminatingRuleId AS `aws.waf.terminatingRuleId`,
+                              |  terminatingRuleType AS `aws.waf.RuleType`,
+                              |  `ruleGroupList.ruleId` AS `aws.waf.ruleGroupList.ruleId`,
+                              |  COUNT(*) AS `aws.waf.event_count`
+                              |FROM (
+                              |  SELECT
+                              |    CAST(FROM_UNIXTIME(`timestamp`/1000) AS TIMESTAMP) AS `@timestamp`,
+                              |    webaclId,
+                              |    action,
+                              |    httpRequest.clientIp AS `httpRequest.clientIp`,
+                              |    httpRequest.country AS `httpRequest.country`,
+                              |    httpRequest.uri AS `httpRequest.uri`,
+                              |    httpRequest.httpMethod AS `httpRequest.httpMethod`,
+                              |    httpSourceId,
+                              |    terminatingRuleId,
+                              |    terminatingRuleType,
+                              |    ruleGroupList.ruleId AS `ruleGroupList.ruleId`
+                              |  FROM
+                              |    $catalogName.default.waf_test
+                              |)
+                              |GROUP BY
+                              |  TUMBLE(`@timestamp`, '5 Minute'),
+                              |  webaclId,
+                              |  action,
+                              |  `httpRequest.clientIp`,
+                              |  `httpRequest.country`,
+                              |  `httpRequest.uri`,
+                              |  `httpRequest.httpMethod`,
+                              |  httpSourceId,
+                              |  terminatingRuleId,
+                              |  terminatingRuleType,
+                              |  `ruleGroupList.ruleId`
+                              |""".stripMargin
+
+  val dslQueryQuery: String =
+    """
+      |{
+      |    "bool": {
+      |      "filter": [
+      |        {
+      |          "match_all": {}
+      |        }
+      |      ]
+      |    }
+      |}
+      |""".stripMargin
+
+  val dslQueryBuilderVPCTSC: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+    val dateHistogramAgg = AggregationBuilders
+      .dateHistogram("2")
+      .field("start_time")
+      .minDocCount(1)
+      .fixedInterval(DateHistogramInterval.minutes(5))
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.vpc.total_bytes")
+
+    dateHistogramAgg.subAggregation(sumAgg)
+    builder.aggregation(dateHistogramAgg)
+
+    builder
+  }
+
+  val dslQueryBuilderVPCPC: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+    val termsAgg = AggregationBuilders.terms("2").field("aws.vpc.srcaddr")
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.vpc.total_bytes")
+
+    termsAgg.subAggregation(sumAgg)
+    builder.aggregation(termsAgg)
+
+    builder
+  }
+
+  val expectedBucketsVPCTSC: Seq[Map[String, Any]] = Seq(
+    Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1),
+    Map("key_as_string" -> "2023-11-01T05:10:00.000Z", "doc_count" -> 2))
+
+  val expectedBucketsVPCPC: Seq[Map[String, Any]] = Seq(
+    Map("key" -> "10.0.0.1", "doc_count" -> 1),
+    Map("key" -> "10.0.0.3", "doc_count" -> 1),
+    Map("key" -> "10.0.0.5", "doc_count" -> 1))
+
+  test(
+    "create aggregated materialized view for VPC flow integration unfiltered time series chart") {
+    withIntegration("vpc_flow") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.vpc_low_test")
+        .createMaterializedView(mvQueryVPC, sourceDisabled = true)
+        .assertDslQueryTSC(dslQueryBuilderVPCTSC, expectedBucketsVPCTSC)
+    }
+  }
+
+  test("create aggregated materialized view for VPC flow integration unfiltered pie chart") {
+    withIntegration("vpc_flow") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.vpc_low_test")
+        .createMaterializedView(mvQueryVPC, sourceDisabled = true)
+        .assertDslQueryPC(dslQueryBuilderVPCPC, expectedBucketsVPCPC)
+    }
+  }
+
   test("create aggregated materialized view for VPC flow integration") {
     withIntegration("vpc_flow") { integration =>
       integration
         .createSourceTable(s"$catalogName.default.vpc_low_test")
-        .createMaterializedView(s"""
-             |SELECT
-             |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
-             |  action AS `aws.vpc.action`,
-             |  srcAddr AS `aws.vpc.srcaddr`,
-             |  dstAddr AS `aws.vpc.dstaddr`,
-             |  protocol AS `aws.vpc.protocol`,
-             |  COUNT(*) AS `aws.vpc.total_count`,
-             |  SUM(bytes) AS `aws.vpc.total_bytes`,
-             |  SUM(packets) AS `aws.vpc.total_packets`
-             |FROM (
-             |  SELECT
-             |    action,
-             |    srcAddr,
-             |    dstAddr,
-             |    bytes,
-             |    packets,
-             |    protocol,
-             |    CAST(FROM_UNIXTIME(start) AS TIMESTAMP) AS `@timestamp`
-             |  FROM
-             |    $catalogName.default.vpc_low_test
-             |)
-             |GROUP BY
-             |  TUMBLE(`@timestamp`, '5 Minute'),
-             |  action,
-             |  srcAddr,
-             |  dstAddr,
-             |  protocol
-             |""".stripMargin)
+        .createMaterializedView(mvQueryVPC, sourceDisabled = false)
         .assertIndexData(
           Row(
             timestampFromUTC("2023-11-01T05:00:00Z"),
@@ -104,53 +278,179 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     }
   }
 
+  val dslQueryBuilderCTTSC: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+    val dateHistogramAgg = AggregationBuilders
+      .dateHistogram("2")
+      .field("start_time")
+      .fixedInterval(DateHistogramInterval.seconds(30))
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.cloudtrail.event_count")
+
+    dateHistogramAgg.subAggregation(sumAgg)
+    builder.aggregation(dateHistogramAgg)
+
+    builder
+  }
+
+  val dslQueryBuilderCTPC: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+    val termsAgg = AggregationBuilders
+      .terms("2")
+      .field("aws.cloudtrail.sourceIPAddress")
+      .order(BucketOrder.aggregation("1", false))
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.cloudtrail.event_count")
+
+    termsAgg.subAggregation(sumAgg)
+    builder.aggregation(termsAgg)
+
+    builder
+  }
+
+  val expectedBucketsCTTSC: Seq[Map[String, Any]] = Seq(
+    Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1))
+
+  val expectedBucketsCTPC: Seq[Map[String, Any]] = Seq(
+    Map("key" -> "198.51.100.45", "doc_count" -> 1))
+
+  test(
+    "create aggregated materialized view for CloudTrail integration unfiltered time series chart") {
+    withIntegration("cloud_trail") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.cloud_trail_test")
+        .createMaterializedView(mvQueryCT, sourceDisabled = true)
+        .assertDslQueryTSC(dslQueryBuilderCTTSC, expectedBucketsCTTSC)
+    }
+  }
+
+  test("create aggregated materialized view for CloudTrail integration unfiltered pie chart") {
+    withIntegration("cloud_trail") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.cloud_trail_test")
+        .createMaterializedView(mvQueryCT, sourceDisabled = true)
+        .assertDslQueryPC(dslQueryBuilderCTPC, expectedBucketsCTPC)
+    }
+  }
+
+  val dslQueryQueryWAFTSC: String =
+    """
+      |{
+      |    "bool": {
+      |      "filter": [
+      |        {
+      |          "match_all": {}
+      |        }
+      |      ]
+      |    }
+      |}
+      |""".stripMargin
+
+  val dslQueryQueryWAFPC: String =
+    """
+      |{
+      |    "bool": {
+      |      "filter": [
+      |        {
+      |          "match_all": {}
+      |        }
+      |      ]
+      |    }
+      |}
+      |""".stripMargin
+
+  val dslQueryBuilderWAFTSC: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryQueryWAFTSC))
+
+    // 1. Main terms aggregation
+    val termsAgg = AggregationBuilders
+      .terms("2")
+      .field("aws.waf.action")
+      .size(5)
+      .order(BucketOrder.aggregation("1", false)) // descending order by sum
+
+    // 2. First level sum aggregation - for ordering the terms
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.waf.event_count")
+
+    // 3. Date histogram sub-aggregation
+    val dateHistogramAgg = AggregationBuilders
+      .dateHistogram("3")
+      .field("start_time")
+      .fixedInterval(new DateHistogramInterval("30s"))
+      .minDocCount(1)
+
+    // 4. Inner sum aggregation inside date histogram
+    val innerSumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.waf.event_count")
+
+    // 5. Build the hierarchy of aggregations
+    dateHistogramAgg.subAggregation(innerSumAgg)
+    termsAgg.subAggregation(sumAgg)
+    termsAgg.subAggregation(dateHistogramAgg)
+
+    // 6. Add to main query builder
+    builder.aggregation(termsAgg)
+
+    builder
+  }
+
+  val dslQueryBuilderWAFPC: SearchSourceBuilder = {
+    val builder = new SearchSourceBuilder()
+      .query(QueryBuilders.wrapperQuery(dslQueryQuery))
+    val termsAgg = AggregationBuilders
+      .terms("2")
+      .field("aws.waf.httpRequest.clientIp")
+      .order(BucketOrder.aggregation("1", false))
+
+    val sumAgg = AggregationBuilders
+      .sum("1")
+      .field("aws.waf.event_count")
+
+    termsAgg.subAggregation(sumAgg)
+    builder.aggregation(termsAgg)
+
+    builder
+  }
+
+  val expectedBucketsWAFTSC: Seq[Map[String, Any]] = Seq(
+    Map("key_as_string" -> "2023-11-01T05:00:00.000Z", "doc_count" -> 1))
+
+  val expectedBucketsWAFPC: Seq[Map[String, Any]] = Seq(
+    Map("key" -> "192.0.2.1", "doc_count" -> 1))
+
+  test("create aggregated materialized view for WAF integration unfiltered time series chart") {
+    withIntegration("waf") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.waf_test")
+        .createMaterializedView(mvQueryWAF, sourceDisabled = true)
+        .assertDslQueryWAFTSC(dslQueryBuilderWAFTSC, expectedBucketsWAFTSC)
+    }
+  }
+
+  test("create aggregated materialized view for WAF integration unfiltered pie chart") {
+    withIntegration("waf") { integration =>
+      integration
+        .createSourceTable(s"$catalogName.default.waf_test")
+        .createMaterializedView(mvQueryWAF, sourceDisabled = true)
+        .assertDslQueryPC(dslQueryBuilderWAFPC, expectedBucketsWAFPC)
+    }
+  }
+
   test("create aggregated materialized view for CloudTrail integration") {
     withIntegration("cloud_trail") { integration =>
       integration
         .createSourceTable(s"$catalogName.default.cloud_trail_test")
-        .createMaterializedView(s"""
-             |SELECT
-             |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
-             |  `userIdentity.type` AS `aws.cloudtrail.userIdentity.type`,
-             |  `userIdentity.accountId` AS `aws.cloudtrail.userIdentity.accountId`,
-             |  `userIdentity.sessionContext.sessionIssuer.userName` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.userName`,
-             |  `userIdentity.sessionContext.sessionIssuer.arn` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.arn`,
-             |  `userIdentity.sessionContext.sessionIssuer.type` AS `aws.cloudtrail.userIdentity.sessionContext.sessionIssuer.type`,
-             |  awsRegion AS `aws.cloudtrail.awsRegion`,
-             |  sourceIPAddress AS `aws.cloudtrail.sourceIPAddress`,
-             |  eventSource AS `aws.cloudtrail.eventSource`,
-             |  eventName AS `aws.cloudtrail.eventName`,
-             |  eventCategory AS `aws.cloudtrail.eventCategory`,
-             |  COUNT(*) AS `aws.cloudtrail.event_count`
-             |FROM (
-             |  SELECT
-             |    CAST(eventTime AS TIMESTAMP) AS `@timestamp`,
-             |    userIdentity.`type` AS `userIdentity.type`,
-             |    userIdentity.`accountId` AS `userIdentity.accountId`,
-             |    userIdentity.sessionContext.sessionIssuer.userName AS `userIdentity.sessionContext.sessionIssuer.userName`,
-             |    userIdentity.sessionContext.sessionIssuer.arn AS `userIdentity.sessionContext.sessionIssuer.arn`,
-             |    userIdentity.sessionContext.sessionIssuer.type AS `userIdentity.sessionContext.sessionIssuer.type`,
-             |    awsRegion,
-             |    sourceIPAddress,
-             |    eventSource,
-             |    eventName,
-             |    eventCategory
-             |  FROM
-             |    $catalogName.default.cloud_trail_test
-             |)
-             |GROUP BY
-             |  TUMBLE(`@timestamp`, '5 Minute'),
-             |  `userIdentity.type`,
-             |  `userIdentity.accountId`,
-             |  `userIdentity.sessionContext.sessionIssuer.userName`,
-             |  `userIdentity.sessionContext.sessionIssuer.arn`,
-             |  `userIdentity.sessionContext.sessionIssuer.type`,
-             |  awsRegion,
-             |  sourceIPAddress,
-             |  eventSource,
-             |  eventName,
-             |  eventCategory
-             |""".stripMargin)
+        .createMaterializedView(mvQueryCT, sourceDisabled = false)
         .assertIndexData(Row(
           timestampFromUTC("2023-11-01T05:00:00Z"),
           "IAMUser",
@@ -171,49 +471,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
     withIntegration("waf") { integration =>
       integration
         .createSourceTable(s"$catalogName.default.waf_test")
-        .createMaterializedView(s"""
-             |SELECT
-             |  TUMBLE(`@timestamp`, '5 Minute').start AS `start_time`,
-             |  webaclId AS `aws.waf.webaclId`,
-             |  action AS `aws.waf.action`,
-             |  `httpRequest.clientIp` AS `aws.waf.httpRequest.clientIp`,
-             |  `httpRequest.country` AS `aws.waf.httpRequest.country`,
-             |  `httpRequest.uri` AS `aws.waf.httpRequest.uri`,
-             |  `httpRequest.httpMethod` AS `aws.waf.httpRequest.httpMethod`,
-             |  httpSourceId AS `aws.waf.httpSourceId`,
-             |  terminatingRuleId AS `aws.waf.terminatingRuleId`,
-             |  terminatingRuleType AS `aws.waf.RuleType`,
-             |  `ruleGroupList.ruleId` AS `aws.waf.ruleGroupList.ruleId`,
-             |  COUNT(*) AS `aws.waf.event_count`
-             |FROM (
-             |  SELECT
-             |    CAST(FROM_UNIXTIME(`timestamp`/1000) AS TIMESTAMP) AS `@timestamp`,
-             |    webaclId,
-             |    action,
-             |    httpRequest.clientIp AS `httpRequest.clientIp`,
-             |    httpRequest.country AS `httpRequest.country`,
-             |    httpRequest.uri AS `httpRequest.uri`,
-             |    httpRequest.httpMethod AS `httpRequest.httpMethod`,
-             |    httpSourceId,
-             |    terminatingRuleId,
-             |    terminatingRuleType,
-             |    ruleGroupList.ruleId AS `ruleGroupList.ruleId`
-             |  FROM
-             |    $catalogName.default.waf_test
-             |)
-             |GROUP BY
-             |  TUMBLE(`@timestamp`, '5 Minute'),
-             |  webaclId,
-             |  action,
-             |  `httpRequest.clientIp`,
-             |  `httpRequest.country`,
-             |  `httpRequest.uri`,
-             |  `httpRequest.httpMethod`,
-             |  httpSourceId,
-             |  terminatingRuleId,
-             |  terminatingRuleType,
-             |  `ruleGroupList.ruleId`
-             |""".stripMargin)
+        .createMaterializedView(mvQueryWAF, sourceDisabled = false)
         .assertIndexData(Row(
           timestampFromUTC("2023-11-01T05:00:00Z"),
           "webacl-12345",
@@ -241,7 +499,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
    * @param codeBlock
    *   the block of code to execute with the integration setup
    */
-  private def withIntegration(name: String)(codeBlock: IntegrationHelper => Unit): Unit = {
+  def withIntegration(name: String)(codeBlock: IntegrationHelper => Unit): Unit = {
     withTempDir { checkpointDir =>
       val integration = new IntegrationHelper(name, checkpointDir)
       try {
@@ -261,7 +519,7 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
    * @param checkpointDir
    *   the directory for Spark Streaming checkpointing
    */
-  private class IntegrationHelper(integrationName: String, checkpointDir: File) {
+  class IntegrationHelper(integrationName: String, checkpointDir: File) {
     var tableName: String = _
     private var mvName: String = _
     private var mvQuery: String = _
@@ -280,21 +538,36 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
       this
     }
 
-    def createMaterializedView(mvQuery: String): IntegrationHelper = {
+    def createMaterializedView(mvQuery: String, sourceDisabled: Boolean): IntegrationHelper = {
       this.mvName = s"$catalogName.default.${integrationName}_mv_test"
       this.mvQuery = mvQuery.replace("{table_name}", tableName)
 
-      sql(s"""
-           |CREATE MATERIALIZED VIEW $mvName
-           |AS
-           |${this.mvQuery}
-           |WITH (
-           |  auto_refresh = true,
-           |  refresh_interval = '5 Seconds',
-           |  watermark_delay = '1 Minute',
-           |  checkpoint_location = '${checkpointDir.getAbsolutePath}'
-           |)
-           |""".stripMargin)
+      if (sourceDisabled) {
+        sql(s"""
+               |CREATE MATERIALIZED VIEW $mvName
+               |AS
+               |${this.mvQuery}
+               |WITH (
+               |  auto_refresh = true,
+               |  refresh_interval = '5 Seconds',
+               |  watermark_delay = '1 Minute',
+               |  checkpoint_location = '${checkpointDir.getAbsolutePath}',
+               |  index_mappings = '{ "_source": { "enabled": false } }'
+               |)
+               |""".stripMargin)
+      } else {
+        sql(s"""
+               |CREATE MATERIALIZED VIEW $mvName
+               |AS
+               |${this.mvQuery}
+               |WITH (
+               |  auto_refresh = true,
+               |  refresh_interval = '5 Seconds',
+               |  watermark_delay = '1 Minute',
+               |  checkpoint_location = '${checkpointDir.getAbsolutePath}'
+               |)
+               |""".stripMargin)
+      }
 
       // Wait for all data processed
       val job = spark.streams.active
@@ -316,6 +589,86 @@ class FlintSparkMaterializedViewIntegrationsITSuite extends FlintSparkSuite with
         .load(flintIndexName)
 
       checkAnswer(actualRows, expectedRows)
+    }
+
+    // "key_as_string": "2025-01-08T09:00:00.000-08:00","doc_count": 795903 as expectedHits, and we will get the same thing from actual hits by extracting from dslQuery
+    def assertDslQueryTSC(
+        dslQueryTSC: SearchSourceBuilder,
+        expectedBuckets: Seq[Map[String, Any]]): Unit = {
+      val flintIndexName =
+        spark.streams.active.find(_.name == getFlintIndexName(mvName)).get.name
+      val searchRequest = new SearchRequest(flintIndexName)
+      searchRequest.source(dslQueryTSC)
+      val actual = openSearchClient.search(searchRequest, RequestOptions.DEFAULT)
+      val dateHistogram = actual.getAggregations
+        .get("2")
+        .asInstanceOf[ParsedDateHistogram]
+
+      val buckets = dateHistogram.getBuckets
+
+      // Map to the format we want to compare
+      val actualBuckets = buckets.asScala.map { bucket =>
+        Map("key_as_string" -> bucket.getKeyAsString, "doc_count" -> bucket.getDocCount.toInt)
+      }.toSeq
+
+      actualBuckets should equal(expectedBuckets)
+    }
+
+    def assertDslQueryWAFTSC(
+        dslQueryTSC: SearchSourceBuilder,
+        expectedBuckets: Seq[Map[String, Any]]): Unit = {
+      val flintIndexName =
+        spark.streams.active.find(_.name == getFlintIndexName(mvName)).get.name
+      val searchRequest = new SearchRequest(flintIndexName)
+      searchRequest.source(dslQueryTSC)
+      val actual = openSearchClient.search(searchRequest, RequestOptions.DEFAULT)
+      // First get the terms aggregation
+      val termsAgg = actual.getAggregations
+        .get("2")
+        .asInstanceOf[
+          ParsedStringTerms
+        ] // Note: This is a terms aggregation, not a date histogram
+
+      // Get the first bucket (ALLOW in this case)
+      val firstTermBucket = termsAgg.getBuckets.asScala.head
+
+      // Get the nested date histogram from this term bucket
+      val dateHistogram = firstTermBucket.getAggregations
+        .get("3")
+        .asInstanceOf[ParsedDateHistogram]
+
+      // Now get the buckets from the date histogram
+      val buckets = dateHistogram.getBuckets
+
+      // Map to the format we want to compare
+      val actualBuckets = buckets.asScala.map { bucket =>
+        Map("key_as_string" -> bucket.getKeyAsString, "doc_count" -> bucket.getDocCount.toInt)
+      }.toSeq
+
+      actualBuckets should equal(expectedBuckets)
+    }
+
+    def assertDslQueryPC(
+        dslQueryBuilder: SearchSourceBuilder,
+        expectedBuckets: Seq[Map[String, Any]]): Unit = {
+      val flintIndexName =
+        spark.streams.active.find(_.name == getFlintIndexName(mvName)).get.name
+      val searchRequest = new SearchRequest(flintIndexName)
+      searchRequest.source(dslQueryBuilder)
+      val actual = openSearchClient.search(searchRequest, RequestOptions.DEFAULT)
+      val stringTerms = actual.getAggregations
+        .get("2")
+        .asInstanceOf[ParsedStringTerms]
+
+      val buckets = stringTerms.getBuckets
+
+      // Map to the format we want to compare
+      val actualBuckets = buckets.asScala.map { bucket =>
+        Map("key" -> bucket.getKeyAsString, "doc_count" -> bucket.getDocCount.toInt)
+      }.toSeq
+
+      actualBuckets should equal(expectedBuckets)
+
     }
   }
 


### PR DESCRIPTION
### Description

Changes are only in ```FlintSparkMaterializedViewIntegrationsITSuite.scala```

Modified integration test for Materialized View.

Originally the integration test uses data fetched from ```_source```, with the implementation of the feature of disabling _source it's no longer sufficient for testing.

This PR rewrote the integration test to make it fetch data from ```openSearchClient``` instead of ```_source```

Implemented testing for 
```VPC flow``` with unfiltered time series chart and pie chart.
```CloudTrail``` with unfiltered time series chart and pie chart.
```WAF``` with unfiltered time series chart and pie chart.