### PR TITLE
Add index state to metadata cache

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -142,6 +142,9 @@ class FlintSpark(val spark: SparkSession) extends FlintSparkTransactionSupport w
             }
             flintClient.createIndex(indexName, metadata)
             flintIndexMetadataService.updateIndexMetadata(indexName, metadata)
+            // We don't update the cache to the "active" state when exiting the finalLog, since `commit` is only called
+            // for transientLog. This is intended: it lets the frontend see the index in the "creating" state until the
+            // first refresh is in action, then that refresh pushes it to "active."
             flintMetadataCacheWriter.updateMetadataCache(indexName, metadata)
             jobSchedulingService.handleJob(index, AsyncQuerySchedulerAction.SCHEDULE)
           })

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -142,9 +142,6 @@ class FlintSpark(val spark: SparkSession) extends FlintSparkTransactionSupport w
             }
             flintClient.createIndex(indexName, metadata)
             flintIndexMetadataService.updateIndexMetadata(indexName, metadata)
-            // We don't update the cache to the "active" state when exiting the finalLog, since `commit` is only called
-            // for transientLog. This is intended: it lets the frontend see the index in the "creating" state until the
-            // first refresh is in action, then that refresh pushes it to "active."
             flintMetadataCacheWriter.updateMetadataCache(indexName, metadata)
             jobSchedulingService.handleJob(index, AsyncQuerySchedulerAction.SCHEDULE)
           })

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCache.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCache.scala
@@ -29,7 +29,8 @@ case class FlintMetadataCache(
     lastRefreshTime: Option[Long],
     /**
      * The current index state per the Flint state machine
-     * @see https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md#index-state-transition-1
+     * @see
+     *   https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md#index-state-transition-1
      */
     indexState: Option[String]) {
 

--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCache.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/metadatacache/FlintMetadataCache.scala
@@ -26,7 +26,12 @@ case class FlintMetadataCache(
     /** Source query for MV */
     sourceQuery: Option[String],
     /** Timestamp when Flint index is last refreshed. Unit: milliseconds */
-    lastRefreshTime: Option[Long]) {
+    lastRefreshTime: Option[Long],
+    /**
+     * The current index state per the Flint state machine
+     * @see https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md#index-state-transition-1
+     */
+    indexState: Option[String]) {
 
   /**
    * Convert FlintMetadataCache to a map. Skips a field if its value is not defined.
@@ -76,12 +81,17 @@ object FlintMetadataCache {
         case timestamp => Some(timestamp)
       }
     }
+    val indexState = metadata.latestLogEntry match {
+      case Some(entry) => Some(entry.state.toString)
+      case None => None
+    }
 
     FlintMetadataCache(
       metadataCacheVersion,
       refreshInterval,
       sourceTables,
       sourceQuery,
-      lastRefreshTime)
+      lastRefreshTime,
+      indexState)
   }
 }

--- a/integ-test/src/integration/scala/org/opensearch/flint/spark/metadatacache/FlintOpenSearchMetadataCacheWriterITSuite.scala
+++ b/integ-test/src/integration/scala/org/opensearch/flint/spark/metadatacache/FlintOpenSearchMetadataCacheWriterITSuite.scala
@@ -14,41 +14,24 @@ import org.json4s.{DefaultFormats, Extraction, JValue}
 import org.json4s.native.JsonMethods._
 import org.opensearch.flint.common.metadata.log.FlintMetadataLogEntry
 import org.opensearch.flint.core.FlintOptions
-import org.opensearch.flint.core.storage.{
-  FlintOpenSearchClient,
-  FlintOpenSearchIndexMetadataService,
-  OpenSearchClientUtils
-}
-import org.opensearch.flint.spark.{
-  FlintSpark,
-  FlintSparkIndexOptions,
-  FlintSparkSuite
-}
+import org.opensearch.flint.core.storage.{FlintOpenSearchClient, FlintOpenSearchIndexMetadataService, OpenSearchClientUtils}
+import org.opensearch.flint.spark.{FlintSpark, FlintSparkIndexOptions, FlintSparkSuite}
 import org.opensearch.flint.spark.covering.FlintSparkCoveringIndex.COVERING_INDEX_TYPE
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView
 import org.opensearch.flint.spark.mv.FlintSparkMaterializedView.MV_INDEX_TYPE
-import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.{
-  getSkippingIndexName,
-  SKIPPING_INDEX_TYPE
-}
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.{getSkippingIndexName, SKIPPING_INDEX_TYPE}
 import org.scalatest.Entry
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.sql.flint.config.FlintSparkConf
 
-class FlintOpenSearchMetadataCacheWriterITSuite
-    extends FlintSparkSuite
-    with Matchers {
+class FlintOpenSearchMetadataCacheWriterITSuite extends FlintSparkSuite with Matchers {
 
   /** Lazy initialize after container started. */
   lazy val options = new FlintOptions(openSearchOptions.asJava)
   lazy val flintClient = new FlintOpenSearchClient(options)
-  lazy val flintMetadataCacheWriter = new FlintOpenSearchMetadataCacheWriter(
-    options
-  )
-  lazy val flintIndexMetadataService = new FlintOpenSearchIndexMetadataService(
-    options
-  )
+  lazy val flintMetadataCacheWriter = new FlintOpenSearchMetadataCacheWriter(options)
+  lazy val flintIndexMetadataService = new FlintOpenSearchIndexMetadataService(options)
 
   private val testTable = "spark_catalog.default.metadatacache_test"
   private val testFlintIndex = getSkippingIndexName(testTable)
@@ -63,8 +46,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite
     FlintMetadataLogEntry.IndexState.ACTIVE,
     Map.empty[String, Any],
     "",
-    Map.empty[String, Any]
-  )
+    Map.empty[String, Any])
   private val indexStateActive = "active"
   private val indexStateCreating = "creating"
 
