### PR TITLE
Pin GitHub Actions to SHAs and fix PPL renameClause typo (0.7)

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: Get PR Commits
         id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.1.0
+        uses: tim-actions/get-pr-commits@55b867b9b28954e6f5c1a0fe2f729dc926c306d0 # v1.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: DCO Check
-        uses: tim-actions/dco@v1.1.0
+        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21 # v1.1.0
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/end-to-end-test-workflow.yml
+++ b/.github/workflows/end-to-end-test-workflow.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: Set up SBT
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt@2e222825582620cc38d2a54e674f3c01b7c14f5d # v1
 
       - name: Set SBT_OPTS
         # Needed to extend the JVM memory size to avoid OutOfMemoryError for HTML test report
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload test report
         if: always() # Ensures the artifact is saved even if tests fail
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-reports
           path: target/test-reports # Adjust this path if necessary

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@master
+        uses: lycheeverse/lychee-action@6da1d14f3a43098a294b7696d93d938aa8d20fc0 # master
         with:
           args: --accept=200,403,429,999 **/*.html **/*.md **/*.txt --exclude-file .lychee.excludes
         env:

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: Set up SBT
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt@2e222825582620cc38d2a54e674f3c01b7c14f5d # v1
 
       - name: Style check
         run: sbt scalafmtCheckAll
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload test report
         if: always() # Ensures the artifact is saved even if tests fail
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-reports
           path: target/test-reports # Adjust this path if necessary

--- a/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl-spark-integration/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -259,7 +259,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   @Override
   public UnresolvedPlan visitRenameCommand(OpenSearchPPLParser.RenameCommandContext ctx) {
     return new Rename(
-        ctx.renameClasue().stream()
+        ctx.renameClause().stream()
             .map(
                 ct ->
                     new Alias(


### PR DESCRIPTION
## Problem

The org now requires all GitHub Actions to be pinned to a full-length commit SHA. The `0.7` branch's workflows still use version tags (`@v3`, `@v4`, …), so **every PR to `0.7` fails immediately at "Set up job"**. `main` was fixed in #1319; this ports the same pinning to `0.7`.

Additionally, `0.7` does not currently compile: `ppl-spark-integration` fails with `cannot find symbol renameClasue()` because the generated parser exposes `renameClause()` (the fix from #1322 never reached `0.7`).

## Changes

1. **Pin GitHub Actions to SHAs** in the PR-gating workflows (CI build, End-to-End Tests, Link Checker, DCO) — byte-identical to `main` except the action refs; no CI logic changes.
2. **Fix the `renameClasue` → `renameClause` typo** in `AstBuilder.java` (one character) so `0.7` compiles. This is a prerequisite for CI to pass on `0.7`.

Verified locally (sbt 1.8.2 / JDK 11): `pplSparkIntegration/compile` succeeds.

> Note: the End-to-End Tests check may still fail on the Docker-cluster startup flake (environmental, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
