### PR TITLE
[Backport 0.7] Redact logical plan and SQL text from analysis/parse exceptions (#1324)

### DIFF
--- a/flint-commons/src/main/scala/org/apache/spark/sql/exception/RedactedException.scala
+++ b/flint-commons/src/main/scala/org/apache/spark/sql/exception/RedactedException.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql.exception
+
+/**
+ * A throwable that exposes only an already-sanitized message while preserving the original
+ * exception's type name and stack trace.
+ *
+ * Spark's `ExtendedAnalysisException` and `ParseException` embed customer query content in their
+ * `getMessage` (the logical plan tree and the raw SQL text respectively). The caller computes a
+ * sanitized message (e.g. via `AnalysisException.getSimpleMessage`, which Spark documents as
+ * emitting the diagnostic without the plan) and wraps the original throwable in this class before
+ * it reaches any logger or is forwarded downstream. That ensures the query content cannot leak
+ * through `getMessage`, `getLocalizedMessage`, `toString`, or the rendered stack trace, while
+ * still keeping the human-readable diagnostic and frames needed to debug where the error arose.
+ *
+ * @param originalClassName
+ *   fully qualified name of the original exception type, surfaced in the rendered stack trace
+ *   header so the error remains recognizable
+ * @param redactedMessage
+ *   the already-sanitized message (must not contain the plan or SQL text)
+ */
+class RedactedException(originalClassName: String, redactedMessage: String)
+    extends RuntimeException(redactedMessage) {
+
+  // log4j renders a throwable's stack trace header from toString(); override it so the header
+  // reads "<original type>: <redacted message>" instead of exposing this wrapper's class name.
+  override def toString: String = {
+    val msg = getMessage
+    if (msg == null) originalClassName else s"$originalClassName: $msg"
+  }
+}

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala
@@ -26,7 +26,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.FlintREPL.instantiate
 import org.apache.spark.sql.SparkConfConstants.{DEFAULT_SQL_EXTENSIONS, SQL_EXTENSIONS_KEY}
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.exception.UnrecoverableException
+import org.apache.spark.sql.exception.{RedactedException, UnrecoverableException}
 import org.apache.spark.sql.flint.config.FlintSparkConf
 import org.apache.spark.sql.flint.config.FlintSparkConf.REFRESH_POLICY
 import org.apache.spark.sql.types._
@@ -452,6 +452,34 @@ trait FlintJobExecutor {
       CleanerFactory.cleaner(streaming))
   }
 
