### PR TITLE
Introducing propery shouldExecuteNextQuery to dynamically stop executing the next query

### DIFF
--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -328,6 +328,9 @@ object FlintSparkConf {
   val TERMINATE_JVM = FlintConfig("spark.flint.terminateJVM")
     .doc("Indicates whether the JVM should be terminated after query execution")
     .createWithDefault("true")
+  val SHOULD_EXECUTE_NEXT_QUERY = FlintConfig("spark.flint.shouldExecuteNextQuery")
+    .doc("Indicates whether next query should be picked up or not")
+    .createWithDefault("true")
 }
 
 /**

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/WarmpoolJob.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/WarmpoolJob.scala
@@ -89,6 +89,10 @@ case class WarmpoolJob(
               spark.conf.get(FlintSparkConf.TERMINATE_JVM.key, "true").toBoolean
             jobOperator.start()
 
+            if (!spark.conf.get(FlintSparkConf.SHOULD_EXECUTE_NEXT_QUERY.key, "true").toBoolean) {
+              canProceed = false
+            }
+
           case _ =>
             canProceed = false
         }

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/util/WarmpoolTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/util/WarmpoolTest.scala
@@ -62,7 +62,8 @@ class WarmpoolTest extends SparkFunSuite with MockitoSugar with JobMatchers {
     when(mockSparkSession.conf.get(FlintSparkConf.DATA_SOURCE_NAME.key))
       .thenReturn(dataSourceName)
     when(mockSparkSession.conf.get(FlintSparkConf.RESULT_INDEX.key)).thenReturn(resultIndex)
-    when(mockSparkSession.conf.get(FlintSparkConf.TERMINATE_JVM.key, "true")).thenReturn("true")
+    when(mockSparkSession.conf.get(FlintSparkConf.TERMINATE_JVM.key, "true")).thenReturn("false")
+    when(mockSparkSession.conf.get(FlintSparkConf.SHOULD_EXECUTE_NEXT_QUERY.key, "true")).thenReturn("true")
     when(mockSparkSession.conf.get(FlintSparkConf.WARMPOOL_ENABLED.key, "false"))
       .thenReturn("true")
     when(mockSparkSession.conf.get(FlintSparkConf.REQUEST_INDEX.key, ""))
@@ -91,6 +92,73 @@ class WarmpoolTest extends SparkFunSuite with MockitoSugar with JobMatchers {
 
     job.queryLoop(mockStatementExecutionManager)
     verify(mockJobOperator, times(2)).start()
+  }
+
+test("verify job operator starts once when there are two Flint statements if shouldExecuteNextQuery is set to false") {
+    val mockSparkSession = mock[SparkSession]
+    val mockConf = mock[RuntimeConfig]
+    val mockStatementExecutionManager = mock[StatementExecutionManager]
+    val mockJobOperator = mock[JobOperator]
+
+    val firstFlintStatement = new FlintStatement(
+      "waiting",
+      "select 1",
+      "30",
+      "10",
+      LangType.SQL,
+      Instant.now().toEpochMilli(),
+      None)
+
+    val secondFlintStatement = new FlintStatement(
+      "waiting",
+      "select * from DB",
+      "30",
+      "10",
+      LangType.SQL,
+      Instant.now().toEpochMilli(),
+      None)
+
+    when(mockSparkSession.conf).thenReturn(mockConf)
+    when(mockStatementExecutionManager.getNextStatement())
+      .thenReturn(Some(firstFlintStatement))
+      .thenReturn(Some(secondFlintStatement))
+      .thenReturn(None)
+
+    when(mockSparkSession.conf.get(FlintSparkConf.JOB_TYPE.key, FlintJobType.BATCH))
+      .thenReturn(FlintJobType.BATCH)
+    when(mockSparkSession.conf.get(FlintSparkConf.DATA_SOURCE_NAME.key))
+      .thenReturn(dataSourceName)
+    when(mockSparkSession.conf.get(FlintSparkConf.RESULT_INDEX.key)).thenReturn(resultIndex)
+    when(mockSparkSession.conf.get(FlintSparkConf.TERMINATE_JVM.key, "true")).thenReturn("false")
+    when(mockSparkSession.conf.get(FlintSparkConf.SHOULD_EXECUTE_NEXT_QUERY.key, "true")).thenReturn("false")
+    when(mockSparkSession.conf.get(FlintSparkConf.WARMPOOL_ENABLED.key, "false"))
+      .thenReturn("true")
+    when(mockSparkSession.conf.get(FlintSparkConf.REQUEST_INDEX.key, ""))
+      .thenReturn(requestIndex)
+
+    val job = spy(
+      WarmpoolJob(
+        applicationId,
+        jobId,
+        mockSparkSession,
+        statementRunningCount,
+        statementRunningCount))
+
+    doAnswer(_ => mockJobOperator)
+      .when(job)
+      .createJobOperator(
+        any(),
+        anyString(),
+        anyString(),
+        any(),
+        anyString(),
+        anyString(),
+        anyString(),
+        any(),
+        any())
+
+    job.queryLoop(mockStatementExecutionManager)
+    verify(mockJobOperator, times(1)).start()
   }
 
   test("Query loop execution failure") {

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/util/WarmpoolTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/util/WarmpoolTest.scala
@@ -63,7 +63,8 @@ class WarmpoolTest extends SparkFunSuite with MockitoSugar with JobMatchers {
       .thenReturn(dataSourceName)
     when(mockSparkSession.conf.get(FlintSparkConf.RESULT_INDEX.key)).thenReturn(resultIndex)
     when(mockSparkSession.conf.get(FlintSparkConf.TERMINATE_JVM.key, "true")).thenReturn("false")
-    when(mockSparkSession.conf.get(FlintSparkConf.SHOULD_EXECUTE_NEXT_QUERY.key, "true")).thenReturn("true")
+    when(mockSparkSession.conf.get(FlintSparkConf.SHOULD_EXECUTE_NEXT_QUERY.key, "true"))
+      .thenReturn("true")
     when(mockSparkSession.conf.get(FlintSparkConf.WARMPOOL_ENABLED.key, "false"))
       .thenReturn("true")
     when(mockSparkSession.conf.get(FlintSparkConf.REQUEST_INDEX.key, ""))
@@ -94,7 +95,8 @@ class WarmpoolTest extends SparkFunSuite with MockitoSugar with JobMatchers {
     verify(mockJobOperator, times(2)).start()
   }
 
-test("verify job operator starts once when there are two Flint statements if shouldExecuteNextQuery is set to false") {
+  test(
+    "verify job operator starts once when there are two Flint statements if shouldExecuteNextQuery is set to false") {
     val mockSparkSession = mock[SparkSession]
     val mockConf = mock[RuntimeConfig]
     val mockStatementExecutionManager = mock[StatementExecutionManager]
@@ -130,7 +132,8 @@ test("verify job operator starts once when there are two Flint statements if sho
       .thenReturn(dataSourceName)
     when(mockSparkSession.conf.get(FlintSparkConf.RESULT_INDEX.key)).thenReturn(resultIndex)
     when(mockSparkSession.conf.get(FlintSparkConf.TERMINATE_JVM.key, "true")).thenReturn("false")
-    when(mockSparkSession.conf.get(FlintSparkConf.SHOULD_EXECUTE_NEXT_QUERY.key, "true")).thenReturn("false")
+    when(mockSparkSession.conf.get(FlintSparkConf.SHOULD_EXECUTE_NEXT_QUERY.key, "true"))
+      .thenReturn("false")
     when(mockSparkSession.conf.get(FlintSparkConf.WARMPOOL_ENABLED.key, "false"))
       .thenReturn("true")
     when(mockSparkSession.conf.get(FlintSparkConf.REQUEST_INDEX.key, ""))


### PR DESCRIPTION


### Description
Adding support to terminate the loop dynamically by setting canProceed to false in WarmpoolJob

### Related Issues
_List any issues this PR will resolve, e.g. Resolves [...]._

### Check List
- [N/A ] Updated documentation (docs/ppl-lang/README.md)
- [Y ] Implemented unit tests
- [x] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [x] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
