### PR TITLE
set correct Flint Statement State after query execution

### DIFF
--- a/flint-commons/src/main/scala/org/opensearch/flint/common/model/FlintStatement.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/model/FlintStatement.scala
@@ -66,7 +66,6 @@ class FlintStatement(
 
   def isWaiting: Boolean = state.equalsIgnoreCase(StatementStates.WAITING)
 
-
   // Does not include context, which could contain sensitive information.
   override def toString: String =
     s"FlintStatement(state=$state, statementId=$statementId, queryId=$queryId, langType=$langType, submitTime=$submitTime, error=$error)"

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/model/FlintStatement.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/model/FlintStatement.scala
@@ -66,6 +66,8 @@ class FlintStatement(
 
   def isWaiting: Boolean = state.equalsIgnoreCase(StatementStates.WAITING)
 
+  def isTimeout: Boolean = state.equalsIgnoreCase(StatementStates.TIMEOUT)
+
   // Does not include context, which could contain sensitive information.
   override def toString: String =
     s"FlintStatement(state=$state, statementId=$statementId, queryId=$queryId, langType=$langType, submitTime=$submitTime, error=$error)"

--- a/flint-commons/src/main/scala/org/opensearch/flint/common/model/FlintStatement.scala
+++ b/flint-commons/src/main/scala/org/opensearch/flint/common/model/FlintStatement.scala
@@ -66,7 +66,6 @@ class FlintStatement(
 
   def isWaiting: Boolean = state.equalsIgnoreCase(StatementStates.WAITING)
 
-  def isTimeout: Boolean = state.equalsIgnoreCase(StatementStates.TIMEOUT)
 
   // Does not include context, which could contain sensitive information.
   override def toString: String =

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -95,6 +95,7 @@ case class JobOperator(
           case Right(_) => data
           case Left(err) =>
             throwableHandler.setError(err)
+            statement.fail()
             constructErrorDF(
               applicationId,
               jobId,
@@ -110,6 +111,7 @@ case class JobOperator(
     } catch {
       case e: TimeoutException =>
         throwableHandler.recordThrowable(s"Preparation for query execution timed out", e)
+        statement.timeout()
         dataToWrite = Some(
           constructErrorDF(
             applicationId,
@@ -125,6 +127,7 @@ case class JobOperator(
         incrementCounter(MetricConstants.QUERY_EXECUTION_FAILED_METRIC)
       case t: Throwable =>
         val error = processQueryException(t)
+        statement.fail()
         dataToWrite = Some(
           constructErrorDF(
             applicationId,


### PR DESCRIPTION
### Description
Previously, the JobOperator was not updating the FlintStatement status before passing it to the QueryResultWriter, causing it to receive statements with incorrect/stale status information. This pr Updates the statement based on query execution result.

### Related Issues
_List any issues this PR will resolve, e.g. Resolves [...]._

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [ ] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
