### PR TITLE
Change grammar fetching from central maven to s3

### DIFF
--- a/project/GrammarDownload.scala
+++ b/project/GrammarDownload.scala
@@ -18,12 +18,12 @@ object GrammarDownload {
 
   // Add resolver for grammar downloads
   val grammarResolvers: Seq[MavenRepository] = Seq(
-    "AWS OSS Sonatype Snapshots" at "https://central.sonatype.com/repository/maven-snapshots"
+    "AWS OSS Sonatype Snapshots" at "https://ci.opensearch.org/ci/dbc/snapshots/maven"
   )
 
   // Helper to find latest snapshot version and construct proper URL
   def findLatestSnapshotArtifactInfo(artifactId: String, version: String): (String, String) = {
-    val metadataUrl = s"https://central.sonatype.com/repository/maven-snapshots/org/opensearch/$artifactId/$version/maven-metadata.xml"
+    val metadataUrl = s"https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/$artifactId/$version/maven-metadata.xml"
 
     try {
       val metadata = XML.load(new URL(metadataUrl))
@@ -115,7 +115,7 @@ object GrammarDownload {
     log.info(s"Found latest snapshot version: $snapshotVersion")
 
     // Download zip file
-    val zipUrl = s"https://central.sonatype.com/repository/maven-snapshots/org/opensearch/$artifactId/$version/$artifactId-$snapshotVersion.zip"
+    val zipUrl = s"https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/$artifactId/$version/$artifactId-$snapshotVersion.zip"
     val zipFile = tempDir / s"$artifactId-$snapshotVersion.zip"
     log.info(s"Downloading grammar from $zipUrl")
     downloadFile(zipUrl, zipFile)


### PR DESCRIPTION
### Description
Change grammar fetching from central maven to s3

### Related PRs
Maven repo migration: https://github.com/opensearch-project/sql/pull/4588
Unblock CI: #1273 


### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [ ] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
