### PR TITLE
fix snapshot uploading

### DIFF
--- a/.github/publish-utils.sh
+++ b/.github/publish-utils.sh
@@ -233,7 +233,11 @@ publish_snapshots_and_update_metadata() {
   echo "::add-mask::$SONATYPE_PASSWORD"
   export SNAPSHOT_REPO_URL="https://aws.oss.sonatype.org/content/repositories/snapshots/"
 
-  # Publish snapshots to maven
+  mkdir -p build/resources/publish/
+  cp build/publish/publish-snapshot.sh build/resources/publish/
+  chmod +x build/resources/publish/publish-snapshot.sh
+
+  # Continue with the original flow
   cd build/resources/publish/
   cp -a $HOME/.m2/repository/* ./
   ./publish-snapshot.sh ./

--- a/.github/publish-utils.sh
+++ b/.github/publish-utils.sh
@@ -233,6 +233,7 @@ publish_snapshots_and_update_metadata() {
   echo "::add-mask::$SONATYPE_PASSWORD"
   export SNAPSHOT_REPO_URL="https://aws.oss.sonatype.org/content/repositories/snapshots/"
 
+  # Make a temp directory for publish-snapshot.sh
   mkdir -p build/resources/publish/
   cp build/publish/publish-snapshot.sh build/resources/publish/
   chmod +x build/resources/publish/publish-snapshot.sh

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: 'opensearch-project/opensearch-build-libraries'
+          repository: 'opensearch-project/opensearch-build'
           path: 'build'
 
       - name: Configure AWS credentials


### PR DESCRIPTION
Update snapshot uploading

I changed the path to fetch the publish-snapshot.sh(https://github.com/opensearch-project/opensearch-build/blob/main/publish/publish-snapshot.sh) from opensearch-build-libraries to opensearch-build since this file no longer exists in opensearch-build-libraries