+  /**
+   * Returns an exception's message with customer query content removed, for compliance.
+   *
+   * `ExtendedAnalysisException` and `ParseException` (both [[AnalysisException]]) embed the
+   * logical plan / raw SQL in `getMessage`. For any [[AnalysisException]] we use
+   * `getSimpleMessage`, which Spark documents as emitting the diagnostic without the plan. For
+   * other throwables we keep only the first line as defense-in-depth (callers unwrap to the root
+   * cause before this is reached).
+   */
+  private[sql] def sanitizedMessage(t: Throwable): String = t match {
+    case ae: AnalysisException => ae.getSimpleMessage
+    case other => Option(other.getMessage).getOrElse("").split("\n", 2)(0)
+  }
+
+  /**
+   * Wraps a throwable so that only its [[sanitizedMessage]] is ever exposed (via getMessage /
+   * toString), while preserving the original exception type name and stack trace for debugging.
+   * This is the single redaction point at the catch site: the wrapper is passed to CustomLogging
+   * so customer query content cannot leak through either the `exception.message` attribute or the
+   * log4j stack trace, and the same sanitized message backs the persisted/forwarded error string.
+   */
+  private[sql] def redactThrowable(t: Throwable): Throwable = {
+    val redacted =
+      new RedactedException(t.getClass.getName, sanitizedMessage(t))
+    redacted.setStackTrace(t.getStackTrace)
+    redacted
+  }
+
   private def handleQueryException(
       t: Throwable,
       messagePrefix: String,
@@ -459,7 +487,10 @@ trait FlintJobExecutor {
       statusCode: Option[Int] = None): String = {
     throwableHandler.setThrowable(t)
 
-    val errorMessage = s"$messagePrefix: ${t.getMessage}"
+    // Redact once at the catch point. The same sanitized throwable backs both the persisted /
+    // forwarded error string (-> query result store and downstream consumers) and the driver logs.
+    val safeThrowable = redactThrowable(t)
+    val errorMessage = s"$messagePrefix: ${safeThrowable.getMessage}"
     val errorDetails = new java.util.LinkedHashMap[String, String]()
     errorDetails.put("message", errorMessage)
     errorSource.foreach(es => errorDetails.put("ErrorSource", es))
@@ -469,12 +500,13 @@ trait FlintJobExecutor {
     val errorJson = mapper.writeValueAsString(errorDetails)
     // Record the processed error message
     throwableHandler.setError(errorJson)
-    // CustomLogging will call log4j logger.error() underneath
+    // CustomLogging will call log4j logger.error() underneath. Pass the redacted throwable so the
+    // logical plan does not leak via the logged exception message or stack trace.
     statusCode match {
       case Some(code) =>
-        CustomLogging.logError(new OperationMessage(errorMessage, code), t)
+        CustomLogging.logError(new OperationMessage(errorMessage, code), safeThrowable)
       case None =>
-        CustomLogging.logError(errorMessage, t)
+        CustomLogging.logError(errorMessage, safeThrowable)
     }
 
     errorJson

--- a/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
+++ b/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintREPL.scala
@@ -691,7 +691,11 @@ object FlintREPL extends Logging with FlintJobExecutor {
           queryWaitTimeMillis))
     } catch {
       case e: TimeoutException =>
-        val error = s"Executing ${flintStatement.query} timed out"
+        // Log only the non-sensitive queryId, never the raw query text. The query string carries
+        // customer content (filter literals, ARNs, account ids); under ZOA it must not reach the
+        // driver logs. queryId is an opaque identifier, consistent with FlintStatement.toString
+        // which also omits the query.
+        val error = s"Executing query with id ${flintStatement.queryId} timed out"
         CustomLogging.logError(error, e)
         Some(
           handleCommandTimeout(

--- a/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
+++ b/spark-sql-application/src/test/scala/org/apache/spark/sql/FlintREPLTest.scala
@@ -29,15 +29,18 @@ import org.opensearch.search.sort.SortOrder
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatestplus.mockito.MockitoSugar
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkContext, SparkException, SparkFunSuite}
 import org.apache.spark.scheduler.SparkListenerApplicationEnd
 import org.apache.spark.sql.FlintREPL.PreShutdownListener
 import org.apache.spark.sql.FlintREPLConfConstants.DEFAULT_QUERY_LOOP_EXECUTION_FREQUENCY
 import org.apache.spark.sql.SessionUpdateMode.SessionUpdateMode
 import org.apache.spark.sql.SparkConfConstants.{DEFAULT_SQL_EXTENSIONS, SQL_EXTENSIONS_KEY}
+import org.apache.spark.sql.catalyst.ExtendedAnalysisException
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Literal}
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.exception.UnrecoverableException
+import org.apache.spark.sql.exception.{RedactedException, UnrecoverableException}
 import org.apache.spark.sql.flint.config.FlintSparkConf
 import org.apache.spark.sql.types.{LongType, NullType, StringType, StructField, StructType}
 import org.apache.spark.sql.util.{DefaultThreadPoolFactory, MockThreadPoolFactory, MockTimeProvider, RealTimeProvider, ShutdownHookManagerTrait}
@@ -613,6 +616,340 @@ class FlintREPLTest
     verify(mockFlintCommand).error = Some(expectedError)
   }
 
+  // A logical plan whose rendered string carries identifiable "customer" query content -- column
+  // names embedding a (fake) account id and an ARN. This mirrors the plan tree that Spark appends
+  // to ExtendedAnalysisException.getMessage and that must not be persisted or logged. A
+  // LocalRelation (leaf node) is used so the plan renders deterministically without needing
+  // resolved expressions, keeping the test independent of Spark's plan-formatting internals.
+  private val planAccountIdMarker = "recipientAccountId_000000000000"
+  private val planArnMarker = "arn_aws_logs_us_east_1_000000000000_example_bucket"
+
+  private def customerPlan(): LogicalPlan = {
+    val recipientAccountId = AttributeReference(planAccountIdMarker, StringType)()
+    val secretArn = AttributeReference(planArnMarker, StringType)()
+    LocalRelation(recipientAccountId, secretArn)
+  }
+
+  // Asserts that none of the customer-content markers from customerPlan() survive in `s`.
+  private def assertNoPlanContent(s: String): Unit = {
+    s should not include planAccountIdMarker
+    s should not include planArnMarker
+    s should not include "LocalRelation"
+  }
+
+  test("processQueryException should strip the logical plan from an ExtendedAnalysisException") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    // ExtendedAnalysisException is the analysis-failure type whose
+    //   getMessage = getSimpleMessage + ";\n" + plan.toString
+    // appends the logical plan tree (which carries customer query content).
+    val plan = customerPlan()
+    val exception = new ExtendedAnalysisException(
+      message = "[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name " +
+        "`alias_1`.`col` cannot be resolved. Did you mean one of the following? " +
+        "[`alias_0`.`col`].",
+      line = Some(1),
+      startPosition = Some(295),
+      plan = Some(plan))
+
+    // Precondition: the unredacted message really does contain the plan, so the test proves a strip.
+    exception.getMessage should include(planAccountIdMarker)
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    // The plan tree MUST be gone.
+    assertNoPlanContent(result)
+    // The diagnostic (error class, suggestion, position) MUST be preserved so customers can fix it.
+    result should include("Fail to analyze query. Cause:")
+    result should include("UNRESOLVED_COLUMN.WITH_SUGGESTION")
+    result should include("Did you mean one of the following?")
+    result should include("line 1 pos 295")
+
+    verify(mockFlintStatement).fail()
+    verify(mockFlintStatement).error = Some(result)
+  }
+
+  test(
+    "processQueryException should preserve the original exception.type after redaction (no metrics/dispatch regression)") {
+    // Redaction wraps the throwable in a RedactedException only for the logged message and the
+    // persisted error string; it must NOT change the exception type that downstream type-based
+    // logic observes (e.g. the S3/Glue error counters, or any consumer reading exception.type).
+    // The persisted exception.type is taken from the original throwable, so it stays the real type
+    // even though the message is sanitized.
+    val mockFlintStatement = mock[FlintStatement]
+    val exception = new ExtendedAnalysisException(
+      message = "[UNRESOLVED_COLUMN] cannot resolve column",
+      line = Some(1),
+      startPosition = Some(10),
+      plan = Some(customerPlan()))
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    // The plan is gone, but the recorded type is the original exception, not RedactedException.
+    assertNoPlanContent(result)
+    result should include(
+      "\"exception.type\":\"org.apache.spark.sql.catalyst.ExtendedAnalysisException\"")
+    result should not include "RedactedException"
+  }
+
+  test(
+    "processQueryException redacts the reported CloudWatch plan leak but keeps the diagnostic") {
+    // Reproduces the exact reported leak: an ExtendedAnalysisException whose getMessage appends a
+    // resolved logical plan carrying customer values (account id, ARN, and the filter literals from
+    // the user's WHERE clause). The fix must drop the whole plan tree (everything after ";\n") yet
+    // keep the human-readable analysis diagnostic, including the column names, so the error stays
+    // debuggable without the filter values.
+    val mockFlintStatement = mock[FlintStatement]
+
+    // Column refs whose names embed the (fake) account id and ARN, plus the filter literals that
+    // Spark renders into the plan's Filter node.
+    val acctCol = AttributeReference("recipientAccountId_480909524268", StringType)()
+    val arnCol =
+      AttributeReference("arn_aws_logs_us_east_1_471112993047_aws_controltower", StringType)()
+    val filterValue = "vci-terraform-state-rnd-us-east-1"
+    val plan = Filter(EqualTo(arnCol, Literal(filterValue)), LocalRelation(acctCol, arnCol))
+
+    val exception = new ExtendedAnalysisException(
+      message = "[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name " +
+        "`_CWLBasic_Alias_1`.`arn` cannot be resolved. Did you mean one of the following? " +
+        "[`_CWLBasic_Alias_0`.`arn`, `_CWLBasic_Alias_0`.`eventName`].",
+      line = Some(1),
+      startPosition = Some(295),
+      plan = Some(plan))
+
+    // Precondition: the raw message really leaks the account id, ARN, and filter value via the plan.
+    exception.getMessage should include("480909524268")
+    exception.getMessage should include("471112993047")
+    exception.getMessage should include(filterValue)
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    // Redacted (not removed): the plan and every customer value it carried are gone ...
+    result should not include "480909524268"
+    result should not include "471112993047"
+    result should not include filterValue
+    result should not include "Filter"
+    result should not include "LocalRelation"
+    // ... but the diagnostic the team wants to keep for debugging survives intact.
+    result should include("Fail to analyze query. Cause:")
+    result should include("UNRESOLVED_COLUMN.WITH_SUGGESTION")
+    result should include("cannot be resolved")
+    result should include("Did you mean one of the following?")
+    result should include("line 1 pos 295")
+    result should include(
+      "\"exception.type\":\"org.apache.spark.sql.catalyst.ExtendedAnalysisException\"")
+  }
+
+  test(
+    "processQueryException should strip the SQL text from a ParseException (== SQL == block)") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    // ParseException.getMessage embeds the raw SQL command in a "== SQL ==" block. The command is
+    // the verbatim customer query and must not be persisted.
+    val customerSql =
+      "SELECT * FROM logs WHERE arn LIKE '%example-secret-bucket%' SYNTAX_ERROR_HERE"
+    val origin = Origin(line = Some(1), startPosition = Some(60))
+    val exception = new ParseException(
+      command = Some(customerSql),
+      message = "Syntax error at or near 'SYNTAX_ERROR_HERE'",
+      start = origin,
+      stop = origin)
+
+    // Precondition: the unredacted message contains the SQL text.
+    exception.getMessage should include("example-secret-bucket")
+    exception.getMessage should include("== SQL ==")
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    // The SQL text and the == SQL == block MUST be gone.
+    result should not include "example-secret-bucket"
+    result should not include "== SQL =="
+    result should not include "SELECT * FROM logs"
+    // The human-readable syntax diagnostic MUST be preserved.
+    result should include("Syntax error")
+    result should include("Syntax error at or near 'SYNTAX_ERROR_HERE'")
+  }
+
+  test(
+    "processQueryException should strip the plan from an ExtendedAnalysisException wrapped in a SparkException (nested root cause)") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    // Real case: analysis can fail mid-execution and surface wrapped in a SparkException. The
+    // caller unwraps to the root cause first, so the typed strip still applies.
+    val analysis = new ExtendedAnalysisException(
+      message = "[UNRESOLVED_COLUMN] cannot resolve column",
+      line = Some(1),
+      startPosition = Some(10),
+      plan = Some(customerPlan()))
+    val wrapper =
+      new SparkException("Job aborted due to stage failure", analysis)
+
+    val result = FlintREPL.processQueryException(wrapper, mockFlintStatement)
+
+    assertNoPlanContent(result)
+    result should include("UNRESOLVED_COLUMN")
+  }
+
+  test(
+    "processQueryException should keep an AnalysisException whose message has newlines but no plan (getSimpleMessage, plan = None)") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    // ExtendedAnalysisException with plan = None: getMessage == getSimpleMessage, no plan annotation.
+    val exception = new ExtendedAnalysisException(
+      message = "Table or view not found: my_table",
+      line = Some(2),
+      startPosition = Some(5),
+      plan = None)
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    result should include("Fail to analyze query. Cause:")
+    result should include("Table or view not found: my_table")
+    result should include("line 2 pos 5")
+    assertNoPlanContent(result)
+  }
+
+  test(
+    "processQueryException should strip embedded newlines from SparkException messages with stack-trace-like content") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    val sparkErrorWithEmbeddedDetails =
+      "Job aborted due to stage failure: Task 0 in stage 1.0 failed\n" +
+        "\tat org.apache.spark.scheduler.DAGScheduler.org\n" +
+        "\tat customer.private.path.value=secret-token-abc123"
+    val exception = new SparkException(sparkErrorWithEmbeddedDetails)
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    // Anything after the first \n must be dropped - internal frames may carry literals.
+    result should not include "DAGScheduler"
+    result should not include "secret-token-abc123"
+    // First line (human-readable summary) is preserved.
+    result should include("Spark exception. Cause:")
+    result should include("Job aborted due to stage failure")
+  }
+
+  test(
+    "processQueryException should leave single-line exception messages unchanged (no false truncation)") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    // Generic exception with a single-line message - no \n means nothing to strip.
+    val exception = new RuntimeException("Connection timed out after 30 seconds")
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    // Full message preserved verbatim because there's no \n to split on.
+    result should include("Fail to run query. Cause: Connection timed out after 30 seconds")
+    result should include("\"exception.type\":\"java.lang.RuntimeException\"")
+  }
+
+  test(
+    "processQueryException should handle exceptions whose getMessage returns null without throwing") {
+    val mockFlintStatement = mock[FlintStatement]
+
+    // NullPointerException without a message is a real-world case (NPE thrown without args).
+    // The original code would have produced "Fail to run query. Cause: null" and the new
+    // code produces "Fail to run query. Cause: " - neither should crash and both stay parseable.
+    val exception = new NullPointerException()
+
+    val result = FlintREPL.processQueryException(exception, mockFlintStatement)
+
+    result should include("Fail to run query. Cause:")
+    result should include("\"exception.type\":\"java.lang.NullPointerException\"")
+    // Must not include the literal "null" string that the old behavior produced - proves
+    // the Option(t.getMessage).getOrElse("") guard works.
+    result should not include "Cause: null"
+  }
+
+  // ---- Direct unit tests for the redaction helpers (FlintJobExecutor via the FlintREPL object) ----
+
+  test(
+    "sanitizedMessage uses getSimpleMessage for ExtendedAnalysisException, dropping the plan") {
+    val plan = customerPlan()
+    val exception = new ExtendedAnalysisException(
+      message = "[UNRESOLVED_COLUMN] cannot resolve `arn`",
+      line = Some(1),
+      startPosition = Some(295),
+      plan = Some(plan))
+
+    val sanitized = FlintREPL.sanitizedMessage(exception)
+
+    sanitized shouldBe exception.getSimpleMessage
+    sanitized should include("UNRESOLVED_COLUMN")
+    sanitized should include("line 1 pos 295")
+    assertNoPlanContent(sanitized)
+    // The raw getMessage carries the plan; sanitizedMessage must be strictly shorter / different.
+    sanitized should not equal exception.getMessage
+  }
+
+  test("sanitizedMessage uses getSimpleMessage for ParseException, dropping the SQL text") {
+    val customerSql = "SELECT secret_col FROM t WHERE x LIKE '%example-secret%' BADTOKEN"
+    val origin = Origin(line = Some(1), startPosition = Some(40))
+    val exception = new ParseException(
+      command = Some(customerSql),
+      message = "Syntax error at or near 'BADTOKEN'",
+      start = origin,
+      stop = origin)
+
+    val sanitized = FlintREPL.sanitizedMessage(exception)
+
+    sanitized shouldBe exception.getSimpleMessage
+    sanitized should include("Syntax error at or near 'BADTOKEN'")
+    sanitized should not include "example-secret"
+    sanitized should not include "== SQL =="
+    sanitized should not include "secret_col"
+  }
+
+  test(
+    "sanitizedMessage keeps only the first line for non-analysis throwables (defense-in-depth)") {
+    val exception = new RuntimeException("summary line\nsecret-detail-line\nmore-secret")
+    FlintREPL.sanitizedMessage(exception) shouldBe "summary line"
+  }
+
+  test("sanitizedMessage returns empty string for a null message without throwing") {
+    FlintREPL.sanitizedMessage(new RuntimeException()) shouldBe ""
+    FlintREPL.sanitizedMessage(new NullPointerException()) shouldBe ""
+  }
+
+  test("sanitizedMessage leaves a single-line message untouched") {
+    val exception = new IllegalArgumentException("bad arg value 42")
+    FlintREPL.sanitizedMessage(exception) shouldBe "bad arg value 42"
+  }
+
+  test(
+    "redactThrowable exposes only the sanitized message via getMessage/toString while preserving the original type name and stack trace") {
+    val plan = customerPlan()
+    val original = new ExtendedAnalysisException(
+      message = "[UNRESOLVED_COLUMN] cannot resolve `arn`",
+      line = Some(1),
+      startPosition = Some(295),
+      plan = Some(plan))
+
+    val redacted = FlintREPL.redactThrowable(original)
+
+    // getMessage / getLocalizedMessage / toString must never expose the plan -- these are the
+    // exact accessors CustomLogging (exception.message attribute) and log4j (stack-trace header)
+    // read from.
+    redacted.getMessage shouldBe original.getSimpleMessage
+    assertNoPlanContent(redacted.getMessage)
+    assertNoPlanContent(redacted.getLocalizedMessage)
+    assertNoPlanContent(redacted.toString)
+    // The original type name is preserved in toString so the error stays recognizable in logs.
+    redacted.toString should include(original.getClass.getName)
+    redacted.toString should include("ExtendedAnalysisException")
+    // Stack frames are preserved for debugging.
+    redacted.getStackTrace shouldBe original.getStackTrace
+    // The rendered full stack trace must not leak the plan either.
+    val sw = new java.io.StringWriter()
+    redacted.printStackTrace(new java.io.PrintWriter(sw))
+    assertNoPlanContent(sw.toString)
+  }
+
+  test("RedactedException.toString falls back to the type name when the message is null") {
+    val redacted = new RedactedException("com.example.FooException", null)
+    redacted.toString shouldBe "com.example.FooException"
+  }
+
   test("Doc Exists and excludeJobIds is an ArrayList Containing JobId") {
     val sessionId = "session123"
     val jobId = "jobABC"
@@ -841,7 +1178,11 @@ class FlintREPLTest
       verify(mockSparkSession, times(1)).sql(any[String])
       verify(sparkContext, times(1)).cancelJobGroup(any[String])
       assert("timeout" == flintStatement.state)
-      assert(s"Executing ${flintStatement.query} timed out" == flintStatement.error.get)
+      // The timeout error must reference the opaque queryId, never the raw query text (ZOA: the
+      // query carries customer content and must not reach the driver logs / error store).
+      assert(
+        s"Executing query with id ${flintStatement.queryId} timed out" == flintStatement.error.get)
+      flintStatement.error.get should not include flintStatement.query
       result should not be None
     } finally threadPool.shutdown()
   }


### PR DESCRIPTION
Backport of #1324 to the `0.7` branch (redaction fix only).

The automated backport workflow could not run (`tibdex/github-app-token`: *"Could not create installation access token"* — broken org-wide), so this was created manually by cherry-picking the squash-merge commit `277bbd98`. Import-line conflicts were resolved against the 0.7 base; the redaction logic and tests are **identical** to the merged PR.

> **Depends on #1327** (Pin GitHub Actions to SHAs + fix PPL `renameClause` typo → 0.7). Until that merges, this PR's CI fails because (a) 0.7's workflows use unpinned action tags and (b) 0.7 has a pre-existing `renameClasue` compile error — both unrelated to this change and both fixed by #1327.

### Verification (local, sbt 1.8.2 / JDK 11)
- `sparkSqlApplication/testOnly FlintREPLTest`: **63 tests, 0 failed** (incl. all redaction tests)

See #1324 for the full description and review discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
