### PR TITLE
Fix ppl-spark-integration compile: match renamed grammar rule renameClause

### DIFF
--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -259,7 +259,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   @Override
   public UnresolvedPlan visitRenameCommand(OpenSearchPPLParser.RenameCommandContext ctx) {
     return new Rename(
-        ctx.renameClasue().stream()
+        ctx.renameClause().stream()
             .map(
                 ct ->
                     new Alias(


### PR DESCRIPTION
### Description

The `ppl-spark-integration` module fails to compile, which breaks the **CI / build** and **Publish snapshots to maven / build-and-publish-snapshots** workflows on `main`:

```
ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java:262: cannot find symbol
  symbol:   method renameClasue()
  location: variable ctx of type ...OpenSearchPPLParser.RenameCommandContext
[error] (pplSparkIntegration / Compile / compileIncremental) javac returned non-zero exit code
```

**Root cause — upstream grammar drift, not any code change in this repo.** This build downloads the PPL grammar from the SQL repo's `language-grammar` artifact at build time (`project/GrammarDownload.scala` resolves the **latest** `org.opensearch:language-grammar:0.1.0-SNAPSHOT` from `ci.opensearch.org`). The upstream typo fix [opensearch-project/sql#5252](https://github.com/opensearch-project/sql/pull/5252) renamed the PPL parser rule `renameClasue` → `renameClause`. Once that landed in a published snapshot (`language-grammar-0.1.0-20260522.223435-6`), the regenerated `OpenSearchPPLParser.RenameCommandContext` exposes `renameClause()`, but `AstBuilder#visitRenameCommand` still called the old misspelled `renameClasue()` — so the module no longer compiles.

Because the grammar is resolved as the latest snapshot (no version pin), this surfaced on the next build regardless of the triggering commit.

**Fix:** update the consumer to call the corrected rule name `ctx.renameClause()`. One-token change; the inner field labels (`renamedField`/`orignalField`) were not changed by the upstream rename and are left untouched.

> Follow-up worth considering separately: since `GrammarDownload.scala` always pulls the latest `language-grammar` snapshot, any breaking grammar change upstream silently breaks this build. Pinning the grammar to a specific timestamped snapshot (and bumping it deliberately) would make builds reproducible and decouple them from upstream drift.

### Related Issues

Caused by the grammar rule rename in opensearch-project/sql#5252. No tracking issue; fixes the red `main` build directly.

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md) — n/a, no behavior change
- [ ] Implemented unit tests — n/a; existing `rename` translator/IT tests exercise this path and now compile again
- [ ] Implemented tests for combination with other commands — n/a
- [x] New added source code should include a copyright header — existing file, header intact
- [x] Commits are signed per the DCO using `--signoff`
- [x] Add `backport 0.x` label if it is a stable change which won't break existing feature — `0.x` has the same break

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
