### PR TITLE
Update maven commit_id uploading logic

### DIFF
--- a/.github/publish-utils.sh
+++ b/.github/publish-utils.sh
@@ -41,6 +41,59 @@ publish_snapshots_and_update_metadata() {
   echo "Publishing snapshots using publish-snapshot.sh..."
   ./publish-snapshot.sh ./
 
+  # Update maven-metadata.xml with commitId for each artifact
+  echo "Updating maven-metadata.xml files with commit ID: ${commit_id}"
+
+  local artifacts=("opensearch-spark-standalone_2.12" "opensearch-spark-ppl_2.12" "opensearch-spark-sql-application_2.12")
+
+  for artifact in "${artifacts[@]}"; do
+    local metadata_s3_path="org/opensearch/${artifact}/${current_version}/maven-metadata.xml"
+    local local_metadata="/tmp/maven-metadata-${artifact}.xml"
+
+    echo "Processing metadata for ${artifact}..."
+
+    # Download current metadata from S3
+    if ! aws s3 cp "${SNAPSHOT_REPO_URL}/${metadata_s3_path}" "${local_metadata}"; then
+      echo "Warning: Could not download metadata for ${artifact}, skipping..."
+      continue
+    fi
+
+    # Verify download succeeded
+    if [ -f "${local_metadata}" ]; then
+      echo "Successfully downloaded metadata, size: $(wc -c < "${local_metadata}") bytes"
+    else
+      echo "Error: Metadata file not found after download for ${artifact}, skipping..."
+      continue
+    fi
+
+    # Use xmlstarlet to properly inject commitId into versioning section
+    if command -v xmlstarlet &> /dev/null; then
+      xmlstarlet ed -L -s "/metadata/versioning" -t elem -n "commitId" -v "${commit_id}" "${local_metadata}"
+    else
+      # Fallback to sed if xmlstarlet not available
+      sed -i "s|</versioning>|  <commitId>${commit_id}</commitId>\n  </versioning>|" "${local_metadata}"
+    fi
+
+    # Re-upload modified metadata
+    if ! aws s3 cp "${local_metadata}" "${SNAPSHOT_REPO_URL}/${metadata_s3_path}"; then
+      echo "Error: Failed to upload modified metadata for ${artifact}. Permission denied or path not writable."
+      continue
+    fi
+
+    # Generate and upload checksums
+    sha256sum "${local_metadata}" | awk '{print $1}' > "${local_metadata}.sha256"
+    sha512sum "${local_metadata}" | awk '{print $1}' > "${local_metadata}.sha512"
+
+    if ! aws s3 cp "${local_metadata}.sha256" "${SNAPSHOT_REPO_URL}/${metadata_s3_path}.sha256"; then
+      echo "Warning: Failed to upload sha256 checksum for ${artifact}"
+    fi
+    if ! aws s3 cp "${local_metadata}.sha512" "${SNAPSHOT_REPO_URL}/${metadata_s3_path}.sha512"; then
+      echo "Warning: Failed to upload sha512 checksum for ${artifact}"
+    fi
+
+    echo "Successfully updated metadata for ${artifact} with commitId"
+  done
+
   echo "Snapshot publishing completed successfully"
   echo "Artifacts published to: ${SNAPSHOT_REPO_URL}"
 }


### PR DESCRIPTION
### Description
Update commit_id uploading logic when modifying the `maven-metadata.xml` file

After the maven repo migration, the old logic for uploading commit_id has been deprecated, this PR is to update the uploading logic for it.
