### PR TITLE
Fix aws credentials for Publishing snapshots to maven

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -70,15 +70,24 @@ jobs:
           repository: 'opensearch-project/opensearch-build'
           path: 'build'
 
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          MAVEN_SNAPSHOTS_S3_REPO: op://opensearch-infra-secrets/maven-snapshots-s3/repo
+          MAVEN_SNAPSHOTS_S3_ROLE: op://opensearch-infra-secrets/maven-snapshots-s3/role
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: ${{ secrets.MAVEN_SNAPSHOTS_S3_ROLE }}
+          role-to-assume: ${{ env.MAVEN_SNAPSHOTS_S3_ROLE }}
           aws-region: us-east-1
 
       - name: Export SNAPSHOT_REPO_URL
         run: |
-          echo "SNAPSHOT_REPO_URL=${{ secrets.MAVEN_SNAPSHOTS_S3_REPO }}" >> $GITHUB_ENV
+          echo "SNAPSHOT_REPO_URL=${{ env.MAVEN_SNAPSHOTS_S3_REPO }}" >> $GITHUB_ENV
 
       - name: Generate SHA and MD5 checksums
         run: |


### PR DESCRIPTION
### Description
Fix aws credentials for Publishing snapshots to maven


### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [ ] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
