### PR TITLE
Disbale commit-history file uploading

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - 0.*
+      - fix-snapshot-upload
 
 # Concurrency control to prevent race conditions in commit mapping
 concurrency:

--- a/project/GrammarDownload.scala
+++ b/project/GrammarDownload.scala
@@ -18,12 +18,12 @@ object GrammarDownload {
 
   // Add resolver for grammar downloads
   val grammarResolvers: Seq[MavenRepository] = Seq(
-    "AWS OSS Sonatype Snapshots" at "https://aws.oss.sonatype.org/content/repositories/snapshots"
+    "AWS OSS Sonatype Snapshots" at "https://central.sonatype.com/repository/maven-snapshots"
   )
 
   // Helper to find latest snapshot version and construct proper URL
   def findLatestSnapshotArtifactInfo(artifactId: String, version: String): (String, String) = {
-    val metadataUrl = s"https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/$artifactId/$version/maven-metadata.xml"
+    val metadataUrl = s"https://central.sonatype.com/repository/maven-snapshots/org/opensearch/$artifactId/$version/maven-metadata.xml"
 
     try {
       val metadata = XML.load(new URL(metadataUrl))
@@ -115,7 +115,7 @@ object GrammarDownload {
     log.info(s"Found latest snapshot version: $snapshotVersion")
 
     // Download zip file
-    val zipUrl = s"https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/$artifactId/$version/$artifactId-$snapshotVersion.zip"
+    val zipUrl = s"https://central.sonatype.com/repository/maven-snapshots/org/opensearch/$artifactId/$version/$artifactId-$snapshotVersion.zip"
     val zipFile = tempDir / s"$artifactId-$snapshotVersion.zip"
     log.info(s"Downloading grammar from $zipUrl")
     downloadFile(zipUrl, zipFile)


### PR DESCRIPTION
## Description
Disable commit-history file creation in snapshot publishing workflow to comply with Maven Central repository restrictions.

## Why this change is needed
Maven Central Sonatype repository enforces strict rules about the types of files that can be uploaded to their snapshot repository. 

Our custom commit-history-*.json files are being rejected by Maven Central as they are non-standard artifacts

What still works

- Snapshot artifacts are published normally
- Commit IDs are still injected into maven-metadata.xml files for traceability
- All standard Maven repository operations continue to function

What is disabled

- Creation of commit-history JSON files in the artifact structure
- Upload of commit mapping files to the repository

Tested on #1265 



