### PR TITLE
Get status code from runtime exception

### DIFF
--- a/flint-core/src/main/java/org/opensearch/flint/core/IRestHighLevelClient.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/IRestHighLevelClient.java
@@ -111,7 +111,7 @@ public interface IRestHighLevelClient extends Closeable {
             CustomLogging.logError(new OperationMessage("OpenSearch Operation failed.", statusCode), openSearchException);
         } else {
             AmazonServiceException amazonServiceException = extractAmazonServiceException(t);
-            if (amazonServiceException != null) {
+            if (amazonServiceException != null && amazonServiceException.getStatusCode() != 0) {
                 statusCode = amazonServiceException.getStatusCode();
             } else {
                 // Fall back to parsing the status code from the exception message when it is
@@ -141,7 +141,7 @@ public interface IRestHighLevelClient extends Closeable {
     static OpenSearchException extractOpenSearchException(Throwable e) {
         if (e instanceof OpenSearchException) {
             return (OpenSearchException) e;
-        } else if (e.getCause() == null) {
+        } else if (e.getCause() == null || e.getCause() == e) {
             return null;
         } else {
             return extractOpenSearchException(e.getCause());
@@ -158,15 +158,15 @@ public interface IRestHighLevelClient extends Closeable {
     static AmazonServiceException extractAmazonServiceException(Throwable e) {
         if (e instanceof AmazonServiceException) {
             return (AmazonServiceException) e;
-        } else if (e.getCause() == null) {
+        } else if (e.getCause() == null || e.getCause() == e) {
             return null;
         } else {
             return extractAmazonServiceException(e.getCause());
         }
     }
 
-    /** Pattern matching an HTTP status code embedded in an exception message, e.g. "Status Code: 403". */
-    Pattern STATUS_CODE_PATTERN = Pattern.compile("Status Code:\\s*(\\d{3})");
+    /** Pattern matching an HTTP 4xx/5xx status code embedded in an exception message, e.g. "Status Code: 403". */
+    Pattern STATUS_CODE_PATTERN = Pattern.compile("Status Code:\\s*([45]\\d{2})");
 
     /**
      * Extracts an HTTP status code embedded in the message text of the given Throwable or any of
@@ -186,6 +186,7 @@ public interface IRestHighLevelClient extends Closeable {
                     return Integer.parseInt(matcher.group(1));
                 }
             }
+            if (current.getCause() == current) break;
             current = current.getCause();
         }
         return 500;

--- a/flint-core/src/main/java/org/opensearch/flint/core/IRestHighLevelClient.java
+++ b/flint-core/src/main/java/org/opensearch/flint/core/IRestHighLevelClient.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.flint.core;
 
+import com.amazonaws.AmazonServiceException;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.bulk.BulkRequest;
@@ -38,6 +39,8 @@ import org.opensearch.flint.core.metrics.MetricsUtil;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Interface for wrapping the OpenSearch High Level REST Client with additional functionality,
@@ -102,11 +105,20 @@ public interface IRestHighLevelClient extends Closeable {
      */
     static void recordOperationFailure(String metricNamePrefix, Throwable t) {
         OpenSearchException openSearchException = extractOpenSearchException(t);
-        int statusCode = openSearchException != null ? openSearchException.status().getStatus() : 500;
+        int statusCode;
         if (openSearchException != null) {
+            statusCode = openSearchException.status().getStatus();
             CustomLogging.logError(new OperationMessage("OpenSearch Operation failed.", statusCode), openSearchException);
         } else {
-            CustomLogging.logError("OpenSearch Operation failed with an exception.", t);
+            AmazonServiceException amazonServiceException = extractAmazonServiceException(t);
+            if (amazonServiceException != null) {
+                statusCode = amazonServiceException.getStatusCode();
+            } else {
+                // Fall back to parsing the status code from the exception message when it is
+                // not available on a typed exception. Defaults to 500 if none can be parsed.
+                statusCode = extractStatusCodeFromMessage(t);
+            }
+            CustomLogging.logError(new OperationMessage("OpenSearch Operation failed with an exception.", statusCode), t);
         }
         if (statusCode == 403) {
             String forbiddenErrorMetricName = metricNamePrefix + ".403.count";
@@ -134,5 +146,48 @@ public interface IRestHighLevelClient extends Closeable {
         } else {
             return extractOpenSearchException(e.getCause());
         }
+    }
+
+    /**
+     * Extracts an AmazonServiceException from the given Throwable.
+     * Checks if the Throwable is an instance of AmazonServiceException or caused by one.
+     *
+     * @param e the exception to be checked
+     * @return the extracted AmazonServiceException, or null if not found
+     */
+    static AmazonServiceException extractAmazonServiceException(Throwable e) {
+        if (e instanceof AmazonServiceException) {
+            return (AmazonServiceException) e;
+        } else if (e.getCause() == null) {
+            return null;
+        } else {
+            return extractAmazonServiceException(e.getCause());
+        }
+    }
+
+    /** Pattern matching an HTTP status code embedded in an exception message, e.g. "Status Code: 403". */
+    Pattern STATUS_CODE_PATTERN = Pattern.compile("Status Code:\\s*(\\d{3})");
+
+    /**
+     * Extracts an HTTP status code embedded in the message text of the given Throwable or any of
+     * its causes. This handles exceptions that carry the status code only as part of the message
+     * string rather than on a typed exception.
+     *
+     * @param e the exception to be checked
+     * @return the parsed status code, or 500 if none can be found in the cause chain
+     */
+    static int extractStatusCodeFromMessage(Throwable e) {
+        Throwable current = e;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null) {
+                Matcher matcher = STATUS_CODE_PATTERN.matcher(message);
+                if (matcher.find()) {
+                    return Integer.parseInt(matcher.group(1));
+                }
+            }
+            current = current.getCause();
+        }
+        return 500;
     }
 }

--- a/flint-core/src/test/java/org/opensearch/flint/core/IRestHighLevelClientTest.java
+++ b/flint-core/src/test/java/org/opensearch/flint/core/IRestHighLevelClientTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.opensearch.flint.core.logging.CustomLogging;
+import org.opensearch.flint.core.metrics.MetricsUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+public class IRestHighLevelClientTest {
+
+    private static final String PREFIX = "testPrefix";
+
+    @Test
+    public void recordOperationFailureParsesStatusCodeFromRuntimeExceptionMessage() {
+        // A 403 wrapped in a plain RuntimeException, with the status code only present as text.
+        Throwable t = new RuntimeException("Access denied; Status Code: 403; Error Code: Forbidden");
+
+        try (MockedStatic<MetricsUtil> metricsUtil = mockStatic(MetricsUtil.class);
+             MockedStatic<CustomLogging> ignored = mockStatic(CustomLogging.class)) {
+            IRestHighLevelClient.recordOperationFailure(PREFIX, t);
+
+            // Must be classified as 403/4xx, NOT 5xx.
+            metricsUtil.verify(() -> MetricsUtil.incrementCounter(PREFIX + ".403.count"), times(1));
+            metricsUtil.verify(() -> MetricsUtil.incrementCounter(PREFIX + ".4xx.count"), times(1));
+            metricsUtil.verify(() -> MetricsUtil.incrementCounter(PREFIX + ".5xx.count"), never());
+        }
+    }
+
+    @Test
+    public void recordOperationFailureParsesStatusCodeFromNestedCause() {
+        Throwable cause = new RuntimeException("downstream failure; Status Code: 429; Error Code: TooManyRequests");
+        Throwable t = new RuntimeException("wrapper", cause);
+
+        try (MockedStatic<MetricsUtil> metricsUtil = mockStatic(MetricsUtil.class);
+             MockedStatic<CustomLogging> ignored = mockStatic(CustomLogging.class)) {
+            IRestHighLevelClient.recordOperationFailure(PREFIX, t);
+
+            metricsUtil.verify(() -> MetricsUtil.incrementCounter(PREFIX + ".429.count"), times(1));
+            metricsUtil.verify(() -> MetricsUtil.incrementCounter(PREFIX + ".4xx.count"), times(1));
+            metricsUtil.verify(() -> MetricsUtil.incrementCounter(PREFIX + ".5xx.count"), never());
+        }
+    }
+
+    @Test
+    public void recordOperationFailureDefaultsTo5xxWhenNoStatusCodeInMessage() {
+        Throwable t = new RuntimeException("some unexpected failure without a status code");
+
+        try (MockedStatic<MetricsUtil> metricsUtil = mockStatic(MetricsUtil.class);
+             MockedStatic<CustomLogging> ignored = mockStatic(CustomLogging.class)) {
+            IRestHighLevelClient.recordOperationFailure(PREFIX, t);
+
+            metricsUtil.verify(() -> MetricsUtil.incrementCounter(PREFIX + ".5xx.count"), times(1));
+            metricsUtil.verify(() -> MetricsUtil.incrementCounter(PREFIX + ".4xx.count"), never());
+        }
+    }
+
+    @Test
+    public void extractStatusCodeFromMessageReturnsDefaultForNullMessage() {
+        assertEquals(500, IRestHighLevelClient.extractStatusCodeFromMessage(new RuntimeException()));
+    }
+
+    @Test
+    public void extractStatusCodeFromMessageParsesCode() {
+        Throwable t = new RuntimeException("... Status Code: 404; ...");
+        assertEquals(404, IRestHighLevelClient.extractStatusCodeFromMessage(t));
+    }
+}


### PR DESCRIPTION
### Description
Fix metric misclassification where HTTP errors (e.g., 403, 429) were reported as generic 5xx failures. Unwraps AmazonServiceException from the cause chain to extract the correct status code.

### Related Issues
_List any issues this PR will resolve, e.g. Resolves [...]._

### Check List
- [ ] Updated documentation (docs/ppl-lang/README.md)
- [x] Implemented unit tests
- [ ] Implemented tests for combination with other commands
- [x] New added source code should include a copyright header
- [x] Commits are signed per the DCO using `--signoff`
- [ ] Add `backport 0.x` label if it is a stable change which won't break existing feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
