### PR TITLE
Add precommit for Scala linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
       rev: v0.5.0
       hooks:
         -   id: sbt-unused-imports
+            args: [--scope=test:compile]
             stages: [pre-commit, pre-push]
         -   id: sbt-scalafmt-apply
             args: [--no-clean]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,8 @@ repos:
       rev: v0.5.0
       default_phase: push #change to commit if desired
       hooks: #mix and match any of the following:
-        -   id: sbt-fatal-warnings #arguments optional
-            args: [--scope=test:compile]
         -   id: sbt-unused-imports #includes fatal warnings, arguments optional
             args: [--scope=test:compile]
         -   id: sbt-scalafmt-apply
             args: [--no-clean]
-            stages: [push]
+            stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
       rev: v0.5.0
       hooks:
         -   id: sbt-unused-imports
-            args: [--scope=test:compile]
             stages: [pre-commit, pre-push]
         -   id: sbt-scalafmt-apply
             args: [--no-clean]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       hooks:
         -   id: sbt-unused-imports
             args: [--scope=test:compile]
-            stages: [pre-push]
+            stages: [pre-commit, pre-push]
         -   id: sbt-scalafmt-apply
             args: [--no-clean]
-            stages: [pre-push]
+            stages: [pre-commit, pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,8 @@
 repos:
   -   repo: https://github.com/softwaremill/scala-pre-commit-hooks
       rev: v0.5.0
-      default_phase: push #change to commit if desired
-      hooks: #mix and match any of the following:
-        -   id: sbt-unused-imports #includes fatal warnings, arguments optional
+      hooks:
+        -   id: sbt-unused-imports
             args: [--scope=test:compile]
         -   id: sbt-scalafmt-apply
             args: [--no-clean]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/Swiddis/scala-pre-commit-hooks
-      # Temporary revision. This rev allows 122000% faster builds. Switch back to the official repo after it's merged.
+      # Temporary revision. This rev allows 2000% faster builds. Switch back to the official repo after it's merged.
       # See: https://github.com/softwaremill/scala-pre-commit-hooks/pull/17
       rev: e51db1845c66c1b9a278be320dbaa345bd52fb9a
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,6 @@
 repos:
-  -   repo: https://github.com/Swiddis/scala-pre-commit-hooks
-      # Temporary revision. This rev allows 2000% faster builds. Switch back to the official repo after it's merged.
-      # See: https://github.com/softwaremill/scala-pre-commit-hooks/pull/17
-      rev: e51db1845c66c1b9a278be320dbaa345bd52fb9a
+  -   repo: https://github.com/softwaremill/scala-pre-commit-hooks
+      rev: v0.5.1
       hooks:
         -   id: sbt-unused-imports
             args: [--no-clean, --scope=test:compile, --client]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  -   repo: https://github.com/softwaremill/scala-pre-commit-hooks
+      rev: v0.5.0
+      default_phase: push #change to commit if desired
+      hooks: #mix and match any of the following:
+        -   id: sbt-fatal-warnings #arguments optional
+            args: [--scope=test:compile]
+        -   id: sbt-unused-imports #includes fatal warnings, arguments optional
+            args: [--scope=test:compile]
+        -   id: sbt-scalafmt-apply
+            args: [--no-clean]
+            stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,12 @@
 repos:
-  -   repo: https://github.com/softwaremill/scala-pre-commit-hooks
-      rev: v0.5.0
+  -   repo: https://github.com/Swiddis/scala-pre-commit-hooks
+      # Temporary revision. This rev allows 122000% faster builds. Switch back to the official repo after it's merged.
+      # See: https://github.com/softwaremill/scala-pre-commit-hooks/pull/17
+      rev: e51db1845c66c1b9a278be320dbaa345bd52fb9a
       hooks:
         -   id: sbt-unused-imports
-            args: [--scope=test:compile]
+            args: [--no-clean, --scope=test:compile, --client]
             stages: [pre-commit, pre-push]
         -   id: sbt-scalafmt-apply
-            args: [--no-clean]
+            args: [--no-clean, --client]
             stages: [pre-commit, pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
       hooks:
         -   id: sbt-unused-imports
             args: [--scope=test:compile]
+            stages: [pre-push]
         -   id: sbt-scalafmt-apply
             args: [--no-clean]
             stages: [pre-push]

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -61,16 +61,31 @@ sbt integtest/awsIntegration
 [info] All tests passed.
 ```
 
-## Scala Formatting Guidelines
+## Linting
 
-For Scala code, flint use [spark scalastyle](https://github.com/apache/spark/blob/master/scalastyle-config.xml). Before submitting the PR, 
-make sure to use "scalafmtAll" to format the code. read more in [scalafmt sbt](https://scalameta.org/scalafmt/docs/installation.html#sbt)
+The easiest way to ensure the code passes linting is with `pre-commit`.
+Using any recent Python version:
+
 ```
-sbt scalafmtAll
+$ pip install pre-commit
+$ pre-commit install
 ```
-The code style is automatically checked, but users can also manually check it.
+
+This will automatically fix formatting and check for other Scala issues on every push.
+
+### Scala Formatting Guidelines
+
+For Scala code, flint use [spark scalastyle](https://github.com/apache/spark/blob/master/scalastyle-config.xml). To automatically apply the scalastyle to all files:
+
 ```
-sbt scalastyle
+$ sbt scalafmtAll
 ```
-For IntelliJ user, read more in [scalafmt IntelliJ](https://scalameta.org/scalafmt/docs/installation.html#intellij) to integrate 
+
+Alternatively, to just check changed files in the working tree:
+
+```
+$ sbt scalastyle
+```
+
+For IntelliJ users, read more in [scalafmt IntelliJ](https://scalameta.org/scalafmt/docs/installation.html#intellij) to integrate 
 scalafmt with IntelliJ


### PR DESCRIPTION
### Description
Has this ever happened to you?

![image](https://github.com/user-attachments/assets/1c59d86f-1850-4f8f-b857-8e8400983c09)

With the power of [modern technology](https://pre-commit.com/), it no longer has to!

---

Has no effect if you don't want to opt-in, but speaking for myself, I've forgotten to scalafmtApply for the last time.

If you do opt-in, with the `--client` hotfix, checking styling and warnings will automatically happen on every commit, and it goes ~20x faster than if you do it yourself.

### Related Issues
N/A

### Check List
- [X] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [X] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
