### PR TITLE
[Backport 0.7] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -8,7 +8,7 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v6
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,14 +26,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.7.0
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # v1.7.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v2.2.0
+        uses: VachaShah/backport@142d3b8a8c70dc54db515e653e5ed3c3fac64100 # v2.2.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           head_template: backport/backport-<%= number %>-to-<%= base %>

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -10,6 +10,6 @@ jobs:
     if: startsWith(github.event.pull_request.head.ref,'backport/')
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
+        uses: SvanBoxel/delete-merged-branch@2b5b058e3db41a3328fd9a6a58fd4c2545a14353 # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -25,16 +25,16 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: Set up SBT
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt@2e222825582620cc38d2a54e674f3c01b7c14f5d # v1
 
       - name: Publish to Local Maven
         run: |
@@ -42,13 +42,13 @@ jobs:
           sbt sparkPPLCosmetic/publishM2
           sbt sparkSqlApplicationCosmetic/publishM2
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: 'opensearch-project/opensearch-build'
           path: 'build'
 
       - name: Load secrets from 1Password
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2
         with:
           export-env: true
         env:
@@ -57,7 +57,7 @@ jobs:
           MAVEN_SNAPSHOTS_S3_ROLE: op://opensearch-infra-secrets/maven-snapshots-s3/role
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ env.MAVEN_SNAPSHOTS_S3_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/stalled.yml
+++ b/.github/workflows/stalled.yml
@@ -11,13 +11,13 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
       - name: Stale PRs
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           repo-token: ${{ steps.github_app_token.outputs.token }}
           stale-pr-label: 'stalled'


### PR DESCRIPTION
### Description

Backport of #1319 to the `0.7` branch.

The `opensearch-project` org enforces a GitHub Actions policy requiring every action reference to be pinned to a full-length commit SHA. The `0.7` branch still references several actions by version tag (e.g. `@v3`, `@v1`), which causes workflow jobs to fail immediately at the **Set up job** step with:

> The actions `actions/checkout@v3`, `actions/setup-java@v3`, `sbt/setup-sbt@v1`, `1password/load-secrets-action@v2`, and `aws-actions/configure-aws-credentials@v5` are not allowed in opensearch-project/opensearch-spark because all actions must be pinned to a full-length commit SHA.

This affects every workflow on `0.7` that uses an unpinned action (e.g. snapshot-publish, backport, stalled).

This PR pins all remaining unpinned actions to the same SHAs already in use on `main`:

| File | Action | Pinned SHA |
|---|---|---|
| `add-untriaged.yml` | `actions/github-script` | `3a2844b7e9c422d3c10d287c895573f7108da1b3` (v6) |
| `backport.yml` | `tibdex/github-app-token` | `021a2405c7f990db57f5eae5397423dcc554159c` (v1.7.0) |
| `backport.yml` | `VachaShah/backport` | `142d3b8a8c70dc54db515e653e5ed3c3fac64100` (v2.2.0) |
| `delete_backport_branch.yml` | `SvanBoxel/delete-merged-branch` | `2b5b058e3db41a3328fd9a6a58fd4c2545a14353` (main) |
| `snapshot-publish.yml` | `actions/checkout` | `f43a0e5ff2bd294095638e18286ca9a3d1956744` (v3) |
| `snapshot-publish.yml` | `actions/setup-java` | `17f84c3641ba7b8f6deff6309fc4c864478f5d62` (v3) |
| `snapshot-publish.yml` | `sbt/setup-sbt` | `2e222825582620cc38d2a54e674f3c01b7c14f5d` (v1) |
| `snapshot-publish.yml` | `1password/load-secrets-action` | `581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0` (v2) |
| `snapshot-publish.yml` | `aws-actions/configure-aws-credentials` | `61815dcd50bd041e203e49132bacad1fd04d2708` (v5) |
| `stalled.yml` | `tibdex/github-app-token` | `3beb63f4bd073e61482598c45c71c1019b59b73a` (v2.1.0) |
| `stalled.yml` | `actions/stale` | `5bef64f19d7facfb25b37b414482c7164d639639` (v9) |

Note: `add-untriaged.yml` was not part of #1319 but is also unpinned on `0.7` and blocked by the same policy, so it is included here.

### Check List
- [x] Backport PR. No new tests required.
- [x] New functionality has been documented. N/A.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-spark/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).