@@ -116,16 +98,13 @@ class FlintOpenSearchMetadataCacheWriterITSuite
     properties should have size 4
     properties should contain allOf (Entry(
       "metadataCacheVersion",
-      FlintMetadataCache.metadataCacheVersion
-    ),
+      FlintMetadataCache.metadataCacheVersion),
     Entry("lastRefreshTime", testLastRefreshCompleteTime),
     Entry("indexState", indexStateActive))
   }
 
   Seq(SKIPPING_INDEX_TYPE, COVERING_INDEX_TYPE).foreach { case kind =>
-    test(
-      s"write metadata cache to $kind index mappings with source tables for non mv index"
-    ) {
+    test(s"write metadata cache to $kind index mappings with source tables for non mv index") {
       val content =
         s""" {
            |   "_meta": {
@@ -149,22 +128,18 @@ class FlintOpenSearchMetadataCacheWriterITSuite
         flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
       properties
         .get("sourceTables")
-        .asInstanceOf[
-          java.util.ArrayList[String]
-        ] should contain theSameElementsAs Array(testTable)
+        .asInstanceOf[java.util.ArrayList[String]] should contain theSameElementsAs Array(
+        testTable)
       properties should not contain key("sourceQuery")
     }
   }
 
-  test(
-    "write metadata cache with source tables and query from mv index metadata"
-  ) {
+  test("write metadata cache with source tables and query from mv index metadata") {
     val mv = FlintSparkMaterializedView(
       "spark_catalog.default.mv",
       s"SELECT 1 FROM $testTable",
       Array(testTable),
-      Map("1" -> "integer")
-    )
+      Map("1" -> "integer"))
     val metadata =
       mv.metadata().copy(latestLogEntry = Some(flintMetadataLogEntry))
 
@@ -175,17 +150,13 @@ class FlintOpenSearchMetadataCacheWriterITSuite
       flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
     properties
       .get("sourceTables")
-      .asInstanceOf[
-        java.util.ArrayList[String]
-      ] should contain theSameElementsAs Array(testTable)
+      .asInstanceOf[java.util.ArrayList[String]] should contain theSameElementsAs Array(testTable)
     properties
       .get("sourceQuery")
       .asInstanceOf[String] shouldBe s"SELECT 1 FROM $testTable"
   }
 
-  test(
-    "write metadata cache with source tables and query from deserialized mv metadata"
-  ) {
+  test("write metadata cache with source tables and query from deserialized mv metadata") {
     val testTable2 = "spark_catalog.default.metadatacache_test2"
     val content =
       s""" {
@@ -214,9 +185,9 @@ class FlintOpenSearchMetadataCacheWriterITSuite
       flintIndexMetadataService.getIndexMetadata(testFlintIndex).properties
     properties
       .get("sourceTables")
-      .asInstanceOf[
-        java.util.ArrayList[String]
-      ] should contain theSameElementsAs Array(testTable, testTable2)
+      .asInstanceOf[java.util.ArrayList[String]] should contain theSameElementsAs Array(
+      testTable,
+      testTable2)
   }
 
   test("write metadata cache to index mappings with refresh interval") {
@@ -247,18 +218,12 @@ class FlintOpenSearchMetadataCacheWriterITSuite
     properties should have size 5
     properties should contain allOf (Entry(
       "metadataCacheVersion",
-      FlintMetadataCache.metadataCacheVersion
-    ),
+      FlintMetadataCache.metadataCacheVersion),
     Entry("refreshInterval", 600),
-    Entry("lastRefreshTime", testLastRefreshCompleteTime), Entry(
-      "indexState",
-      indexStateActive
-    ))
+    Entry("lastRefreshTime", testLastRefreshCompleteTime), Entry("indexState", indexStateActive))
   }
 
-  test(
-    "exclude refresh interval in metadata cache when auto refresh is false"
-  ) {
+  test("exclude refresh interval in metadata cache when auto refresh is false") {
     val content =
       """ {
         |   "_meta": {
@@ -285,9 +250,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite
     properties should not contain key("refreshInterval")
   }
 
-  test(
-    "exclude last refresh time in metadata cache when index has not been refreshed"
-  ) {
+  test("exclude last refresh time in metadata cache when index has not been refreshed") {
     val content =
       s""" {
          |   "properties": {
@@ -299,9 +262,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite
          |""".stripMargin
     val metadata = FlintOpenSearchIndexMetadataService
       .deserialize(content)
-      .copy(latestLogEntry =
-        Some(flintMetadataLogEntry.copy(lastRefreshCompleteTime = 0L))
-      )
+      .copy(latestLogEntry = Some(flintMetadataLogEntry.copy(lastRefreshCompleteTime = 0L)))
     flintClient.createIndex(testFlintIndex, metadata)
     flintMetadataCacheWriter.updateMetadataCache(testFlintIndex, metadata)
 
@@ -310,9 +271,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite
     properties should not contain key("lastRefreshTime")
   }
 
-  test(
-    "write metadata cache to index mappings and preserve other index metadata"
-  ) {
+  test("write metadata cache to index mappings and preserve other index metadata") {
     val content =
       """ {
         |   "_meta": {
@@ -357,12 +316,10 @@ class FlintOpenSearchMetadataCacheWriterITSuite
     properties should have size 5
     properties should contain allOf (Entry(
       "metadataCacheVersion",
-      FlintMetadataCache.metadataCacheVersion
-    ),
+      FlintMetadataCache.metadataCacheVersion),
     Entry("lastRefreshTime", testLastRefreshCompleteTime), Entry(
       "custom_in_properties",
-      "test_custom"
-    ),
+      "test_custom"),
     Entry("indexState", indexStateActive))
 
     // Directly get the index mapping and verify custom field is preserved
@@ -380,8 +337,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite
         "auto_refresh" -> "true",
         "scheduler_mode" -> "external",
         "refresh_interval" -> "10 Minute",
-        "checkpoint_location" -> "s3a://test/"
-      ),
+        "checkpoint_location" -> "s3a://test/"),
       s"""
          | {
          |   "indexState": "$indexStateCreating",
@@ -389,8 +345,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite
          |   "refreshInterval": 600,
          |   "sourceTables": ["$testTable"]
          | }
-         |""".stripMargin
-    ),
+         |""".stripMargin),
     (
       "full refresh index",
       Map.empty[String, String],
@@ -400,23 +355,17 @@ class FlintOpenSearchMetadataCacheWriterITSuite
          |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
          |   "sourceTables": ["$testTable"]
          | }
-         |""".stripMargin
-    ),
+         |""".stripMargin),
     (
       "incremental refresh index",
-      Map(
-        "incremental_refresh" -> "true",
-        "checkpoint_location" -> "s3a://test/"
-      ),
+      Map("incremental_refresh" -> "true", "checkpoint_location" -> "s3a://test/"),
       s"""
          | {
          |   "indexState": "$indexStateCreating",
          |   "metadataCacheVersion": "${FlintMetadataCache.metadataCacheVersion}",
          |   "sourceTables": ["$testTable"]
          | }
-         |""".stripMargin
-    )
-  ).foreach { case (refreshMode, optionsMap, expectedJson) =>
+         |""".stripMargin)).foreach { case (refreshMode, optionsMap, expectedJson) =>
     test(s"write metadata cache for $refreshMode") {
       withExternalSchedulerEnabled {
         val flint: FlintSpark = new FlintSpark(spark)
@@ -427,10 +376,8 @@ class FlintOpenSearchMetadataCacheWriterITSuite
               .get("checkpoint_location")
               .map(_ =>
                 optionsMap
-                  .updated("checkpoint_location", checkpointDir.getAbsolutePath)
-              )
-              .getOrElse(optionsMap)
-          )
+                  .updated("checkpoint_location", checkpointDir.getAbsolutePath))
+              .getOrElse(optionsMap))
 
           flint
             .skippingIndex()
