### PR TITLE
maven repo migration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)"
+    ],
+    "deny": [],
+    "ask": [],
+    "defaultMode": "acceptEdits"
+  }
+}

--- a/.github/publish-utils.sh
+++ b/.github/publish-utils.sh
@@ -97,7 +97,7 @@ process_project_metadata() {
   METADATA_FILE="${TEMP_DIR}/maven-metadata.xml"
 
   # Download the current metadata from the repository
-  META_URL="https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/${project}/${current_version}/maven-metadata.xml"
+  META_URL="https://central.sonatype.com/repository/maven-snapshots/org/opensearch/${project}/${current_version}/maven-metadata.xml"
   echo "Downloading metadata from ${META_URL}"
 
   # Wait a bit to ensure the metadata file is available after publishing
@@ -226,12 +226,14 @@ publish_snapshots_and_update_metadata() {
   local current_version="$1"
   local commit_id="$2"
 
-  # Get credentials to upload files directly
-  export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-  export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+  # Credentials are loaded from 1Password via environment variables
+  if [ -z "$SONATYPE_USERNAME" ] || [ -z "$SONATYPE_PASSWORD" ]; then
+    echo "Error: SONATYPE_USERNAME or SONATYPE_PASSWORD not set"
+    exit 1
+  fi
   echo "::add-mask::$SONATYPE_USERNAME"
   echo "::add-mask::$SONATYPE_PASSWORD"
-  export SNAPSHOT_REPO_URL="https://aws.oss.sonatype.org/content/repositories/snapshots/"
+  export SNAPSHOT_REPO_URL="https://central.sonatype.com/repository/maven-snapshots/"
 
   # Make a temp directory for publish-snapshot.sh
   mkdir -p build/resources/publish/

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -24,8 +24,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
-        id: checkout
+      - uses: actions/checkout@v4
 
       # Extract version from build.sbt file
       - name: Extract version from build.sbt
@@ -45,7 +44,7 @@ jobs:
           echo "Using commit ID: ${COMMIT_ID}"
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 11
@@ -64,16 +63,20 @@ jobs:
           echo "Checking published artifacts:"
           find $HOME/.m2/repository/org/opensearch/ -name "*${{ steps.extract_version.outputs.version }}*" || echo "No artifacts found with the expected version"
 
-      - uses: actions/checkout@v3
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
+        with:
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
+
+      - uses: actions/checkout@v4
         with:
           repository: 'opensearch-project/opensearch-build'
           path: 'build'
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1.7.0
-        with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
 
       - name: Generate SHA and MD5 checksums
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ logs/
 *.zip
 
 gen/
+
+# Claude Code
+./claude

--- a/docs/index.md
+++ b/docs/index.md
@@ -714,7 +714,7 @@ For now, only single or conjunct conditions (conditions connected by AND) in WHE
 Flint use [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html). When running in EMR Spark, Flint use executionRole credentials
 ```
 --conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:1.0.0-SNAPSHOT \
---conf spark.jars.repositories=https://aws.oss.sonatype.org/content/repositories/snapshots \
+--conf spark.jars.repositories=https://central.sonatype.com/repository/maven-snapshots \
 --conf spark.emr-serverless.driverEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.datasource.flint.host=opensearch-domain.us-west-2.es.amazonaws.com \
@@ -756,7 +756,7 @@ Flint use [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJa
 3. Set the spark.datasource.flint.customAWSCredentialsProvider property with value as com.amazonaws.emr.AssumeRoleAWSCredentialsProvider. Set the environment variable ASSUME_ROLE_CREDENTIALS_ROLE_ARN with the ARN value of CrossAccountRoleB.
 ```
 --conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:1.0.0-SNAPSHOT \
---conf spark.jars.repositories=https://aws.oss.sonatype.org/content/repositories/snapshots \
+--conf spark.jars.repositories=https://central.sonatype.com/repository/maven-snapshots \
 --conf spark.emr-serverless.driverEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.datasource.flint.host=opensearch-domain.us-west-2.es.amazonaws.com \

--- a/project/GrammarDownload.scala
+++ b/project/GrammarDownload.scala
@@ -18,12 +18,12 @@ object GrammarDownload {
 
   // Add resolver for grammar downloads
   val grammarResolvers: Seq[MavenRepository] = Seq(
-    "AWS OSS Sonatype Snapshots" at "https://aws.oss.sonatype.org/content/repositories/snapshots"
+    "Sonatype Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots"
   )
 
   // Helper to find latest snapshot version and construct proper URL
   def findLatestSnapshotArtifactInfo(artifactId: String, version: String): (String, String) = {
-    val metadataUrl = s"https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/$artifactId/$version/maven-metadata.xml"
+    val metadataUrl = s"https://central.sonatype.com/repository/maven-snapshots/org/opensearch/$artifactId/$version/maven-metadata.xml"
 
     try {
       val metadata = XML.load(new URL(metadataUrl))
@@ -115,7 +115,7 @@ object GrammarDownload {
     log.info(s"Found latest snapshot version: $snapshotVersion")
 
     // Download zip file
-    val zipUrl = s"https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/$artifactId/$version/$artifactId-$snapshotVersion.zip"
+    val zipUrl = s"https://central.sonatype.com/repository/maven-snapshots/org/opensearch/$artifactId/$version/$artifactId-$snapshotVersion.zip"
     val zipFile = tempDir / s"$artifactId-$snapshotVersion.zip"
     log.info(s"Downloading grammar from $zipUrl")
     downloadFile(zipUrl, zipFile)


### PR DESCRIPTION
Update the Maven Snapshots publish URL in accordance with the recent Sonatype migration.
https://central.sonatype.org/publish/publish-portal-snapshots/

We have stored the onepassword token in this repo secrets and new credentials for Sonatypes username & password have been stored in onepassword. These credentials will be exported as env variables which used by maven publish.