### PR TITLE
Redact customer query content from Flint SQL parser fallback log and …

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlParser.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlParser.scala
@@ -63,9 +63,7 @@ class FlintSparkSqlParser(sparkParser: ParserInterface) extends ParserInterface 
     } catch {
       // Fall back to Spark parse plan logic if flint cannot parse
       case e: ParseException =>
-        logInfo(
-          s"Failed to parse PPL with PPL parser. Falling back to Spark parser. PPL: $sqlText",
-          e)
+        logInfo("Failed to parse with Flint SQL parser. Falling back to Spark parser.", e)
         sparkParser.parsePlan(sqlText)
 
     }

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -459,7 +459,9 @@ trait FlintJobExecutor {
       statusCode: Option[Int] = None): String = {
     throwableHandler.setThrowable(t)
 
-    val errorMessage = s"$messagePrefix: ${t.getMessage}"
+    val rawMessage = Option(t.getMessage).getOrElse("")
+    val sanitizedMessage = rawMessage.split("\n", 2)(0)
+    val errorMessage = s"$messagePrefix: $sanitizedMessage"
     val errorDetails = new java.util.LinkedHashMap[String, String]()
     errorDetails.put("message", errorMessage)
     errorSource.foreach(es => errorDetails.put("ErrorSource", es))

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -29,7 +29,7 @@ import org.opensearch.search.sort.SortOrder
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatestplus.mockito.MockitoSugar
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkContext, SparkException, SparkFunSuite}
 import org.apache.spark.scheduler.SparkListenerApplicationEnd
 import org.apache.spark.sql.FlintREPL.PreShutdownListener
 import org.apache.spark.sql.FlintREPLConfConstants.DEFAULT_QUERY_LOOP_EXECUTION_FREQUENCY
@@ -611,6 +611,91 @@ class FlintREPLTest
     result shouldEqual expectedError
     verify(mockFlintCommand).fail()
     verify(mockFlintCommand).error = Some(expectedError)
+  }
+
+  test(
+    "processQueryException should strip the Spark logical plan annotation from AnalysisException messages") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    // AnalysisException.getMessage = "<simple message>; line X pos Y;\n<plan tree>"
+    // The plan tree contains customer query literals (filter values, arns, account ids)
+    // and must NOT be persisted to logs / DQS / DDB.
+    val analysisErrorWithPlan =
+      "[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name " +
+        "`_CWLBasic_Alias_1`.`arn` cannot be resolved. Did you mean one of the following? " +
+        "[`_CWLBasic_Alias_0`.`arn`].; line 1 pos 295;\n" +
+        "'GlobalLimit 1000\n" +
+        "+- 'Filter (recipientAccountId#16 = 480909524268 AND " +
+        "'_CWLBasic_Alias_1.arn LIKE %customer-secret-bucket%)\n"
+    val exception = new AnalysisException(analysisErrorWithPlan)
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    // The plan tree (everything after the first \n) MUST be stripped.
+    result should not include "GlobalLimit"
+    result should not include "Filter"
+    result should not include "480909524268"
+    result should not include "customer-secret-bucket"
+    // The diagnostic prefix (before \n) MUST be preserved so customers can fix their query.
+    result should include("Fail to analyze query. Cause:")
+    result should include("UNRESOLVED_COLUMN.WITH_SUGGESTION")
+    result should include("Did you mean one of the following?")
+    result should include("line 1 pos 295")
+
+    verify(mockFlintStatement).fail()
+    verify(mockFlintStatement).error = Some(result)
+  }
+
+  test(
+    "processQueryException should strip embedded newlines from SparkException messages with stack-trace-like content") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    val sparkErrorWithEmbeddedDetails =
+      "Job aborted due to stage failure: Task 0 in stage 1.0 failed\n" +
+        "\tat org.apache.spark.scheduler.DAGScheduler.org\n" +
+        "\tat customer.private.path.value=secret-token-abc123"
+    val exception = new SparkException(sparkErrorWithEmbeddedDetails)
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    // Anything after the first \n must be dropped — internal frames may carry literals.
+    result should not include "DAGScheduler"
+    result should not include "secret-token-abc123"
+    // First line (human-readable summary) is preserved.
+    result should include("Spark exception. Cause:")
+    result should include("Job aborted due to stage failure")
+  }
+
+  test(
+    "processQueryException should leave single-line exception messages unchanged (no false truncation)") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    // Generic exception with a single-line message — no \n means nothing to strip.
+    val exception = new RuntimeException("Connection timed out after 30 seconds")
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    // Full message preserved verbatim because there's no \n to split on.
+    result should include("Fail to run query. Cause: Connection timed out after 30 seconds")
+    result should include("\"exception.type\":\"java.lang.RuntimeException\"")
+  }
+
+  test(
+    "processQueryException should handle exceptions whose getMessage returns null without throwing") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    // NullPointerException without a message is a real-world case (NPE thrown without args).
+    // The original code would have produced "Fail to run query. Cause: null" and the new
+    // code produces "Fail to run query. Cause: " — neither should crash and both stay parseable.
+    val exception = new NullPointerException()
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    result should include("Fail to run query. Cause:")
+    result should include("\"exception.type\":\"java.lang.NullPointerException\"")
+    // Must not include the literal "null" string that the old behavior produced — proves
+    // the Option(t.getMessage).getOrElse("") guard works.
+    result should not include "Cause: null"
   }
 
   test("Doc Exists and excludeJobIds is an ArrayList Containing JobId") {


### PR DESCRIPTION
…exception handler

### Description
Redact customer query content from Flint SQL parser fallback log and exception handler

      The opensearch-spark JAR is consumed by AWS EMR Serverless to run customer
      queries against CloudWatch Logs. Two paths leak customer query content
      into operator-readable surfaces:

      1. FlintSparkSqlParser.parsePlan catch block logs the full sqlText on
         Flint -> Spark parser fallback. Every customer SELECT/PPL query trips
         this fallback, so every query gets logged in plaintext.
         Fix: drop $sqlText from the log; ParseException is still passed for
         stack-trace diagnostics.

      2. FlintJobExecutor.handleQueryException builds errorMessage from
         t.getMessage. For Spark AnalysisException / SparkException, getMessage
         has the structure "<simple message>; line X pos Y;\n<plan tree>" where
         the plan tree contains the original Filter/Project nodes with literal
         filter values (account ids, ARNs, search strings).
         That message is logged via CustomLogging.logError AND embedded in the
         errorJson sent to DQS UpdateQueryMetadata, which then persists it in
         DQS DDB at rest. Operators with read access to EMR job logs, DQS DDB,
         or the GetQueryMetadata Coral API can see the literals.
         Fix: split t.getMessage at the first \n and keep only the diagnostic
         prefix. AWSLogsQueryStatusManager.ErrorMessageParser.truncateErrorMessage
         already strips at \n on the customer-read path, so this change is
         transparent to customers - it just removes the leak earlier in the
         pipeline. The exception itself is still passed to logError for stack-
         trace preservation.

      Tests added in FlintREPLTest cover:
      - AnalysisException with plan annotation (primary leak case)
      - SparkException with multi-line content
      - Single-line exception (no false truncation)
      - Exception with null getMessage (NPE-free path)

### Related Issues
 As part of ZOA operator should not be able to access any customer data because of which we are removing query string getting logge

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [ ] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
