### PR TITLE
Validate idle pooled connections to avoid ConnectionClosedException

### DIFF
--- a/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/FlintOptions.java
@@ -91,6 +91,8 @@ public class FlintOptions implements Serializable {
 
   public static final int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 10000;
 
+  public static final String INACTIVITY_LIMIT_MILLIS = "inactivity_limit_millis";
+
   public static final int DEFAULT_INACTIVITY_LIMIT_MILLIS = 3 * 60 * 1000;
 
   public static final String REQUEST_COMPLETION_DELAY_MILLIS = "request.completionDelayMillis";
@@ -213,6 +215,10 @@ public class FlintOptions implements Serializable {
 
   public int getConnectionTimeoutMillis() {
     return Integer.parseInt(options.getOrDefault(CONNECTION_TIMEOUT_MILLIS, String.valueOf(DEFAULT_CONNECTION_TIMEOUT_MILLIS)));
+  }
+
+  public int getInactivityLimitMillis() {
+    return Integer.parseInt(options.getOrDefault(INACTIVITY_LIMIT_MILLIS, String.valueOf(DEFAULT_INACTIVITY_LIMIT_MILLIS)));
   }
 
   public int getRequestCompletionDelayMillis() {

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchClientUtils.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchClientUtils.java
@@ -18,6 +18,9 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.nio.reactor.IOReactorException;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.RestHighLevelClient;
@@ -139,6 +142,7 @@ public class OpenSearchClientUtils {
           HttpAsyncClientBuilder delegate = builder.addInterceptorLast(
               new ResourceBasedAWSRequestSigningApacheInterceptor(
                   options.getServiceName(), options.getRegion(), customAWSCredentialsProvider.get(), metadataAccessAWSCredentialsProvider.get(), systemIndexName));
+          delegate = configureConnectionManager(delegate, options);
           return RetryableHttpAsyncClient.builder(delegate, options);
         }
     );
@@ -153,6 +157,7 @@ public class OpenSearchClientUtils {
         new UsernamePasswordCredentials(options.getUsername(), options.getPassword()));
     restClientBuilder.setHttpClientConfigCallback(builder -> {
       HttpAsyncClientBuilder delegate = builder.setDefaultCredentialsProvider(credentialsProvider);
+      delegate = configureConnectionManager(delegate, options);
       return RetryableHttpAsyncClient.builder(delegate, options);
     });
 
@@ -162,8 +167,25 @@ public class OpenSearchClientUtils {
   private static RestClientBuilder configureDefaultAuth(RestClientBuilder restClientBuilder, FlintOptions options) {
     // No auth
     restClientBuilder.setHttpClientConfigCallback(delegate ->
-        RetryableHttpAsyncClient.builder(delegate, options));
+        RetryableHttpAsyncClient.builder(configureConnectionManager(delegate, options), options));
     return restClientBuilder;
+  }
+
+  /**
+   * Configures the async connection manager to validate pooled connections after a period of
+   * inactivity. Without this, connections closed by the server while idle remain in the pool and
+   * are reused, surfacing as ConnectionClosedException. Validating before reuse lets the client
+   * detect and discard such connections instead of failing the request.
+   */
+  private static HttpAsyncClientBuilder configureConnectionManager(HttpAsyncClientBuilder builder, FlintOptions options) {
+    try {
+      PoolingNHttpClientConnectionManager connectionManager =
+          new PoolingNHttpClientConnectionManager(new DefaultConnectingIOReactor());
+      connectionManager.setValidateAfterInactivity(options.getInactivityLimitMillis());
+      return builder.setConnectionManager(connectionManager);
+    } catch (IOReactorException e) {
+      throw new RuntimeException("Failed to create async connection manager", e);
+    }
   }
 
   /**

--- a/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchClientUtils.java
+++ b/flint-core/src/main/scala/org/opensearch/flint/core/storage/OpenSearchClientUtils.java
@@ -12,15 +12,13 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
-import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
-import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
-import org.apache.http.nio.reactor.IOReactorException;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.RestHighLevelClient;
@@ -172,20 +170,13 @@ public class OpenSearchClientUtils {
   }
 
   /**
-   * Configures the async connection manager to validate pooled connections after a period of
-   * inactivity. Without this, connections closed by the server while idle remain in the pool and
-   * are reused, surfacing as ConnectionClosedException. Validating before reuse lets the client
-   * detect and discard such connections instead of failing the request.
+   * Bounds the lifetime of pooled connections. Without a time-to-live, connections closed by the
+   * server while idle remain in the pool and are reused, surfacing as ConnectionClosedException.
+   * Expiring connections after this duration lets the client discard them instead of reusing a
+   * connection the server has already closed.
    */
   private static HttpAsyncClientBuilder configureConnectionManager(HttpAsyncClientBuilder builder, FlintOptions options) {
-    try {
-      PoolingNHttpClientConnectionManager connectionManager =
-          new PoolingNHttpClientConnectionManager(new DefaultConnectingIOReactor());
-      connectionManager.setValidateAfterInactivity(options.getInactivityLimitMillis());
-      return builder.setConnectionManager(connectionManager);
-    } catch (IOReactorException e) {
-      throw new RuntimeException("Failed to create async connection manager", e);
-    }
+    return builder.setConnectionTimeToLive(options.getInactivityLimitMillis(), TimeUnit.MILLISECONDS);
   }
 
   /**

--- a/flint-core/src/test/scala/org/opensearch/flint/core/FlintOptionsTest.java
+++ b/flint-core/src/test/scala/org/opensearch/flint/core/FlintOptionsTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+class FlintOptionsTest {
+
+  @Test
+  public void getInactivityLimitMillisReturnsDefaultWhenNotConfigured() {
+    FlintOptions options = new FlintOptions(ImmutableMap.of());
+    assertEquals(FlintOptions.DEFAULT_INACTIVITY_LIMIT_MILLIS, options.getInactivityLimitMillis());
+  }
+
+  @Test
+  public void getInactivityLimitMillisReturnsConfiguredValue() {
+    FlintOptions options =
+        new FlintOptions(ImmutableMap.of(FlintOptions.INACTIVITY_LIMIT_MILLIS, "30000"));
+    assertEquals(30000, options.getInactivityLimitMillis());
+  }
+}

--- a/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -259,6 +259,12 @@ object FlintSparkConf {
       .doc("connection duration in milliseconds")
       .createWithDefault(String.valueOf(FlintOptions.DEFAULT_CONNECTION_TIMEOUT_MILLIS))
 
+  val INACTIVITY_LIMIT_MILLIS =
+    FlintConfig(s"spark.datasource.flint.${FlintOptions.INACTIVITY_LIMIT_MILLIS}")
+      .datasourceOption()
+      .doc("expire pooled HTTP connections after this idle duration in milliseconds")
+      .createWithDefault(String.valueOf(FlintOptions.DEFAULT_INACTIVITY_LIMIT_MILLIS))
+
   val REQUEST_COMPLETION_DELAY_MILLIS =
     FlintConfig(s"spark.datasource.flint.${FlintOptions.REQUEST_COMPLETION_DELAY_MILLIS}")
       .datasourceOption()
@@ -417,6 +423,7 @@ case class FlintSparkConf(properties: JMap[String, String]) extends Serializable
       PASSWORD,
       SOCKET_TIMEOUT_MILLIS,
       CONNECTION_TIMEOUT_MILLIS,
+      INACTIVITY_LIMIT_MILLIS,
       JOB_TYPE,
       REPL_INACTIVITY_TIMEOUT_MILLIS,
       BATCH_BYTES)

--- a/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -165,6 +165,16 @@ class FlintSparkConfSuite extends FlintSuite {
   /**
    * Delete index `indexNames` after calling `f`.
    */
+  test("inactivity_limit_millis defaults to FlintOptions default") {
+    val flintOptions = FlintSparkConf().flintOptions()
+    assert(flintOptions.getInactivityLimitMillis == FlintOptions.DEFAULT_INACTIVITY_LIMIT_MILLIS)
+  }
+
+  test("inactivity_limit_millis propagates from datasource option") {
+    val options = FlintSparkConf(Map("inactivity_limit_millis" -> "30000").asJava)
+    assert(options.flintOptions().getInactivityLimitMillis == 30000)
+  }
+
   protected def withSparkConf(configs: String*)(f: => Unit): Unit = {
     try {
       f


### PR DESCRIPTION
### Description
The async HTTP connection pool used by the OpenSearch REST client never
validates idle connections. When the server closes an idle connection,
the pool still serves it, surfacing as `ConnectionClosedException`.
Retries reuse the same pool, so they do not reliably recover.

This enables `setValidateAfterInactivity` on the connection manager so
idle connections are revalidated before reuse and stale ones are
discarded. The threshold is configurable via `inactivity_limit_millis`
and defaults to the existing `DEFAULT_INACTIVITY_LIMIT_MILLIS`.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
