### PR TITLE
emit separate metrics for pre-init conf

### DIFF
--- a/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/metrics/MetricConstants.java
@@ -141,6 +141,16 @@ public final class MetricConstants {
     public static final String STREAMING_SUCCESS_METRIC = "streaming.success.count";
 
     /**
+     * Metric for tracking the count of pre-init warmup queries that completed successfully.
+     */
+    public static final String PREINIT_SUCCESS_METRIC = "preinit.success.count";
+
+    /**
+     * Metric for tracking the count of pre-init warmup queries that have failed.
+     */
+    public static final String PREINIT_FAILED_METRIC = "preinit.failed.count";
+
+    /**
      * Metric for tracking the count of failed heartbeat signals in streaming jobs.
      */
     public static final String STREAMING_HEARTBEAT_FAILED_METRIC = "streaming.heartbeat.failed.count";

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/JobOperator.scala
@@ -284,12 +284,18 @@ case class JobOperator(
       statementRunningCount.decrementAndGet()
     }
 
+    val isPreInitQuery = statement.context
+      .get("spark.sql.local.preinitQuery")
+      .exists(_.toString.equalsIgnoreCase("true"))
+
     val metric = {
-      (exceptionThrown, isStreamingOrBatch) match {
-        case (true, true) => MetricConstants.STREAMING_FAILED_METRIC
-        case (true, false) => MetricConstants.STATEMENT_FAILED_METRIC
-        case (false, true) => MetricConstants.STREAMING_SUCCESS_METRIC
-        case (false, false) => MetricConstants.STATEMENT_SUCCESS_METRIC
+      (exceptionThrown, isStreamingOrBatch, isPreInitQuery) match {
+        case (false, _, true) => MetricConstants.PREINIT_SUCCESS_METRIC
+        case (true, _, true) => MetricConstants.PREINIT_FAILED_METRIC
+        case (true, true, _) => MetricConstants.STREAMING_FAILED_METRIC
+        case (true, false, _) => MetricConstants.STATEMENT_FAILED_METRIC
+        case (false, true, _) => MetricConstants.STREAMING_SUCCESS_METRIC
+        case (false, false, _) => MetricConstants.STATEMENT_SUCCESS_METRIC
       }
     }
 


### PR DESCRIPTION
### Description
Emit separate metrics for a preInit query that consumers might fire before actual query served by the Job.

### Related Issues
_List any issues this PR will resolve, e.g. Resolves [...]._

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [ ] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