@@ -445,9 +392,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite
 
           flint.refreshIndex(testFlintIndex)
           val lastRefreshTime =
-            compact(
-              render(getPropertiesJValue(testFlintIndex) \ "lastRefreshTime")
-            ).toLong
+            compact(render(getPropertiesJValue(testFlintIndex) \ "lastRefreshTime")).toLong
           lastRefreshTime should be > 0L
         }
       }
@@ -467,11 +412,8 @@ class FlintOpenSearchMetadataCacheWriterITSuite
               "auto_refresh" -> "true",
               "scheduler_mode" -> "internal",
               "refresh_interval" -> "10 Minute",
-              "checkpoint_location" -> checkpointDir.getAbsolutePath
-            )
-          ),
-          testFlintIndex
-        )
+              "checkpoint_location" -> checkpointDir.getAbsolutePath)),
+          testFlintIndex)
         .create()
 
       val propertiesJson = compact(render(getPropertiesJValue(testFlintIndex)))
@@ -485,9 +427,7 @@ class FlintOpenSearchMetadataCacheWriterITSuite
             |""".stripMargin)
 
       flint.refreshIndex(testFlintIndex)
-      compact(
-        render(getPropertiesJValue(testFlintIndex))
-      ) should not include "lastRefreshTime"
+      compact(render(getPropertiesJValue(testFlintIndex))) should not include "lastRefreshTime"
     }
   }
 


### PR DESCRIPTION
### Description
Useful for detecting the current status of data sources from OSD, particularly for Dashboards to know if an index is currently refreshing or not.

There's a quirk with the `creating` state not being switched off until the next refresh picks it up. I think it's technically a bug, but I think we can/should leave it as-is since it's more directly useful to the front-end that an index is newly created but not yet started refreshing: I added a comment and wrote tests around this. Alternatively, I could do some refactoring to make it work right, probably adding some cache-flush layer directly in `metadata.copy` that makes it update by default.

[Example of how this is used on the front-end](https://github.com/Swiddis/OpenSearch-Dashboards/compare/18d96875a4503773a6691a22947ed3fb6cbfd7f5...ad579c3c37b2100248f9d749a642036a29843cb5)

### Related Issues
N/A

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
