### PR TITLE
Switch from AWS OSS sonatype to Maven Central

### DIFF
--- a/.github/publish-utils.sh
+++ b/.github/publish-utils.sh
@@ -97,7 +97,7 @@ process_project_metadata() {
   METADATA_FILE="${TEMP_DIR}/maven-metadata.xml"
 
   # Download the current metadata from the repository
-  META_URL="https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/${project}/${current_version}/maven-metadata.xml"
+  META_URL="https://central.sonatype.com/repository/maven-snapshots/org/opensearch/${project}/${current_version}/maven-metadata.xml"
   echo "Downloading metadata from ${META_URL}"
 
   # Wait a bit to ensure the metadata file is available after publishing

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429,999 --exclude-mail **/*.html **/*.md **/*.txt --exclude-file .lychee.excludes
+          args: --accept=200,403,429,999 **/*.html **/*.md **/*.txt --exclude-file .lychee.excludes
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -69,11 +69,15 @@ jobs:
           repository: 'opensearch-project/opensearch-build'
           path: 'build'
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1.7.0
+      - name: Load secrets (for Sonatype)
+        uses: 1password/load-secrets-action@v3
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
 
       - name: Generate SHA and MD5 checksums
         run: |

--- a/.lychee.excludes
+++ b/.lychee.excludes
@@ -1,4 +1,4 @@
-https://aws.oss.sonatype.*
+https://central.sonatype.com/*
 http://localhost.*
 https://localhost.*
 https://odfe-node1:9200/.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -714,7 +714,7 @@ For now, only single or conjunct conditions (conditions connected by AND) in WHE
 Flint use [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html). When running in EMR Spark, Flint use executionRole credentials
 ```
 --conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:1.0.0-SNAPSHOT \
---conf spark.jars.repositories=https://aws.oss.sonatype.org/content/repositories/snapshots \
+--conf spark.jars.repositories=https://central.sonatype.com/repository/maven-snapshots/ \
 --conf spark.emr-serverless.driverEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.datasource.flint.host=opensearch-domain.us-west-2.es.amazonaws.com \
@@ -756,7 +756,7 @@ Flint use [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJa
 3. Set the spark.datasource.flint.customAWSCredentialsProvider property with value as com.amazonaws.emr.AssumeRoleAWSCredentialsProvider. Set the environment variable ASSUME_ROLE_CREDENTIALS_ROLE_ARN with the ARN value of CrossAccountRoleB.
 ```
 --conf spark.jars.packages=org.opensearch:opensearch-spark-standalone_2.12:1.0.0-SNAPSHOT \
---conf spark.jars.repositories=https://aws.oss.sonatype.org/content/repositories/snapshots \
+--conf spark.jars.repositories=https://central.sonatype.com/repository/maven-snapshots/ \
 --conf spark.emr-serverless.driverEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.executorEnv.JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 \
 --conf spark.datasource.flint.host=opensearch-domain.us-west-2.es.amazonaws.com \


### PR DESCRIPTION
### Description
Switches from the deprecated AWS OSS Sonatype server to Maven Central.

Based on https://github.com/opensearch-project/opensearch-java/pull/1634

### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/5548

### Check List
- [x] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [x] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
