### PR TITLE
removing usage of doc id in skipping index while document creation

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndex.scala
@@ -87,7 +87,6 @@ case class FlintSparkSkippingIndex(
     df.getOrElse(spark.read.table(quotedTableName(tableName)))
       .groupBy(input_file_name().as(FILE_PATH_COLUMN))
       .agg(namedAggFuncs.head, namedAggFuncs.tail: _*)
-      .withColumn(ID_COLUMN, sha1(col(FILE_PATH_COLUMN)))
   }
 }
 

--- a/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndexSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingIndexSuite.scala
@@ -69,7 +69,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
 
     val df = spark.createDataFrame(Seq(("hello", 20))).toDF("name", "age")
     val indexDf = index.build(spark, Some(df))
-    indexDf.schema.fieldNames should contain only ("name", FILE_PATH_COLUMN, ID_COLUMN)
+    indexDf.schema.fieldNames should contain only ("name", FILE_PATH_COLUMN)
   }
 
   test("can build index on table name with special characters") {
@@ -82,7 +82,7 @@ class FlintSparkSkippingIndexSuite extends FlintSuite {
 
     val df = spark.createDataFrame(Seq(("hello", 20))).toDF("name", "age")
     val indexDf = index.build(spark, Some(df))
-    indexDf.schema.fieldNames should contain only ("name", FILE_PATH_COLUMN, ID_COLUMN)
+    indexDf.schema.fieldNames should contain only ("name", FILE_PATH_COLUMN)
   }
 
   // Test index build for different column type


### PR DESCRIPTION
### Description
_Describe what this change achieves._
In OpenSearch Serverless (AOSS) time series collections, document creation and update operations fail when a document ID is specified, this change removed the usage of doc ID while writing as it is not required for skipping index to work.

### Related Issues
_List any issues this PR will resolve, e.g. Resolves [...]._
https://github.com/opensearch-project/opensearch-spark/issues/1012
### Check List
- [ NA] Updated documentation (docs/ppl-lang/README.md)
- [NA ] Implemented unit tests
- [ NA] Implemented tests for combination with other commands
- [ NA] New added source code should include a copyright header
- [ Y] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
