### PR TITLE
[Backport 0.x] Fix ppl-spark-integration compile: match renamed grammar rule renameClause

### DIFF
--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -259,7 +259,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   @Override
   public UnresolvedPlan visitRenameCommand(OpenSearchPPLParser.RenameCommandContext ctx) {
     return new Rename(
-        ctx.renameClasue().stream()
+        ctx.renameClause().stream()
             .map(
                 ct ->
                     new Alias(


### PR DESCRIPTION
Backport of #1322 to `0.x`.

### Description

`ppl-spark-integration` fails to compile on `0.x` (same break as `main`), failing the **CI / build** and **Publish snapshots to maven** workflows:

```
AstBuilder.java:262: cannot find symbol
  symbol:   method renameClasue()
  location: variable ctx of type ...OpenSearchPPLParser.RenameCommandContext
```

The build downloads the latest `org.opensearch:language-grammar:0.1.0-SNAPSHOT` at build time (`project/GrammarDownload.scala`). The upstream typo fix [opensearch-project/sql#5252](https://github.com/opensearch-project/sql/pull/5252) renamed the PPL parser rule `renameClasue` → `renameClause`, so the regenerated parser exposes `renameClause()` while `AstBuilder#visitRenameCommand` still called the old `renameClasue()`. This updates the consumer to the corrected rule name (one-token change; inner field labels unchanged).

### Related Issues

Backport of #1322. Caused by opensearch-project/sql#5252.

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md) — n/a, no behavior change
- [ ] Implemented unit tests — n/a; existing `rename` tests exercise this path and now compile again
- [ ] Implemented tests for combination with other commands — n/a
- [x] New added source code should include a copyright header — existing file, header intact
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
