### PR TITLE
Redact query content from Flint SQL parser fallback log

### DIFF
--- a/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlParser.scala
+++ b/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlParser.scala
@@ -63,9 +63,7 @@ class FlintSparkSqlParser(sparkParser: ParserInterface) extends ParserInterface 
     } catch {
       // Fall back to Spark parse plan logic if flint cannot parse
       case e: ParseException =>
-        logInfo(
-          s"Failed to parse PPL with PPL parser. Falling back to Spark parser. PPL: $sqlText",
-          e)
+        logInfo("Failed to parse with Flint SQL parser. Falling back to Spark parser.", e)
         sparkParser.parsePlan(sqlText)
 
     }


### PR DESCRIPTION
 

### Description
 Drops the SQL text from the fallback logInfo so customer query content
  is not written to Spark driver logs when the Flint parser cannot parse
  and we fall back to the Spark parser.
  
### Related Issues
Query String will not be logged in successfull EMR job execution

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [ ] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [ ] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [x] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
