### PR TITLE
Pin GitHub Actions to commit SHAs in snapshot-publish workflow (0.x)

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -25,7 +25,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         id: checkout
 
       # Extract version from build.sbt file
@@ -46,13 +46,13 @@ jobs:
           echo "Using commit ID: ${COMMIT_ID}"
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: Set up SBT
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt@2e222825582620cc38d2a54e674f3c01b7c14f5d # v1
 
       - name: Publish to Local Maven
         run: |
@@ -65,13 +65,13 @@ jobs:
           echo "Checking published artifacts:"
           find $HOME/.m2/repository/org/opensearch/ -name "*${{ steps.extract_version.outputs.version }}*" || echo "No artifacts found with the expected version"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: 'opensearch-project/opensearch-build'
           path: 'build'
 
       - name: Load secrets from 1Password
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2
         with:
           export-env: true
         env:
@@ -80,7 +80,7 @@ jobs:
           MAVEN_SNAPSHOTS_S3_ROLE: op://opensearch-infra-secrets/maven-snapshots-s3/role
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ env.MAVEN_SNAPSHOTS_S3_ROLE }}
           aws-region: us-east-1


### PR DESCRIPTION
### Description

The `Publish snapshots to maven` / `build-and-publish-snapshots` job has been failing on `0.x` at the **Set up job** step (~5s runs) with:

> The actions `actions/checkout@v3`, `actions/setup-java@v3`, `sbt/setup-sbt@v1`, `1password/load-secrets-action@v2`, and `aws-actions/configure-aws-credentials@v5` are not allowed in opensearch-project/opensearch-spark because all actions must be pinned to a full-length commit SHA.

The org now enforces a policy requiring every GitHub Action to be pinned to a full-length commit SHA. #1328 pinned the PR/test/build workflows but missed `snapshot-publish.yml`, so the snapshot publish job was rejected on every push to `0.x`.

### Changes

Pin all five actions in `.github/workflows/snapshot-publish.yml` to full-length commit SHAs, using the exact SHAs already in use on `main` and the sibling `0.x` workflows (`test-and-build-workflow.yml`, `end-to-end-test-workflow.yml`). No action version changes — behavior is unchanged.

- `actions/checkout@v3` → `@f43a0e5ff2bd294095638e18286ca9a3d1956744` (×2)
- `actions/setup-java@v3` → `@17f84c3641ba7b8f6deff6309fc4c864478f5d62`
- `sbt/setup-sbt@v1` → `@2e222825582620cc38d2a54e674f3c01b7c14f5d`
- `1password/load-secrets-action@v2` → `@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0`
- `aws-actions/configure-aws-credentials@v5` → `@61815dcd50bd041e203e49132bacad1fd04d2708`

This brings `0.x`'s `snapshot-publish.yml` in line with `main` (which is already correctly pinned).

### Check List
- [x] Updated documentation / not applicable
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.