### PR TITLE
Changed Java utils logging to SLF4J logger for flint-core package.

### DIFF
--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricsUtil.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricsUtil.java
@@ -17,14 +17,15 @@ import org.apache.spark.metrics.source.Source;
 import scala.collection.Seq;
 
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for managing metrics in the OpenSearch Flint context.
  */
 public final class MetricsUtil {
 
-    private static final Logger LOG = Logger.getLogger(MetricsUtil.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(MetricsUtil.class);
 
     private MetricsUtil() {
         // Private constructor to prevent instantiation
@@ -174,7 +175,7 @@ public final class MetricsUtil {
     public static void registerGauge(String metricName, final AtomicInteger value, boolean isIndexMetric) {
         MetricRegistry metricRegistry = getMetricRegistry(isIndexMetric);
         if (metricRegistry == null) {
-            LOG.warning("MetricRegistry not available, cannot register gauge: " + metricName);
+            LOG.warn("MetricRegistry not available, cannot register gauge: " + metricName);
             return;
         }
         metricRegistry.register(metricName, (Gauge<Integer>) value::get);
@@ -193,7 +194,7 @@ public final class MetricsUtil {
     private static MetricRegistry getMetricRegistry(boolean isIndexMetric) {
         SparkEnv sparkEnv = SparkEnv.get();
         if (sparkEnv == null) {
-            LOG.warning("Spark environment not available, cannot access MetricRegistry.");
+            LOG.warn("Spark environment not available, cannot access MetricRegistry.");
             return null;
         }
 

--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/reporter/DimensionUtils.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/reporter/DimensionUtils.java
@@ -7,9 +7,8 @@ package org.opensearch.flint.core.metrics.reporter;
 
 import java.util.Map;
 import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import org.apache.commons.lang3.StringUtils;
@@ -22,7 +21,7 @@ import org.apache.spark.SparkEnv;
  * application ID, and more.
  */
 public class DimensionUtils {
-    private static final Logger LOG = Logger.getLogger(DimensionUtils.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(DimensionUtils.class);
     private static final String DIMENSION_JOB_ID = "jobId";
     private static final String DIMENSION_JOB_TYPE = "jobType";
     private static final String DIMENSION_APPLICATION_ID = "applicationId";
@@ -136,10 +135,10 @@ public class DimensionUtils {
             if (SparkEnv.get() != null && SparkEnv.get().conf() != null) {
                 propertyValue = SparkEnv.get().conf().get(sparkConfKey, defaultValue);
             } else {
-                LOG.warning("Spark environment or configuration is not available, defaulting to provided default value.");
+                LOG.warn("Spark environment or configuration is not available, defaulting to provided default value.");
             }
         } catch (Exception e) {
-            LOG.log(Level.SEVERE, "Error accessing Spark configuration with key: " + sparkConfKey + ", defaulting to provided default value.", e);
+            LOG.error("Error accessing Spark configuration with key: " + sparkConfKey + ", defaulting to provided default value.", e);
             throw e;
         }
         return propertyValue;

--- a/flint-core/src/main/scala/org/opensearch/flint/core/auth/AWSRequestSigV4ASigningApacheInterceptor.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/auth/AWSRequestSigV4ASigningApacheInterceptor.java
@@ -34,8 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.http.protocol.HttpCoreContext.HTTP_TARGET_HOST;
 import static org.opensearch.flint.core.auth.AWSRequestSigningApacheInterceptor.nvpToMapParams;
@@ -47,7 +47,7 @@ import static org.opensearch.flint.core.auth.AWSRequestSigningApacheInterceptor.
  * and updates the request headers to include the signature.
  */
 public class AWSRequestSigV4ASigningApacheInterceptor implements HttpRequestInterceptor {
-    private static final Logger LOG = Logger.getLogger(AWSRequestSigV4ASigningApacheInterceptor.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(AWSRequestSigV4ASigningApacheInterceptor.class);
 
     private static final String HTTPS_PROTOCOL = "https";
     private static final int HTTPS_PORT = 443;
@@ -170,7 +170,7 @@ public class AWSRequestSigV4ASigningApacheInterceptor implements HttpRequestInte
         try {
             return signer.sign(request, executionAttributes);
         } catch (Exception e) {
-            LOG.log(Level.SEVERE, "Error Sigv4a signing the request", e);
+            LOG.error("Error Sigv4a signing the request", e);
             throw e;
         }
     }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/FlintRetryOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/FlintRetryOptions.java
@@ -19,7 +19,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.flint.core.http.handler.ExceptionClassNameFailurePredicate;
@@ -32,7 +33,7 @@ import java.io.Serializable;
  */
 public class FlintRetryOptions implements Serializable {
 
-  private static final Logger LOG = Logger.getLogger(FlintRetryOptions.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(FlintRetryOptions.class);
 
   /**
    * All Flint options.
@@ -109,11 +110,11 @@ public class FlintRetryOptions implements Serializable {
   }
 
   private static <T> void onFailure(ExecutionAttemptedEvent<T> event) {
-    LOG.severe("Attempt to execute request failed: " + event);
+    LOG.error("Attempt to execute request failed: " + event);
   }
 
   private static <T> void onRetry(ExecutionAttemptedEvent<T> event) {
-    LOG.warning("Retrying failed request at #" + event.getAttemptCount());
+    LOG.warn("Retrying failed request at #" + event.getAttemptCount());
   }
 
   private String getServiceName() {

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/RetryableHttpAsyncClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/RetryableHttpAsyncClient.java
@@ -12,7 +12,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
@@ -26,7 +27,7 @@ import org.opensearch.flint.core.FlintOptions;
  */
 public class RetryableHttpAsyncClient extends CloseableHttpAsyncClient {
 
-  private static final Logger LOG = Logger.getLogger(RetryableHttpAsyncClient.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(RetryableHttpAsyncClient.class);
 
   /**
    * Delegated internal HTTP client that execute the request underlying.
@@ -108,7 +109,7 @@ public class RetryableHttpAsyncClient extends CloseableHttpAsyncClient {
                 return futureGet.call();
               });
         } catch (FailsafeException ex) {
-          LOG.severe("Request failed permanently. Re-throwing original exception.");
+          LOG.error("Request failed permanently. Re-throwing original exception.");
 
           // Failsafe will wrap checked exception, such as ExecutionException
           // So here we have to unwrap failsafe exception and rethrow it

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/ErrorStacktraceFailurePredicate.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/ErrorStacktraceFailurePredicate.java
@@ -8,14 +8,15 @@ package org.opensearch.flint.core.http.handler;
 import dev.failsafe.function.CheckedPredicate;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Failure predicate that determines if retryable based on error stacktrace iteration.
  */
 public abstract class ErrorStacktraceFailurePredicate implements CheckedPredicate<Throwable> {
 
-  private static final Logger LOG = Logger.getLogger(ErrorStacktraceFailurePredicate.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(ErrorStacktraceFailurePredicate.class);
 
   /**
    * This base class implementation iterates the stacktrace and pass each exception

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/ExceptionClassNameFailurePredicate.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/ExceptionClassNameFailurePredicate.java
@@ -6,21 +6,21 @@
 package org.opensearch.flint.core.http.handler;
 
 import static java.util.Collections.newSetFromMap;
-import static java.util.logging.Level.SEVERE;
 
 import dev.failsafe.function.CheckedPredicate;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import java.util.WeakHashMap;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Failure handler based on exception class type check.
  */
 public class ExceptionClassNameFailurePredicate extends ErrorStacktraceFailurePredicate {
 
-  private static final Logger LOG = Logger.getLogger(ErrorStacktraceFailurePredicate.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(ExceptionClassNameFailurePredicate.class);
 
   /**
    * Retryable exception class types.
@@ -63,7 +63,7 @@ public class ExceptionClassNameFailurePredicate extends ErrorStacktraceFailurePr
       return (Class<? extends Throwable>) Class.forName(className);
     } catch (ClassNotFoundException e) {
       String errorMsg = "Failed to load class " + className;
-      LOG.log(SEVERE, errorMsg, e);
+      LOG.error(errorMsg, e);
       throw new IllegalStateException(errorMsg);
     }
   }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/HttpAOSSResultPredicate.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/HttpAOSSResultPredicate.java
@@ -11,7 +11,8 @@ import org.apache.http.HttpResponse;
 import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.util.EntityUtils;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Failure handler based on HTTP response from AOSS.
@@ -20,7 +21,7 @@ import java.util.logging.Logger;
  */
 public class HttpAOSSResultPredicate<T> implements CheckedPredicate<T> {
 
-  private static final Logger LOG = Logger.getLogger(HttpAOSSResultPredicate.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(HttpAOSSResultPredicate.class);
 
   public static final int BAD_REQUEST_STATUS_CODE = 400;
   public static final String RESOURCE_ALREADY_EXISTS_EXCEPTION_MESSAGE = "resource_already_exists_exception";

--- a/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/HttpStatusCodeResultPredicate.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/http/handler/HttpStatusCodeResultPredicate.java
@@ -8,7 +8,8 @@ package org.opensearch.flint.core.http.handler;
 import dev.failsafe.function.CheckedPredicate;
 import java.util.Arrays;
 import java.util.Set;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 import org.apache.http.HttpResponse;
 
@@ -19,7 +20,7 @@ import org.apache.http.HttpResponse;
  */
 public class HttpStatusCodeResultPredicate<T> implements CheckedPredicate<T> {
 
-  private static final Logger LOG = Logger.getLogger(HttpStatusCodeResultPredicate.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(HttpStatusCodeResultPredicate.class);
 
   /**
    * Retryable HTTP status code list

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchClient.java
@@ -18,12 +18,13 @@ import org.opensearch.flint.core.FlintOptions;
 import org.opensearch.flint.core.IRestHighLevelClient;
 import org.opensearch.flint.core.metrics.MetricConstants;
 import org.opensearch.flint.core.metrics.MetricsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.Option;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -31,7 +32,7 @@ import java.util.stream.Collectors;
  */
 public class FlintOpenSearchClient implements FlintClient {
 
-  private static final Logger LOG = Logger.getLogger(FlintOpenSearchClient.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(FlintOpenSearchClient.class);
 
   private final FlintOptions options;
 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLog.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.flint.core.storage;
 
-import static java.util.logging.Level.SEVERE;
 import static org.opensearch.flint.core.storage.FlintMetadataLogEntryOpenSearchConverter.constructLogEntry;
 import static org.opensearch.flint.core.storage.FlintMetadataLogEntryOpenSearchConverter.toJson;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy;
@@ -16,7 +15,8 @@ import java.io.IOException;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.delete.DeleteRequest;
@@ -45,7 +45,7 @@ import org.opensearch.flint.core.IRestHighLevelClient;
  */
 public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadataLogEntry> {
 
-  private static final Logger LOG = Logger.getLogger(FlintOpenSearchMetadataLog.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(FlintOpenSearchMetadataLog.class);
 
   /**
    * Flint options to create Rest OpenSearch client
@@ -77,7 +77,7 @@ public class FlintOpenSearchMetadataLog implements FlintMetadataLog<FlintMetadat
     FlintMetadataLogEntry latest;
     if (!exists()) {
       String errorMsg = "Flint Metadata Log index not found " + metadataLogIndexName;
-      LOG.log(SEVERE, errorMsg);
+      LOG.error(errorMsg);
       throw new IllegalStateException(errorMsg);
     }
     if (logEntry.id().isEmpty()) {

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/FlintOpenSearchMetadataLogService.java
@@ -7,7 +7,8 @@ package org.opensearch.flint.core.storage;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.GetIndexRequest;
@@ -26,7 +27,7 @@ import org.opensearch.flint.core.metadata.log.DefaultOptimisticTransaction;
  */
 public class FlintOpenSearchMetadataLogService implements FlintMetadataLogService {
 
-  private static final Logger LOG = Logger.getLogger(FlintOpenSearchMetadataLogService.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(FlintOpenSearchMetadataLogService.class);
 
   public final static String METADATA_LOG_INDEX_NAME_PREFIX = ".query_execution_request";
 
@@ -74,7 +75,7 @@ public class FlintOpenSearchMetadataLogService implements FlintMetadataLogServic
           initIndexMetadataLog();
         } else {
           String errorMsg = "Metadata log index not found " + metadataLogIndexName;
-          LOG.warning(errorMsg);
+          LOG.warn(errorMsg);
           return Optional.empty();
         }
       }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchBulkWrapper.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchBulkWrapper.java
@@ -16,7 +16,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkRequest;
@@ -37,7 +38,7 @@ import org.opensearch.rest.RestStatus;
  */
 public class OpenSearchBulkWrapper {
 
-  private static final Logger LOG = Logger.getLogger(OpenSearchBulkWrapper.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(OpenSearchBulkWrapper.class);
 
   private final RetryPolicy<BulkResponse> retryPolicy;
   private final BulkRequestRateLimiter rateLimiter;
@@ -111,7 +112,7 @@ public class OpenSearchBulkWrapper {
           });
       return res;
     } catch (FailsafeException ex) {
-      LOG.severe("Request failed permanently. Re-throwing original exception.");
+      LOG.error("Request failed permanently. Re-throwing original exception.");
 
       // unwrap original exception and throw
       throw new RuntimeException(ex.getCause());

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchQueryReader.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchQueryReader.java
@@ -13,7 +13,8 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.opensearch.flint.core.metrics.MetricConstants.REQUEST_METADATA_READ_METRIC_PREFIX;
 
@@ -22,7 +23,7 @@ import static org.opensearch.flint.core.metrics.MetricConstants.REQUEST_METADATA
  */
 public class OpenSearchQueryReader extends OpenSearchReader {
 
-  private static final Logger LOG = Logger.getLogger(OpenSearchQueryReader.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(OpenSearchQueryReader.class);
 
   public OpenSearchQueryReader(IRestHighLevelClient client, String indexName, SearchSourceBuilder searchSourceBuilder) {
     super(client, new SearchRequest().indices(indexName).source(searchSourceBuilder));

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchSearchAfterQueryReader.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchSearchAfterQueryReader.java
@@ -15,7 +15,8 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 
 /**
@@ -23,8 +24,7 @@ import java.util.stream.Collectors;
  */
 public class OpenSearchSearchAfterQueryReader extends OpenSearchReader {
 
-  private static final Logger LOG =
-      Logger.getLogger(OpenSearchSearchAfterQueryReader.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(OpenSearchSearchAfterQueryReader.class);
 
   /**
    * current search_after value, init value is null
@@ -56,7 +56,7 @@ public class OpenSearchSearchAfterQueryReader extends OpenSearchReader {
           .collect(Collectors.joining(",")));
       return response;
     } catch (Exception e) {
-      LOG.warning(e.getMessage());
+      LOG.warn(e.getMessage());
       throw new RuntimeException(e);
     }
   }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchUpdater.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchUpdater.java
@@ -14,8 +14,8 @@ import org.opensearch.flint.core.FlintClient;
 import org.opensearch.flint.core.IRestHighLevelClient;
 
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.opensearch.flint.core.metrics.MetricConstants.REQUEST_METADATA_READ_METRIC_PREFIX;
 import static org.opensearch.flint.core.metrics.MetricConstants.REQUEST_METADATA_WRITE_METRIC_PREFIX;
@@ -26,7 +26,7 @@ import static org.opensearch.flint.core.metrics.MetricConstants.REQUEST_METADATA
  * document updates and upserts with optional optimistic concurrency control.
  */
 public class OpenSearchUpdater {
-    private static final Logger LOG = Logger.getLogger(OpenSearchUpdater.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(OpenSearchUpdater.class);
 
     private final String indexName;
     private final FlintClient flintClient;
@@ -101,7 +101,7 @@ public class OpenSearchUpdater {
 
         if (!exists) {
             String errorMsg = "Index not found: " + indexName;
-            LOG.log(Level.SEVERE, errorMsg);
+            LOG.error(errorMsg);
             throw new IllegalStateException(errorMsg);
         }
     }

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/ratelimit/BulkRequestRateLimiterImpl.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/ratelimit/BulkRequestRateLimiterImpl.java
@@ -7,7 +7,8 @@ package org.opensearch.flint.core.storage.ratelimit;
 
 import com.google.common.util.concurrent.RateLimiter;
 import java.time.Clock;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opensearch.flint.core.FlintOptions;
 import org.opensearch.flint.core.metrics.MetricConstants;
 import org.opensearch.flint.core.metrics.MetricsUtil;
@@ -42,7 +43,7 @@ import org.opensearch.flint.core.storage.RequestRateMeter;
  * Just call acquirePermit and proceed when it returns.
  */
 public class BulkRequestRateLimiterImpl implements BulkRequestRateLimiter, FeedbackHandler {
-  private static final Logger LOG = Logger.getLogger(BulkRequestRateLimiterImpl.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(BulkRequestRateLimiterImpl.class);
 
   /** Minimum rate limit. */
   private final long minRate;
@@ -135,7 +136,7 @@ public class BulkRequestRateLimiterImpl implements BulkRequestRateLimiter, Feedb
   public long handleFeedback(TimeoutRequestFeedback feedbackEvent) {
     long currentRateLimit = getRate();
     if (canDecreaseRate()) {
-      LOG.warning("Decreasing rate. Reason: Bulk request socket/connection timeout.");
+      LOG.warn("Decreasing rate. Reason: Bulk request socket/connection timeout.");
       return (long) (currentRateLimit * decreaseRatioTimeout);
     }
     return currentRateLimit;
@@ -145,7 +146,7 @@ public class BulkRequestRateLimiterImpl implements BulkRequestRateLimiter, Feedb
   public long handleFeedback(RetryableFailureRequestFeedback feedbackEvent) {
     long currentRateLimit = getRate();
     if (canDecreaseRate()) {
-      LOG.warning("Decreasing rate. Reason: Bulk request failed.");
+      LOG.warn("Decreasing rate. Reason: Bulk request failed.");
       return (long) (currentRateLimit * decreaseRatioFailure);
     }
     return currentRateLimit;
@@ -156,7 +157,7 @@ public class BulkRequestRateLimiterImpl implements BulkRequestRateLimiter, Feedb
     long currentRateLimit = getRate();
     if (feedbackEvent.latencyMillis > latencyThresholdMillis) {
       if (canDecreaseRate()) {
-        LOG.warning("Decreasing rate. Reason: Bulk latency high. Latency = " + feedbackEvent.latencyMillis + " exceeds threshold " + latencyThresholdMillis);
+        LOG.warn("Decreasing rate. Reason: Bulk latency high. Latency = " + feedbackEvent.latencyMillis + " exceeds threshold " + latencyThresholdMillis);
         return (long) (currentRateLimit * decreaseRatioLatency);
       }
       return currentRateLimit;
@@ -164,7 +165,7 @@ public class BulkRequestRateLimiterImpl implements BulkRequestRateLimiter, Feedb
     if (isEstimatedCurrentRateCloseToLimit()) {
       return currentRateLimit + increaseStep;
     }
-    LOG.warning("Rate increase blocked. Reason: Current rate is not close to limit " + currentRateLimit);
+    LOG.warn("Rate increase blocked. Reason: Current rate is not close to limit " + currentRateLimit);
     return currentRateLimit;
   }
 
@@ -174,7 +175,7 @@ public class BulkRequestRateLimiterImpl implements BulkRequestRateLimiter, Feedb
    */
   private long getEstimatedCurrentRate() {
     long currentEstimatedRate = requestRateMeter.getCurrentEstimatedRate();
-    LOG.warning("Current estimated rate is " + currentEstimatedRate + " bytes/sec");
+    LOG.warn("Current estimated rate is " + currentEstimatedRate + " bytes/sec");
     return currentEstimatedRate;
   }
 

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/ratelimit/BulkRequestRateLimiterNoop.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/ratelimit/BulkRequestRateLimiterNoop.java
@@ -5,10 +5,11 @@
 
 package org.opensearch.flint.core.storage.ratelimit;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BulkRequestRateLimiterNoop implements BulkRequestRateLimiter {
-  private static final Logger LOG = Logger.getLogger(BulkRequestRateLimiterNoop.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(BulkRequestRateLimiterNoop.class);
 
   public BulkRequestRateLimiterNoop() {
     LOG.info("Rate limit for bulk request was not set.");

--- a/flint-core/src/main/scala/org/opensearch/flint/core/table/OpenSearchCluster.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/table/OpenSearchCluster.java
@@ -15,12 +15,13 @@ import org.opensearch.flint.core.storage.OpenSearchClientUtils;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 
 public class OpenSearchCluster {
 
-  private static final Logger LOG = Logger.getLogger(OpenSearchCluster.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(OpenSearchCluster.class);
 
   /**
    * Creates list of OpenSearchIndexTable instance of indices in OpenSearch domain.


### PR DESCRIPTION
### Description
Fixed NullPointerException in FlintOpenSearchClient.createWriter() caused by null logger context in the SLF4J bridge handler. The exception occurred during Spark task execution when attempting to write data to OpenSearch, specifically at line 125 of FlintOpenSearchClient.java where logging was attempted with a null logger instance.

### Related Issues
Resolves NullPointerException in FlintOpenSearchClient during data writing operations.

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests - Not required as only logger changes
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [Y ] Commits are signed per the DCO using `--signoff`
- [Y ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
